### PR TITLE
Customized Residue ID selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logs/side-packages-install.log
 .Rproj.user
 docs
 .quarto
+.DS_Store
+MolecularNodes/dev.py

--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -181,6 +181,7 @@ def register():
     bpy.utils.register_class(MOL_OT_install_dependencies)
     bpy.utils.register_class(MOL_OT_Add_Custom_Node_Group)
 
+    bpy.utils.register_class(MOL_OT_Residues_Selection_Custom)
 
 
 def unregister():
@@ -239,6 +240,7 @@ def unregister():
     bpy.utils.unregister_class(MOL_OT_install_dependencies)
     bpy.utils.unregister_class(MOL_OT_Add_Custom_Node_Group)
 
+    bpy.utils.unregister_class(MOL_OT_Residues_Selection_Custom)
 
 if __name__=="__main__":
     register()

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -478,32 +478,29 @@ def chain_color(node_name, input_list, label_prefix = "Chain "):
 
 def resid_multiple_selection(node_name, input_resid_string):
     """
-    Given a an input_list, will create a node which takes an Integer input, 
-    and has a boolean tick box for each item in the input list. The outputs will
-    be the resulting selection and the inversion of the selection.
-    Can contain a prefix for the resulting labels. Mostly used for constructing 
-    chain selections when required for specific proteins.
+    Returns a node group that takes an integer input and creates a boolean 
+    tick box for each item in the input list. Outputs are the selected 
+    residues and the inverse selection. Used for constructing chain 
+    selections in specific proteins.
     """
         
-    # parse input_resid_string
-    input_list = []
-    for sub_list in input_resid_string.split(','):
-        if len(sub_list) <1 :
-            continue
-        elif '-' in sub_list:
-            start,end = sub_list.split('-')[:2]
-            for i in range(int(start), int(end)+1):
-                input_list.append(i)
-        else:
-            input_list.append(int(sub_list))
+    #print(f'recieved input: {input_resid_string}')
+    # do a cleanning of input string to allow fuzzy input from users
+    for c in ";/+ .":
+        if c in input_resid_string:
+            input_resid_string=input_resid_string.replace(c, ',')
+
+    for c in "_=:":
+        if c in input_resid_string:
+            input_resid_string=input_resid_string.replace(c, '-')
+
+    #print(f'fixed input:{input_resid_string}')
+
+    # parse input_resid_string into sub selecting string list
+    sub_list=[item for item in input_resid_string.split(',') if item]
     
     # distance vertical to space all of the created nodes
     node_sep_dis = -100
-
-    # just reutn the group name early if it already exists
-    # group = bpy.data.node_groups.get(node_name)
-    # if group:
-    #     return group
 
     # get the active object, might need to change to taking an object as an input
     # and making it active isntead, to be more readily applied to multiple objects
@@ -515,39 +512,59 @@ def resid_multiple_selection(node_name, input_resid_string):
     
     obj.modifiers.active = node_mod
     
-    # link shortcut for creating links between nodes
-    link = node_mod.node_group.links.new
     # create the custom node group data block, where everything will go
     # also create the required group node input and position it
     residue_id_group = bpy.data.node_groups.new(node_name, "GeometryNodeTree")
     residue_id_group_in = residue_id_group.nodes.new("NodeGroupInput")
-    residue_id_group_in.location = [0, node_sep_dis * len(input_list)/2]
+    residue_id_group_in.location = [0, node_sep_dis * len(sub_list)/2]
     
     group_link = residue_id_group.links.new
     new_node = residue_id_group.nodes.new
     
-    for residue_id_index in range(len(input_list)):
-        #print(f'adding #{residue_id_index} residue: {input_list[residue_id_index]}')
-        # create a integer input for the group for each item in the list
-        residue_id_group.inputs.new("NodeSocketInt",'res_id')
-        residue_id_group.inputs[residue_id_index].default_value = input_list[residue_id_index]
+    for residue_id_index,residue_id in enumerate(sub_list):
         
