### PR TITLE
Adds a field for custom selection strings

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -43,6 +43,13 @@ def register():
         subtype = 'NONE', 
         maxlen = 4
         )
+    bpy.types.Scene.mol_md_selection = bpy.props.StringProperty(
+        name = 'md_selection', 
+        description = 'Custom selection string when importing MD simulation. See: "https://docs.mdanalysis.org/stable/documentation_pages/selections.html"', 
+        options = {'TEXTEDIT_UPDATE'}, 
+        default = 'not (name H* or name OW)', 
+        subtype = 'NONE'
+        )
     bpy.types.Scene.mol_import_center = bpy.props.BoolProperty(
         name = "mol_import_centre", 
         description = "Move the imported Molecule on the World Origin",
@@ -163,6 +170,7 @@ def register():
 
 def unregister():
     del bpy.types.Scene.mol_pdb_code
+    del bpy.types.Scene.mol_md_selection
     del bpy.types.Scene.mol_import_center
     del bpy.types.Scene.mol_import_del_solvent
     del bpy.types.Scene.mol_import_include_bonds

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -59,7 +59,8 @@ def molecule_local(file_path,
         except:
             transforms = None
             # self.report({"WARNING"}, message='Unable to parse biological assembly information.')
-    
+    else:
+        warnings.warn("Unable to open local file. Format not supported.")
     # if include_bonds chosen but no bonds currently exist (mol.bonds is None)
     # then attempt to find bonds by distance
     if include_bonds and not mol.bonds:
@@ -179,7 +180,7 @@ def create_molecule(mol_array, mol_name, center_molecule = False, del_solvent = 
     if not collection:
         collection = coll_mn()
     
-    if include_bonds:
+    if include_bonds and mol_array.bonds:
         bonds = mol_array.bonds.as_array()
         mol_object = create_object(name = mol_name, collection = collection, locations = locations, bonds = bonds[:, [0,1]])
     else:
@@ -187,19 +188,58 @@ def create_molecule(mol_array, mol_name, center_molecule = False, del_solvent = 
 
     # compute the attributes as numpy arrays for the addition of them to the points of the structure
     # TODO find a way to do this nicer, and with more control when something fails
-    atomic_number = np.fromiter(map(lambda x: data.elements.get(x, {'atomic_number': -1}).get("atomic_number"), np.char.title(mol_array.element)), dtype = np.int)
-    res_id = mol_array.res_id
-    res_name = np.fromiter(map(lambda x: data.residues.get(x, {'res_name_num': -1}).get('res_name_num'), np.char.upper(mol_array.res_name)), dtype = np.int)
-    chain_id = np.searchsorted(np.unique(mol_array.chain_id), mol_array.chain_id)
-    vdw_radii =  np.fromiter(map(struc.info.vdw_radius_single, mol_array.element), dtype=np.float) * world_scale
-    is_alpha = np.fromiter(map(lambda x: x == "CA", mol_array.atom_name), dtype = np.bool)
-    is_solvent = struc.filter_solvent(mol_array)
-    is_backbone = (struc.filter_backbone(mol_array) | np.isin(mol_array.atom_name, ["P", "O5'", "C5'", "C4'", "C3'", "O3'"]))
-    is_nucleic = struc.filter_nucleotides(mol_array)
-    is_peptide = struc.filter_canonical_amino_acids(mol_array)
-    is_hetero = mol_array.hetero
-    is_carb = struc.filter_carbohydrates(mol_array)
-    b_factor = mol_array.b_factor
+    try:
+        atomic_number = np.fromiter(map(lambda x: data.elements.get(x, {'atomic_number': -1}).get("atomic_number"), np.char.title(mol_array.element)), dtype = np.int)
+    except:
+        atomic_number = None
+    try:
+        res_id = mol_array.res_id
+    except:
+        res_id = None
+    try: 
+        res_name = np.fromiter(map(lambda x: data.residues.get(x, {'res_name_num': -1}).get('res_name_num'), np.char.upper(mol_array.res_name)), dtype = np.int)
+    except:
+        res_name = None
+    try:
+        chain_id = np.searchsorted(np.unique(mol_array.chain_id), mol_array.chain_id)
+    except:
+        chain_id = None
+    try:
+        vdw_radii =  np.fromiter(map(struc.info.vdw_radius_single, mol_array.element), dtype=np.float) * world_scale
+    except:
+        vdw_radii = None
+    try:
+        is_alpha = np.fromiter(map(lambda x: x == "CA", mol_array.atom_name), dtype = np.bool)
+    except:
+        is_alpha = None
+    try:
+        is_solvent = struc.filter_solvent(mol_array)
+    except:
+        is_solvent = None
+    try:
+        is_backbone = (struc.filter_backbone(mol_array) | np.isin(mol_array.atom_name, ["P", "O5'", "C5'", "C4'", "C3'", "O3'"]))
+    except:
+        is_backbone = None
+    try:
+        is_nucleic = struc.filter_nucleotides(mol_array)
+    except:
+        is_nucleic = None
+    try:
+        is_peptide = struc.filter_canonical_amino_acids(mol_array)
+    except:
+        is_peptide = None
+    try:
+        is_hetero = mol_array.hetero
+    except:
+        is_hetero = None
+    try:
+        is_carb = struc.filter_carbohydrates(mol_array)
+    except:
+        is_carb = None
+    try:
+        b_factor = mol_array.b_factor
+    except:
+        b_factor = None
 
     # Add information about the bond types to the model on the edge domain
     # Bond types: 'ANY' = 0, 'SINGLE' = 1, 'DOUBLE' = 2, 'TRIPLE' = 3, 'QUADRUPLE' = 4

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -214,6 +214,9 @@ def create_molecule(mol_array, mol_name, center_molecule = False, del_solvent = 
         chain_id = np.searchsorted(np.unique(mol_array.chain_id), mol_array.chain_id)
         return chain_id
     
+    def att_b_factor():
+        return mol_array.b_factor
+    
     def att_vdw_radii():
         vdw_radii =  np.fromiter(map(
             struc.info.vdw_radius_single, 
@@ -244,8 +247,6 @@ def create_molecule(mol_array, mol_name, center_molecule = False, del_solvent = 
     def att_is_carb():
         return struc.filter_carbohydrates(mol_array)
     
-    def att_is_b_factor():
-        return mol_array.b_factor
 
     # Add information about the bond types to the model on the edge domain
     # Bond types: 'ANY' = 0, 'SINGLE' = 1, 'DOUBLE' = 2, 'TRIPLE' = 3, 'QUADRUPLE' = 4

--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -22,143 +22,100 @@ def load_trajectory(file_top,
     
     # initially load in the trajectory
     univ = mda.Universe(file_top, file_traj)
+    # separate the trajectory, separate to the topology or the subsequence selections
     traj = univ.trajectory[md_start:md_end:md_step]
     
-    # if the universe doesn't currenlty have element names, add this to the universe
-    try:
-        elements = univ.atoms.elements
-    except:
-        elements = [mda.topology.guessers.guess_atom_element(x) for x in univ.atoms.names]
-        #univ.add_TopologyAttr('elements', np.array(elements))
-        
-    
-    bonds = []
-    if include_bonds:
-        # TODO: support bonds in MD import
-        # potentially have to recalculate, MDAnalysis has some support for bond calculation
-        bonds = []
-    
-    
-    # fix issues with proteins going outside of the bounding box of the simulation
-    # TODO: ask about why this might not be working
-    center_on_protein = False
-    
-    if center_on_protein:
-        try:
-            protein = univ.select_atoms('protein')
-            for ts in traj:
-                protein.unwrap(compound = 'fragments')
-                protein_center = protein.center_of_mass(wrap = True)
-                dim = ts.triclinic_dimensions
-                box_center = np.sum(dim, axis = 0) / 2
-                univ.atoms.translate(box_center - protein_center)
-        except:
-            warnings.warn("Unable to center the protein during import.")
-
-    # wrap the solvent around as well to better wrap around the protein
-    wrap_molecules = False
-    if wrap_molecules:
-        try:
-            not_protein = univ.select_atoms('not protein')
-            for ts in traj:
-                not_protein.wrap(compound = 'residues')
-        except:
-            warnings.warn("Unable to wrap molecules on import.")
-
     # if there is a non-blank selection, apply the selection text to the universe for 
     # later use. This also affects the trajectory, even though it has been separated earlier
     if selection != "":
         try:
             univ = univ.select_atoms(selection)
-            elements = [mda.topology.guessers.guess_atom_element(x) for x in univ.atoms.names]
         except:
             warnings.warn(f"Unable to apply selection: '{selection}'. Loading entire topology.")
-
-    # create the initial model
+    
+    # Try and extract the elements from the topology. If the universe doesn't contain
+    # the element information, then guess based on the atom names in the toplogy
+    try:
+        elements = univ.atoms.elements
+    except:
+        elements = [mda.topology.guessers.guess_atom_element(x) for x in univ.atoms.names]
+    
+        # create the initial model
     mol_object = create_object(
         name = name,
         collection = coll_mn(), 
         locations = univ.atoms.positions * world_scale, 
-        bonds = bonds
+        bonds = []
     )
     
-    
     ## add the attributes for the model
-    # atomic_number
     
-    try:
+    # The attributes for the model are initially defined as single-use functions. This allows
+    # for a loop that attempts to add each attibute by calling the function. Only during this
+    # loop will the call fail if the attribute isn't accessible, and the warning is reported
+    # there rather than setting up a try: except: for each individual attribute which makes
+    # some really messy code.
+    
+    def att_atomic_number():
         atomic_number = np.array(list(map(
             # if getting the element fails for some reason, return an atomic number of -1
             lambda x: data.elements.get(x, {"atomic_number": -1}).get("atomic_number"), 
             np.char.title(elements) 
         )))
-        
-        add_attribute(mol_object, 'atomic_number', atomic_number, 'INT')
-    except:
-        warnings.warn("Unable to add atomic numbers")
-    
-    # vdw radii
-    try:
+        return atomic_number
+
+    def att_vdw_radii():
         vdw_radii = np.array(list(map(
             lambda x: mda.topology.tables.vdwradii.get(x, 1), 
             np.char.upper(elements)
         )))
         
-        vdw_radii = vdw_radii * world_scale
-        
-        add_attribute(mol_object, 'vdw_radii', vdw_radii, 'FLOAT')
-    except:
-        warnings.warn("Unable to add vdw_radii attribute.")
+        return vdw_radii * world_scale
     
-    # residue ids (numeric)
-    try:
-        add_attribute(mol_object, 'res_id', univ.atoms.resnums, "INT")
-    except:
-        warnings.warn("Unable to add residue IDs")
+    def att_res_id():
+        return univ.atoms.resnums
     
-    ### residue names converted to integers in alphabetical order
-    try:
+    def att_res_name():
         res_names =  np.array(list(map(lambda x: x[0: 3], univ.atoms.resnames)))
         res_numbers = np.array(list(map(lambda x: data.residues.get(x, {'res_name_num': 0}).get('res_name_num'), res_names)))
-        add_attribute(mol_object, 'res_name', res_numbers, "INT")
-    except:
-        warnings.warn("Unable to add residue names")
+        return res_numbers
     
-    # TODO: find better way to handle univ that is missing components
-    # this works currently but its ugly, need better way to handle missing
-    # components and warng the user rather than a massive error
-    try:
-        add_attribute(mol_object, 'b_factor', univ.atoms.tempfactors, "FLOAT")
-    except:
-        warnings.warn("Unable to add b_factor (may not be supported in this structure")
+    def att_b_factor():
+        return univ.atoms.tempfactors
     
-    # chain_id
-    try:
+    def att_chain_id():
         chain_id = univ.atoms.chainIDs
         chain_id_unique = np.unique(chain_id)
-        
         chain_id_num = np.array(list(map(lambda x: np.where(x == chain_id_unique)[0][0], chain_id)))
-        add_attribute(mol_object, 'chain_id', chain_id_num, "INT")
-    except:
-        warnings.warn("Unable to add Chain IDs")
+        return chain_id_num
+    
+    def att_is_backbone():
+        return np.isin(univ.atoms.ix, univ.select_atoms("backbone or nucleicbackbone").ix).astype(bool)
+    
+    def att_is_alpha_carbon():
+        return np.isin(univ.atoms.ix, univ.select_atoms("name CA").ix).astype(bool)
+
+    
+    attributes = (
+        {'name': 'atomic_number',   'value': att_atomic_number,   'type': 'INT',     'domain': 'POINT'}, 
+        {'name': 'vdw_radii',       'value': att_vdw_radii,       'type': 'FLOAT',   'domain': 'POINT'},
+        {'name': 'res_id',          'value': att_res_id,          'type': 'INT',     'domain': 'POINT'}, 
+        {'name': 'res_name',        'value': att_res_name,        'type': 'INT',     'domain': 'POINT'}, 
+        {'name': 'b_factor',        'value': att_b_factor,        'type': 'float',   'domain': 'POINT'}, 
+        {'name': 'chain_id',        'value': att_chain_id,        'type': 'INT',     'domain': 'POINT'}, 
+        {'name': 'is_backbone',     'value': att_is_backbone,     'type': 'BOOLEAN', 'domain': 'POINT'}, 
+        {'name': 'is_alpha_carbon', 'value': att_is_alpha_carbon, 'type': 'BOOLEAN', 'domain': 'POINT'}, 
         
+    )
     
-    # is_backbone
-    try:
-        is_backbone = np.isin(univ.atoms.ix, univ.select_atoms("backbone or nucleicbackbone").ix).astype(bool)
-        add_attribute(mol_object, 'is_backbone', is_backbone, "BOOLEAN")
-    except:
-        warnings.warn("Unable to add is_backbone attribute.")
-    
-    try:
-        is_alpha_carbon = np.isin(univ.atoms.ix, univ.select_atoms("name CA").ix).astype(bool)
-        add_attribute(mol_object, 'is_alpha_carbon', is_alpha_carbon, "BOOLEAN")
-    except:
-        warnings.warn("Unable to add is_ca attribute.")
-    
-    
-    
-    
+    for att in attributes:
+        # tries to add the attribute to the mesh by calling the 'value' function which returns
+        # the required values do be added to the domain.
+        try:
+            add_attribute(mol_object, att['name'], att['value'](), att['type'], att['domain'])
+        except:
+            warnings.warn(f"Unable to add attribute: {att['name']}.")
+
     # create the frames of the trajectory in their own collection to be disabled
     coll_frames = bpy.data.collections.new(name + "_frames")
     coll_mn().children.link(coll_frames)

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -56,13 +56,11 @@ class MOL_OT_Import_Protein_Local(bpy.types.Operator):
 
     def execute(self, context):
         file_path = bpy.context.scene.mol_import_local_path
-        include_bonds = bpy.context.scene.mol_import_include_bonds
-        
         
         mol_object = load.molecule_local(
             file_path=file_path, 
             mol_name=bpy.context.scene.mol_import_local_name,
-            include_bonds=include_bonds, 
+            include_bonds=bpy.context.scene.mol_import_include_bonds, 
             center_molecule=bpy.context.scene.mol_import_center, 
             del_solvent=bpy.context.scene.mol_import_del_solvent, 
             default_style=bpy.context.scene.mol_import_default_style, 
@@ -91,11 +89,22 @@ class MOL_OT_Import_Protein_MD(bpy.types.Operator):
         file_top = bpy.context.scene.mol_import_md_topology
         file_traj = bpy.context.scene.mol_import_md_trajectory
         name = bpy.context.scene.mol_import_md_name
+        selection = bpy.context.scene.mol_md_selection
+        md_start = bpy.context.scene.mol_import_md_frame_start
+        md_step =  bpy.context.scene.mol_import_md_frame_step
+        md_end =   bpy.context.scene.mol_import_md_frame_end
+        del_solvent = bpy.context.scene.mol_import_del_solvent
+        
         
         mol_object, coll_frames = md.load_trajectory(
-            file_top = file_top, 
-            file_traj = file_traj, 
-            name = name
+            file_top    = file_top, 
+            file_traj   = file_traj, 
+            md_start    = md_start,
+            md_end      = md_end,
+            md_step     = md_step,
+            name        = name, 
+            del_solvent = del_solvent, 
+            selection   = selection
         )
         n_frames = len(coll_frames.objects)
         
@@ -183,6 +192,11 @@ def MOL_PT_panel_md_traj(layout_function, ):
     row_frame.prop(
         bpy.context.scene, 'mol_import_md_frame_end', 
         text = 'End',
+        emboss = True
+    )
+    col_main.prop(
+        bpy.context.scene, 'mol_md_selection', 
+        text = 'Selection', 
         emboss = True
     )
     


### PR DESCRIPTION
For the MD import panel, adds a string field that enables custom selection strings. Selections are specified and parsed by MDAnalysis, details of which can be found in the [documentation](https://docs.mdanalysis.org/stable/documentation_pages/selections.html).

Starts with a default selection which removes water and hydrogen from the trajectory. A blank field keeps all atoms on import.

![image](https://user-images.githubusercontent.com/36021261/210039217-59659d2b-1dae-4ae2-b1ab-a161711c66b6.png)
