### PR TITLE
Fix non-English error when New Data translation is disabled.

### DIFF
--- a/MolecularNodes/assembly.py
+++ b/MolecularNodes/assembly.py
@@ -97,8 +97,8 @@ def create_biological_assembly_node(name, transform_dict):
     
     node_bio = nodes.gn_new_group_empty('MOL_assembly_' + name)
     
-    node_input = node_bio.nodes[bpy.app.translations.pgettext("Group Input",)]
-    node_output = node_bio.nodes[bpy.app.translations.pgettext("Group Output",)]
+    node_input = node_bio.nodes[bpy.app.translations.pgettext_data("Group Input",)]
+    node_output = node_bio.nodes[bpy.app.translations.pgettext_data("Group Output",)]
     
     
     node_output.location = [400, 0]

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -112,9 +112,9 @@ def create_starting_node_tree(obj, coll_frames, starting_style = "atoms"):
     #     mol_append_node(node_group)
     
     # move the input and output nodes for the group
-    node_input = node_mod.node_group.nodes[bpy.app.translations.pgettext("Group Input",)]
+    node_input = node_mod.node_group.nodes[bpy.app.translations.pgettext_data("Group Input",)]
     node_input.location = [0, 0]
-    node_output = node_mod.node_group.nodes[bpy.app.translations.pgettext("Group Output",)]
+    node_output = node_mod.node_group.nodes[bpy.app.translations.pgettext_data("Group Output",)]
     node_output.location = [800, 0]
     
     # node_properties = add_custom_node_group(node_group, 'MOL_prop_setup', [0, 0])
@@ -204,9 +204,9 @@ def create_custom_surface(name, n_chains):
     
     link = group.links.new
     
-    node_input = group.nodes[bpy.app.translations.pgettext("Group Input",)]
+    node_input = group.nodes[bpy.app.translations.pgettext_data("Group Input",)]
     # node_input.inputs['Geometry'].name = 'Atoms'
-    node_output = group.nodes[bpy.app.translations.pgettext("Group Output",)]
+    node_output = group.nodes[bpy.app.translations.pgettext_data("Group Output",)]
     
     node_chain_id = group.nodes.new("GeometryNodeInputNamedAttribute")
     node_chain_id.location = [-250, -450]


### PR DESCRIPTION
Blender has provided a series of translation APIs that allow addon designers and users to translate the texts on UI, Tools, Tips and data. 

As @Mangkun-Chen metioned in #146 , Blender does not recommend using the "New Data" translation option (Edit-Preferences-Interface-Translation-Affect-New Data) as it may cause conflicts with many addons. 

So let me just make it clear: 
- `bpy.app.translations.pgettext()` always performs the translation, regardless of translation options, which should be rarely used, 
- `bpy.app.translations.pgettext_tip()` translates the tool and tip messages only if `Tooltips` is checked,
- `bpy.app.translations.pgettext_iface()` handles the main user interface and is controlled by the `Interface` option,
- `bpy.app.translations.pgettext_data()` manages the "New Data" and is controlled by the "New Data" option.

In this case, the `Group Input`/`Group Output` should be always handled by `pgettext_data()` and the translation is determined by the user.