-
-    for residue_id_index in range(len(input_list)):
+        if '-' in residue_id:
+            [resid_start, resid_end] = residue_id.split('-')[:2]
+            # set two new inputs
+            residue_id_group.inputs.new("NodeSocketInt",'res_id_start').default_value = int(resid_start)
+            residue_id_group.inputs.new("NodeSocketInt",'res_id_end').default_value = int(resid_end)
+        else:
+            # set a new input and set the resid
+            residue_id_group.inputs.new("NodeSocketInt",'res_id').default_value = int(residue_id)
         
-        # add an new node of MOL_sel_res_id
+    # set a counter for MOL_sel_res_id* nodes
+    counter=0
+    for residue_id_index,residue_id in enumerate(sub_list):
+        
+        # add an new node of MOL_sel_res_id or MOL_sek_res_id_range
         current_node = new_node("GeometryNodeGroup")
-        current_node.node_tree = mol_append_node('MOL_sel_res_id')
-        current_node.location = [200,(residue_id_index+1) * node_sep_dis]
 
         # add an bool_math block 
         bool_math = new_node("FunctionNodeBooleanMath")
         bool_math.location = [400,(residue_id_index+1) * node_sep_dis]
         bool_math.operation = "OR"
-        
-        # link the input
-        group_link(residue_id_group_in.outputs[residue_id_index], current_node.inputs[0])
 
+        if '-' in residue_id:
+            # a residue range
+            current_node.node_tree = mol_append_node('MOL_sel_res_id_range')
+            
+            group_link(residue_id_group_in.outputs[counter], current_node.inputs[0])
+            counter+=1
+            
+            group_link(residue_id_group_in.outputs[counter], current_node.inputs[1])
+            
+        else:
+            # create a node
+            current_node.node_tree = mol_append_node('MOL_sel_res_id')
+            # link the input of MOL_sel_res_id
+            print(f'counter={counter} of {residue_id}')
+            group_link(residue_id_group_in.outputs[counter], current_node.inputs[0])
+        
+        counter+=1
+        
+        # set the coordinates
+        current_node.location = [200,(residue_id_index+1) * node_sep_dis]
+    
         if residue_id_index == 0:
             # link the first residue selection to the first input of its OR block
             group_link(current_node.outputs['Selection'],bool_math.inputs[0])
@@ -566,7 +583,7 @@ def resid_multiple_selection(node_name, input_resid_string):
     residue_id_group.outputs.new("NodeSocketBool", "Inverted")
     group_link(previous_bool_node.outputs[0], residue_id_group_out.inputs['Selection'])
     invert_bool_math = new_node("FunctionNodeBooleanMath")
-    invert_bool_math.location = [600,(residue_id_index+1)/ 3 * node_sep_dis]
+    invert_bool_math.location = [600,(residue_id_index+1)/ 3 * 2 * node_sep_dis]
     invert_bool_math.operation = "NOT"
     group_link(previous_bool_node.outputs[0], invert_bool_math.inputs[0])
     group_link(invert_bool_math.outputs[0], residue_id_group_out.inputs['Inverted'])

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -557,7 +557,7 @@ def resid_multiple_selection(node_name, input_resid_string):
             # create a node
             current_node.node_tree = mol_append_node('MOL_sel_res_id')
             # link the input of MOL_sel_res_id
-            print(f'counter={counter} of {residue_id}')
+            #print(f'counter={counter} of {residue_id}')
             group_link(residue_id_group_in.outputs[counter], current_node.inputs[0])
         
         counter+=1

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -452,6 +452,15 @@ class MOL_OT_Assembly_Bio(bpy.types.Operator):
         
         return {"FINISHED"}
 
