### PR TITLE
Atom name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `atom_name` attribute, which is a numerical representation of the atom name (C, CA, C5 etc)
+  - Dicussed in [#118](https://github.com/BradyAJohnston/MolecularNodes/issues/118)
+  - Allows for more precise selections for new styling and animation nodes
+- Reimplemented amino acid 'wiggle' node: using the `atom_name` attribute
+  - 3x faster with the improved `atom_name` attribute and refactor of the underlying nodes
+- Reimplemented the amino acid to curve node
+- Ribbon Style Nucleic: A ribbon representation for nucleic acids to complement the ribbon represenation of the proteins from alpha carbons. Enabled now thanks to the `atom_name` attribute.
+
+### Fixed
+- Changed naming of `MOL_style_atoms` to `MOL_style_atoms_cycles` and `MOL_style_ribbon` to `MOL_style_ribbon_protein`
+
+## [2.1.0]
+
 ### Added 
 
 - `CHANGELOG.md` for tracking changes to the project

--- a/MolecularNodes/data.py
+++ b/MolecularNodes/data.py
@@ -806,6 +806,83 @@ lipophobicity = {
 }
 
 
+# Ordering is a mix between the AlphaFold ordering (for proteins) and the original spec 
+# for nucleic acids from 1992: 
+# https://cdn.rcsb.org/wwpdb/docs/documentation/file-format/PDB_format_1992.pdf
+# rotation points for artificial 'wiggle' are: 5, 6, 12, 20, 25
+# rotation point around the alpha carbon is: 2
+atom_names = {
+        # backbone atoms
+        'N'  : 1, 
+        'CA' : 2, 
+        'C'  : 3, 
+        'O'  : 4, 
+        
+        # sidechain atoms
+        'CB' : 5, # rotation point
+        
+        'CG' : 6, # rotation point
+        
+        'CG1': 7, 
+        'CG2': 8, 
+        'OG' : 9, 
+        'OG1': 10, 
+        'SG' : 11, 
+        
+        'CD' : 12, # rotation point
+        
+        'CD1': 13, 
+        'CD2': 14, 
+        'ND1': 15, 
+        'ND2': 16, 
+        'OD1': 17, 
+        'OD2': 18, 
+        'SD' : 19, 
+        
+        'CE' : 20, # rotation point
+        
+        'CE1': 21, 
+        'CE2': 23, 
+        'CE3': 24,
+        
+        'NE' : 25, # rotation point
+        
+        'NE1': 26, 
+        'NE2': 27, 
+        'OE1': 28, 
+        'OE2': 29, 
+        'CH2': 30, 
+        'NH1': 31, 
+        'NH2': 32, 
+        'OH' : 33, 
+        'CZ' : 34, 
+        'CZ2': 35,
+        'CZ3': 36, 
+        'NZ' : 37, 
+        'OXT': 38,
+        
+        # nucleic acids
+        
+        # sugar-phosephate backbone
+        "P"  : 50, # connection from the previous ribose
+        "O1P": 51,
+        "02P": 52, 
+        "O5" : 53, 
+        "C5" : 54, 
+        "C4" : 55, # ring
+        "O4" : 56, # ring
+        "C3" : 57, # ring
+        "O3" : 58, # connection to the next phosphate
+        "C2" : 59, # ring
+        "O2" : 60, 
+        "C1" : 61, # ring # connection to the base
+        
+        # connection point to the base
+        "N1" : 62,
+        "N9" : 63
+}
+
+
 # taken from biotite code: https://www.biotite-python.org/examples/gallery/structure/glycan_visualization.html
 # originally adapted from "Mol*" Software
 # The dictionary maps residue names of saccharides to their common names

--- a/MolecularNodes/data.py
+++ b/MolecularNodes/data.py
@@ -814,23 +814,19 @@ lipophobicity = {
 atom_names = {
         # backbone atoms
         'N'  : 1, 
-        'CA' : 2, 
+        'CA' : 2, # rotation point
         'C'  : 3, 
         'O'  : 4, 
         
         # sidechain atoms
         'CB' : 5, # rotation point
-        
         'CG' : 6, # rotation point
-        
         'CG1': 7, 
         'CG2': 8, 
         'OG' : 9, 
         'OG1': 10, 
         'SG' : 11, 
-        
         'CD' : 12, # rotation point
-        
         'CD1': 13, 
         'CD2': 14, 
         'ND1': 15, 
@@ -838,15 +834,11 @@ atom_names = {
         'OD1': 17, 
         'OD2': 18, 
         'SD' : 19, 
-        
         'CE' : 20, # rotation point
-        
         'CE1': 21, 
         'CE2': 23, 
         'CE3': 24,
-        
         'NE' : 25, # rotation point
-        
         'NE1': 26, 
         'NE2': 27, 
         'OE1': 28, 
@@ -861,25 +853,35 @@ atom_names = {
         'NZ' : 37, 
         'OXT': 38,
         
-        # nucleic acids
         
-        # sugar-phosephate backbone
-        "P"  : 50, # connection from the previous ribose
+        ## DNA 
+        # currently works for RNA as well, but haven't optimised
+        
+        # phosphate    
+        "P"  : 50, # connection to the previous ribose
         "O1P": 51,
         "02P": 52, 
-        "O5" : 53, 
-        "C5" : 54, 
-        "C4" : 55, # ring
-        "O4" : 56, # ring
-        "C3" : 57, # ring
-        "O3" : 58, # connection to the next phosphate
-        "C2" : 59, # ring
-        "O2" : 60, 
-        "C1" : 61, # ring # connection to the base
+        # ribose
+        "O5'" : 53, 
+        "C5'" : 54, 
+        "C4'" : 55, # ring
+        "O4'" : 56, # ring
+        "C3'" : 57, # ring
+        "O3'" : 58, # connection to the next phosphate
+        "C2'" : 59, # ring
+        "O2'" : 60, 
+        "C1'" : 61, # ring # connection to the base
         
         # connection point to the base
         "N1" : 62,
-        "N9" : 63
+        "N9" : 63,
+        "N3" : 64
+        
+        # unsure how to proceed past this point, as atom names are reused inside of 
+        # different bases but represent totally different locations like the N9 and N1 atoms 
+        # can both be the connecting carbon to the ribose, or a carbon much further into the
+        # structure see page 29: 
+        # https://cdn.rcsb.org/wwpdb/docs/documentation/file-format/PDB_format_1992.pdf
 }
 
 

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -223,6 +223,14 @@ def create_molecule(mol_array, mol_name, center_molecule = False, del_solvent = 
             mol_array.element), dtype=np.float)
         return vdw_radii * world_scale
     
+    def att_atom_name():
+        atom_name = np.array(list(map(
+            lambda x: data.atom_names.get(x, 9999), 
+            mol_array.atom_name
+        )))
+        
+        return atom_name
+    
     def att_is_alpha():
         is_alpha = np.fromiter(map(lambda x: x == "CA", mol_array.atom_name), dtype = np.bool)
         return is_alpha
@@ -275,6 +283,7 @@ def create_molecule(mol_array, mol_name, center_molecule = False, del_solvent = 
         {'name': 'b_factor',        'value': att_b_factor,            'type': 'FLOAT',   'domain': 'POINT'},
         {'name': 'vdw_radii',       'value': att_vdw_radii,           'type': 'FLOAT',   'domain': 'POINT'},
         {'name': 'chain_id',        'value': att_chain_id,            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'atom_name',       'value': att_atom_name,           'type': 'INT',     'domain': 'POINT'},
         {'name': 'is_backbone',     'value': att_is_backbone,         'type': 'BOOLEAN', 'domain': 'POINT'},
         {'name': 'is_alpha_carbon', 'value': att_is_alpha,            'type': 'BOOLEAN', 'domain': 'POINT'},
         {'name': 'is_solvent',      'value': att_is_solvent,          'type': 'BOOLEAN', 'domain': 'POINT'},

--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -82,7 +82,10 @@ def load_trajectory(file_top,
     
     def att_res_name():
         res_names =  np.array(list(map(lambda x: x[0: 3], univ.atoms.resnames)))
-        res_numbers = np.array(list(map(lambda x: data.residues.get(x, {'res_name_num': 0}).get('res_name_num'), res_names)))
+        res_numbers = np.array(list(map(
+            lambda x: data.residues.get(x, {'res_name_num': 0}).get('res_name_num'), 
+            res_names
+            )))
         return res_numbers
     
     def att_b_factor():

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -138,7 +138,7 @@ def create_starting_node_tree(obj, coll_frames, starting_style = "atoms"):
     link(node_random_colour.outputs['Value'], node_colour.inputs['Carbon'])
     link(node_chain_id.outputs[4], node_random_colour.inputs['ID'])
     
-    styles = ['MOL_style_atoms', 'MOL_style_ribbon', 'MOL_style_ball_and_stick']
+    styles = ['MOL_style_atoms_cycles', 'MOL_style_ribbon_protein', 'MOL_style_ball_and_stick']
     
     # if starting_style == "atoms":
     

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -708,6 +708,11 @@ class MOL_MT_Add_Node_Menu_Animation(bpy.types.Menu):
         menu_item_interface(layout, 'Animate Value', 'MOL_animate_value', 
                             "Animates between given start and end values, based on the input start and end frame of the timeline. Clamped will limit the output to the 'To Min' and 'To Max', while unclamped will continue to interpolate past these values. 'Smoother Step' will ease in and out of these values, with default being linear interpolation")
         layout.separator()
+        menu_item_interface(layout, 'Res Wiggle', "MOL_animate_res_wiggle", 
+                            "Wiggles the side chains of amino acids based on b_factor, adding movement to a structure.")
+        menu_item_interface(layout, 'Res to Curve', "MOL_animate_res_to_curve", 
+                            "Takes atoms and maps them along a curve, as a single long peptide chain.")
+        layout.separator()
         menu_item_interface(layout, 'Noise Position', 'MOL_noise_position', 
                             "Generate 3D noise field based on the position attribute")
         menu_item_interface(layout, 'Noise Field', 'MOL_noise_field', 

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -573,12 +573,14 @@ class MOL_MT_Add_Node_Menu_Styling(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
         layout.operator_context = "INVOKE_DEFAULT"
-        menu_item_interface(layout, 'Atoms Cycles', 'MOL_style_atoms', 
-                            'Create a sphere representation that is visible ONLY inside of the Cycles render engine')
+        menu_item_interface(layout, 'Atoms Cycles', 'MOL_style_atoms_cycles', 
+                            'A sphere atom representation, visible ONLY in Cycles. Based on point-cloud rendering')
         menu_item_interface(layout, 'Atoms EEVEE', 'MOL_style_atoms_eevee', 
-                            'Create a sphere representation that is visible inside of the EEVEE and Cycles render egines')
-        menu_item_interface(layout, 'Ribbon', 'MOL_style_ribbon', 
+                            'A sphere atom representation, visible in EEVEE and Cycles. Based on mesh instancing which slows down viewport performance')
+        menu_item_interface(layout, 'Ribbon Protein', 'MOL_style_ribbon_protein', 
                             'Create a ribbon mesh based off of the alpha-carbons of the structure')
+        menu_item_interface(layout, 'Ribbon Nucleic', 'MOL_style_ribbon_nucleic', 
+                            'Create a ribbon mesh and instanced cylinders for nucleic acids.')
         menu_item_interface(layout, 'Surface', 'MOL_style_surface_single', 
                             'Create a single joined surface representation.\n' +
                             'Generates an isosurface based on atomic vdw_radii. All chains are part of the same surface. Use "Surface Split Chains" ' + 
@@ -682,7 +684,7 @@ class MOL_MT_Add_Node_Menu_DNA(bpy.types.Menu):
         menu_item_interface(layout, 'Bases', 'MOL_dna_bases', 
                             "Provide the DNA bases as instances to be styled and passed onto the Double Helix node")
         layout.separator()
-        menu_item_interface(layout, 'Style Atoms Cyeles', 'MOL_dna_style_atoms', 
+        menu_item_interface(layout, 'Style Atoms Cyeles', 'MOL_dna_style_atoms_cycles', 
                             "Style the DNA bases with spheres only visible in Cycles")
         menu_item_interface(layout, 'Style Atoms EEVEE', 'MOL_dna_style_atoms_eevee', 
                             "Style the DNA bases with spheres visible in Cycles and EEVEE")


### PR DESCRIPTION
An implementation of the `atom_name` discussed in #118. 

Now it is implemented, the 'wiggle' node and others can be implemented cleaner (and faster) than before. Nucleic acids now have the `Style Ribbon` node as well, with examples of 1bna and the ribosome below.

The new style isn't the _best_ implementation, but it's a good start and fills the niche currently.

### Added
- `atom_name` attribute, which is a numerical representation of the atom name (C, CA, C5 etc)
  - Dicussed in [#118](https://github.com/BradyAJohnston/MolecularNodes/issues/118)
  - Allows for more precise selections for new styling and animation nodes
- Reimplemented amino acid 'wiggle' node: using the `atom_name` attribute
  - 3x faster with the improved `atom_name` attribute and refactor of the underlying nodes
- Reimplemented the amino acid to curve node
- Ribbon Style Nucleic: A ribbon representation for nucleic acids to complement the ribbon represenation of the proteins from alpha carbons. Enabled now thanks to the `atom_name` attribute.

### Fixed
- Changed naming of `MOL_style_atoms` to `MOL_style_atoms_cycles` and `MOL_style_ribbon` to `MOL_style_ribbon_protein`
![dna-ribbon](https://user-images.githubusercontent.com/36021261/210190283-812221d0-89a6-47a0-bc2a-fb54be3c9d04.png)
![ribsome-ribbon](https://user-images.githubusercontent.com/36021261/210190284-12e42718-3785-4bcc-a422-28a61fbada8f.png)