+def menu_residues_selection_custom(layout_function):
+    obj = bpy.context.view_layer.objects.active
+    label = 'Residue selection'
+    op = layout_function.operator(
+        'mol.residues_selection_custom', 
+        text = label, 
+        emboss = True, 
+        depress = True
+    )
 
 def menu_item_surface_custom(layout_function, label):
     op = layout_function.operator('mol.style_surface_custom', 
@@ -521,6 +530,39 @@ class MOL_OT_Chain_Selection_Custom(bpy.types.Operator):
         mol_add_node(node_chains.name)
         
         return {"FINISHED"}
+
+
+class MOL_OT_Residues_Selection_Custom(bpy.types.Operator):
+    bl_idname = "mol.residues_selection_custom"
+    bl_label = "Multiple Residue Selection"
+    bl_description = "Create a selection based on the provided residue strings.\nThis node is built on a per-molecule basis, taking into account the residues that were input. "
+    bl_options = {"REGISTER", "UNDO"}
+
+    input_list: bpy.props.StringProperty(
+        name="Select residues: ",
+        description="Enter a string value, comma-separated.",
+        default="10,20-24"
+    )
+
+    @classmethod
+    def poll(cls, context):
+        return True
+    
+    def execute(self, context):
+        obj = bpy.context.view_layer.objects.active
+        node_residues = nodes.resid_multiple_selection(
+            node_name = 'MOL_sel_residues', 
+            input_resid_string = self.input_list, 
+            )
+    
+        
+        mol_add_node(node_residues.name)
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+
 
 def menu_ligand_selection_custom(layout_function):
     obj = bpy.context.view_layer.objects.active
@@ -690,6 +732,7 @@ class MOL_MT_Add_Node_Menu_Selections(bpy.types.Menu):
                             "Create a selection of particular nucleic acids by name")
         menu_item_interface(layout, 'Res ID', 'MOL_sel_res_id', 
                             "Create a selection if res_id matches input field")
+        menu_residues_selection_custom(layout)                        
         menu_item_interface(layout, 'Res ID Range', 'MOL_sel_res_id_range', 
                             "Create a selection if the res_id is within the given thresholds")
         menu_item_interface(layout, 'Res Whole', 'MOL_sel_res_whole', 

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -454,7 +454,7 @@ class MOL_OT_Assembly_Bio(bpy.types.Operator):
 
 def menu_residues_selection_custom(layout_function):
     obj = bpy.context.view_layer.objects.active
-    label = 'Residue ID Selection'
+    label = 'Res ID'
     op = layout_function.operator(
         'mol.residues_selection_custom', 
         text = label, 
@@ -723,20 +723,20 @@ class MOL_MT_Add_Node_Menu_Selections(bpy.types.Menu):
         menu_item_interface(layout, 'Slice', 'MOL_sel_slice', 
                             "Create a selection that is a slice along one of the XYZ axes, based on the position of an object.")
         layout.separator()
-        menu_item_interface(layout, 'Res Atoms', 'MOL_sel_res_atoms', 
-                            "Create a selection based on the atoms of a residue.\n" +
-                            "Selections for CA, backbone atoms (N, C, O), sidechain and backbone")
-        menu_item_interface(layout, 'Res Name', 'MOL_sel_res_name', 
+        menu_residues_selection_custom(layout)                        
+        menu_item_interface(layout, 'Res ID Single', 'MOL_sel_res_id', 
+                            "Create a selection if res_id matches input field")
+        menu_item_interface(layout, 'Res ID Range', 'MOL_sel_res_id_range', 
+                            "Create a selection if the res_id is within the given thresholds")
+        menu_item_interface(layout, 'Res Name Peptide', 'MOL_sel_res_name', 
                             "Create a selection of particular amino acids by name")
         menu_item_interface(layout, 'Res Name Nucleic', 'MOL_sel_res_name_nucleic', 
                             "Create a selection of particular nucleic acids by name")
-        # menu_item_interface(layout, 'Res ID', 'MOL_sel_res_id', 
-        #                     "Create a selection if res_id matches input field")
-        menu_residues_selection_custom(layout)                        
-        # menu_item_interface(layout, 'Res ID Range', 'MOL_sel_res_id_range', 
-        #                     "Create a selection if the res_id is within the given thresholds")
         menu_item_interface(layout, 'Res Whole', 'MOL_sel_res_whole', 
                             "Expand the selection to every atom in a residue, if any of those atoms are in the initial selection")
+        menu_item_interface(layout, 'Res Atoms', 'MOL_sel_res_atoms', 
+                            "Create a selection based on the atoms of a residue.\n" +
+                            "Selections for CA, backbone atoms (N, C, O), sidechain and backbone")
 
 class MOL_MT_Add_Node_Menu_Assembly(bpy.types.Menu):
     bl_idname = 'MOL_MT_ADD_NODE_MENU_ASSEMBLY'

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -454,7 +454,7 @@ class MOL_OT_Assembly_Bio(bpy.types.Operator):
 
 def menu_residues_selection_custom(layout_function):
     obj = bpy.context.view_layer.objects.active
-    label = 'Residue selection'
+    label = 'Residue ID Selection'
     op = layout_function.operator(
         'mol.residues_selection_custom', 
         text = label, 
@@ -538,10 +538,10 @@ class MOL_OT_Residues_Selection_Custom(bpy.types.Operator):
     bl_description = "Create a selection based on the provided residue strings.\nThis node is built on a per-molecule basis, taking into account the residues that were input. "
     bl_options = {"REGISTER", "UNDO"}
 
-    input_list: bpy.props.StringProperty(
-        name="Select residues: ",
-        description="Enter a string value, comma-separated.",
-        default="10,20-24"
+    input_resid_string: bpy.props.StringProperty(
+        name="Select residue IDs: ",
+        description="Enter a string value.",
+        default="19,94,1-16"
     )
 
     @classmethod
@@ -552,7 +552,7 @@ class MOL_OT_Residues_Selection_Custom(bpy.types.Operator):
         obj = bpy.context.view_layer.objects.active
         node_residues = nodes.resid_multiple_selection(
             node_name = 'MOL_sel_residues', 
-            input_resid_string = self.input_list, 
+            input_resid_string = self.input_resid_string, 
             )
     
         
@@ -730,11 +730,11 @@ class MOL_MT_Add_Node_Menu_Selections(bpy.types.Menu):
                             "Create a selection of particular amino acids by name")
         menu_item_interface(layout, 'Res Name Nucleic', 'MOL_sel_res_name_nucleic', 
                             "Create a selection of particular nucleic acids by name")
-        menu_item_interface(layout, 'Res ID', 'MOL_sel_res_id', 
-                            "Create a selection if res_id matches input field")
+        # menu_item_interface(layout, 'Res ID', 'MOL_sel_res_id', 
+        #                     "Create a selection if res_id matches input field")
         menu_residues_selection_custom(layout)                        
-        menu_item_interface(layout, 'Res ID Range', 'MOL_sel_res_id_range', 
-                            "Create a selection if the res_id is within the given thresholds")
+        # menu_item_interface(layout, 'Res ID Range', 'MOL_sel_res_id_range', 
+        #                     "Create a selection if the res_id is within the given thresholds")
         menu_item_interface(layout, 'Res Whole', 'MOL_sel_res_whole', 
                             "Expand the selection to every atom in a residue, if any of those atoms are in the initial selection")
 


### PR DESCRIPTION
Introducing a new and improved feature for custom residue id selection in MolecularNodes! With this update, selecting residues has never been easier. The residue selection string can now be inputted in a user-friendly format, combining dash-separated continuous residue IDs and comma-separated individual residue IDs.

For instance, to select residues 1 to 10, 20 to 25 and 30, simply input the string `1-10,20-25,30`. Happy selecting!

<img width="611" alt="MN_residue_selection_input" src="https://user-images.githubusercontent.com/33014714/215721214-dda9aef1-4e4b-48e2-bef9-6780489ec4ac.png">
