### PR TITLE
Refactor dependencies setup stuff

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -40,7 +40,7 @@ def register():
         name = 'pypi_mirror', 
         description = 'PyPI Mirror', 
         options = {'TEXTEDIT_UPDATE'}, 
-        default = 'Original', 
+        default = 'Default', 
         subtype = 'NONE', 
         search = get_pypi_mirror_alias,
         )

--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -32,7 +32,7 @@ pkg.verify()
 from .load import *
 from .ui import *
 from .md import *
-
+from .pkg import get_pypi_mirror_alias
 
 
 def register():
@@ -40,8 +40,9 @@ def register():
         name = 'pypi_mirror', 
         description = 'PyPI Mirror', 
         options = {'TEXTEDIT_UPDATE'}, 
-        default = '', 
+        default = 'Original', 
         subtype = 'NONE', 
+        search = get_pypi_mirror_alias,
         )
     bpy.types.Scene.mol_pdb_code = bpy.props.StringProperty(
         name = 'pdb_code', 

--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -36,6 +36,13 @@ from .md import *
 
 
 def register():
+    bpy.types.Scene.pypi_mirror = bpy.props.StringProperty(
+        name = 'pypi_mirror', 
+        description = 'PyPI Mirror', 
+        options = {'TEXTEDIT_UPDATE'}, 
+        default = '', 
+        subtype = 'NONE', 
+        )
     bpy.types.Scene.mol_pdb_code = bpy.props.StringProperty(
         name = 'pdb_code', 
         description = 'The 4-character PDB code to download', 
@@ -151,7 +158,7 @@ def register():
     )
     
     bpy.types.NODE_MT_add.append(mol_add_node_menu)
-    
+
     bpy.utils.register_class(MOL_PT_panel)
     bpy.utils.register_class(MOL_PT_AddonPreferences)
     bpy.utils.register_class(MOL_MT_Add_Node_Menu)
@@ -168,7 +175,9 @@ def register():
     bpy.utils.register_class(MOL_MT_Default_Style)
 
     bpy.utils.register_class(MOL_OT_Style_Surface_Custom)
+
     bpy.utils.register_class(MOL_OT_Import_Protein_RCSB)
+
     bpy.utils.register_class(MOL_OT_Import_Method_Selection)
     bpy.utils.register_class(MOL_OT_Import_Protein_Local)
     bpy.utils.register_class(MOL_OT_Import_Protein_MD)

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -38,12 +38,17 @@ def verify():
 def run_pip(cmd, mirror='', timeout=600):
     # path to python.exe
     python_exe = os.path.realpath(sys.executable)
-    cmd_list=[python_exe, "-m"] + cmd.split(' ')
+    if type(cmd)==list:
+        cmd_list=[python_exe, "-m"] + cmd
+    elif type(cmd)==str:
+        cmd_list=[python_exe, "-m"] + cmd.split(" ")
+    else:
+        raise TypeError(f"Invalid type of input cmd.")
     if mirror and mirror.startswith('https'):
         cmd_list+=['-i', mirror]
     try:
         print("Running pip:")
-        print(' '.join(cmd_list))
+        print(cmd_list)
         pip_result = subprocess.run(cmd_list, timeout=timeout, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
         error_message = e.stderr.decode()
@@ -62,7 +67,7 @@ def install(pypi_mirror=''):
 
     #install required packages
     try:
-        stderr=run_pip(f'pip install -r {ADDON_DIR}/requirements.txt', mirror=PYPI_MIRROR[pypi_mirror])
+        stderr=run_pip(cmd=['pip', 'install', '-r', f'{ADDON_DIR}/requirements.txt'], mirror=PYPI_MIRROR[pypi_mirror])
         return stderr
     except:
         return("Error installing dependencies")

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -14,12 +14,17 @@ print(ADDON_DIR)
 
 PYPI_MIRROR = {
     # the original.
-    '':'', 
+    'Original':'', 
     # two mirrors in China Mainland to help those poor victims under GFW.
     'BFSU':'https://mirrors.bfsu.edu.cn/pypi/web/simple',
     'TUNA':'https://pypi.tuna.tsinghua.edu.cn/simple',
     # append more if necessary.
+
 }
+
+def get_pypi_mirror_alias(self, context, edit_text):
+    return PYPI_MIRROR.keys()
+    
 
 def verify_user_sitepackages(package_location):
     if os.path.exists(package_location) and package_location not in sys.path:

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -14,7 +14,7 @@ print(ADDON_DIR)
 
 PYPI_MIRROR = {
     # the original.
-    'Original':'', 
+    'Default':'', 
     # two mirrors in China Mainland to help those poor victims under GFW.
     'BFSU (Beijing)':'https://mirrors.bfsu.edu.cn/pypi/web/simple',
     'TUNA (Beijing)':'https://pypi.tuna.tsinghua.edu.cn/simple',
@@ -53,9 +53,9 @@ def run_pip(cmd, mirror='', timeout=600):
     except subprocess.CalledProcessError as e:
         error_message = e.stderr.decode()
         if ("fatal error: 'Python.h' file not found" in error_message) and (platform.system()== "Darwin") and ('arm' in platform.machine()):
-            return("BUG: Could not find the Python.h header file in the Blender-build-in-Python.\n" \
-                    "This is currently a bug in the Blender of Apple Silicon build.\n" \
-                    "Please follow the link to solve it manually: \n" \
+            return("ERROR: Could not find the 'Python.h' header file in version of Python bundled with Blender.\n" \
+                    "This is a problem with the Apple Silicon versions of Blender.\n" \
+                    "Please follow the link to the MolecularNodes GitHub page to solve it manually: \n" \
                     "https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 ")
         else:
             return("Full error message:\n" + error_message)
@@ -83,7 +83,3 @@ def available():
         except Exception as e:
             all_packages_available = False
     return all_packages_available
-
-
-
-    

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -3,6 +3,23 @@ import sys
 import os
 import site
 from importlib.metadata import version
+import bpy
+import re
+import requests
+import platform
+import pathlib
+
+ADDON_DIR = pathlib.Path(__file__).resolve().parent
+print(ADDON_DIR)
+
+PYPI_MIRROR = {
+    # the original.
+    '':'', 
+    # two mirrors in China Mainland to help those poor victims under GFW.
+    'BFSU':'https://mirrors.bfsu.edu.cn/pypi/web/simple',
+    'TUNA':'https://pypi.tuna.tsinghua.edu.cn/simple',
+    # append more if necessary.
+}
 
 def verify_user_sitepackages(package_location):
     if os.path.exists(package_location) and package_location not in sys.path:
@@ -12,17 +29,40 @@ def verify_user_sitepackages(package_location):
 def verify(): 
     verify_user_sitepackages(site.getusersitepackages())
 
-def install():
+
+def run_pip(cmd, mirror='', timeout=600):
     # path to python.exe
     python_exe = os.path.realpath(sys.executable)
+    cmd_list=[python_exe, "-m"] + cmd.split(' ')
+    if mirror and mirror.startswith('https'):
+        cmd_list+=['-i', mirror]
+    try:
+        print("Running pip:")
+        print(' '.join(cmd_list))
+        pip_result = subprocess.run(cmd_list, timeout=timeout, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    except subprocess.CalledProcessError as e:
+        error_message = e.stderr.decode()
+        if ("fatal error: 'Python.h' file not found" in error_message) and (platform.system()== "Darwin") and ('arm' in platform.machine()):
+            print("BUG: Could not find the Python.h header file in the Blender-build-in-Python.\n" \
+                    "This is currently a bug in the Blender of Apple Silicon build.\n" \
+                    "Please follow the link to solve it manually: \n" \
+                    "https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 ")
+        else:
+            print("Full error message:\n")
+            print(error_message)
 
-    # upgrade pip
-    subprocess.call([python_exe, "-m", "ensurepip"])
-    subprocess.call([python_exe, "-m", "pip", "install","--upgrade", "pip"], timeout=600)
+def install(pypi_mirror=''):
+    # Get PIP upgraded
+    run_pip('ensurepip')
+    run_pip('pip install --upgrade pip', mirror=PYPI_MIRROR[pypi_mirror])
 
     #install required packages
-    subprocess.call([python_exe, "-m", "pip", "install", "biotite==0.35.0"], timeout=600)
-    subprocess.call([python_exe, "-m", "pip", "install", "MDAnalysis==2.2.0"], timeout=600)
+
+    try:
+        run_pip(f'pip install -r {ADDON_DIR}/requirements.txt', mirror=PYPI_MIRROR[pypi_mirror])
+    except:
+        run_pip(f'pip install -r {ADDON_DIR}/requirements.txt', mirror=PYPI_MIRROR['BFSU'])
+        
 
 def available():
     verify()
@@ -30,6 +70,10 @@ def available():
     for module in ['biotite', 'MDAnalysis']:
         try:
             version(module)
-        except:
+        except Exception as e:
             all_packages_available = False
     return all_packages_available
+
+
+
+    

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -50,29 +50,27 @@ def run_pip(cmd, mirror='', timeout=600):
         print("Running pip:")
         print(cmd_list)
         pip_result = subprocess.run(cmd_list, timeout=timeout, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        return [cmd_list,pip_result.stdout.decode()]    
     except subprocess.CalledProcessError as e:
         error_message = e.stderr.decode()
-        if ("fatal error: 'Python.h' file not found" in error_message) and (platform.system()== "Darwin") and ('arm' in platform.machine()):
-            return("ERROR: Could not find the 'Python.h' header file in version of Python bundled with Blender.\n" \
-                    "This is a problem with the Apple Silicon versions of Blender.\n" \
-                    "Please follow the link to the MolecularNodes GitHub page to solve it manually: \n" \
-                    "https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 ")
-        else:
-            return("Full error message:\n" + error_message)
+        return [cmd_list,"Full error message:\n" + error_message]
 
 def install(pypi_mirror=''):
+    
+    install_commands=[]
+    install_logs=[]
+
     # Get PIP upgraded
-    run_pip('ensurepip')
-    run_pip('pip install --upgrade pip', mirror=PYPI_MIRROR[pypi_mirror])
 
-    #install required packages
-    try:
-        stderr=run_pip(cmd=['pip', 'install', '-r', f'{ADDON_DIR}/requirements.txt'], mirror=PYPI_MIRROR[pypi_mirror])
-        return stderr
-    except:
-        return("Error installing dependencies")
 
+    for cmd_list,stdouterr in [
+        run_pip('ensurepip'),
+        run_pip('pip install --upgrade pip', mirror=PYPI_MIRROR[pypi_mirror]),
+        run_pip(cmd=['pip', 'install', '-r', f'{ADDON_DIR}/requirements.txt'], mirror=PYPI_MIRROR[pypi_mirror])]:
         
+        install_commands.append(cmd_list)
+        install_logs.append(stdouterr)
+    return [install_commands,install_logs]
 
 def available():
     verify()

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -16,8 +16,8 @@ PYPI_MIRROR = {
     # the original.
     'Original':'', 
     # two mirrors in China Mainland to help those poor victims under GFW.
-    'BFSU':'https://mirrors.bfsu.edu.cn/pypi/web/simple',
-    'TUNA':'https://pypi.tuna.tsinghua.edu.cn/simple',
+    'BFSU (Beijing)':'https://mirrors.bfsu.edu.cn/pypi/web/simple',
+    'TUNA (Beijing)':'https://pypi.tuna.tsinghua.edu.cn/simple',
     # append more if necessary.
 
 }
@@ -48,13 +48,12 @@ def run_pip(cmd, mirror='', timeout=600):
     except subprocess.CalledProcessError as e:
         error_message = e.stderr.decode()
         if ("fatal error: 'Python.h' file not found" in error_message) and (platform.system()== "Darwin") and ('arm' in platform.machine()):
-            print("BUG: Could not find the Python.h header file in the Blender-build-in-Python.\n" \
+            return("BUG: Could not find the Python.h header file in the Blender-build-in-Python.\n" \
                     "This is currently a bug in the Blender of Apple Silicon build.\n" \
                     "Please follow the link to solve it manually: \n" \
                     "https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 ")
         else:
-            print("Full error message:\n")
-            print(error_message)
+            return("Full error message:\n" + error_message)
 
 def install(pypi_mirror=''):
     # Get PIP upgraded
@@ -62,11 +61,12 @@ def install(pypi_mirror=''):
     run_pip('pip install --upgrade pip', mirror=PYPI_MIRROR[pypi_mirror])
 
     #install required packages
-
     try:
-        run_pip(f'pip install -r {ADDON_DIR}/requirements.txt', mirror=PYPI_MIRROR[pypi_mirror])
+        stderr=run_pip(f'pip install -r {ADDON_DIR}/requirements.txt', mirror=PYPI_MIRROR[pypi_mirror])
+        return stderr
     except:
-        run_pip(f'pip install -r {ADDON_DIR}/requirements.txt', mirror=PYPI_MIRROR['BFSU'])
+        return("Error installing dependencies")
+
         
 
 def available():

--- a/MolecularNodes/pref.py
+++ b/MolecularNodes/pref.py
@@ -42,21 +42,53 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
     
     def execute(self, context):
         if not pkg.available():
-            stderr=pkg.install(
+            import datetime,platform
+            
+            # generate logfile
+            logfile_path = os.path.abspath(MolecularNodesAddon.logpath + 'side-packages-install.log')
+            logfile = open(logfile_path, 'a')
+            
+            logfile.write("-----------------------------------" + '\n')
+            logfile.write("Installer Started: " + str(datetime.datetime.now()) + '\n')
+            logfile.write("-----------------------------------" + '\n')
+            install_commands,install_logs=pkg.install(
                 pypi_mirror=bpy.context.scene.pypi_mirror,
             )
+
+            # log cmd and stdout/stderr
+            for cmd,log in zip(install_commands,install_logs):
+                logfile.write(f'{cmd}\n{log}\n')
+
+                # solve this Apple Silicon installation failure 
+                if ("fatal error: 'Python.h' file not found" in log) and (platform.system()== "Darwin") and ('arm' in platform.machine()):
+                    error_msg = f"ERROR: Could not find the 'Python.h' header file in version of Python bundled with Blender.\n" \
+                            "This is a problem with the Apple Silicon versions of Blender.\n" \
+                            "Please follow the link to the MolecularNodes GitHub page to solve it manually: \n" \
+                            "https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 "
+                    logfile.write(f"{error_msg}\n")
+                    # print this message to Blender script window
+                    print(error_msg)
+
+
+            logfile.write("###################################" + '\n')
+            logfile.write("Installer finished: " + str(datetime.datetime.now()) + '\n')
+            logfile.write("###################################" + '\n')
             
+            # close the logfile
+            logfile.close()
+
         if pkg.available():
             # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = True
             self.report(
                 {'INFO'}, 
                 message='Successfully Installed Required Packages'
                 )
+            
         else:
             # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = False
             self.report(
                 {'ERROR'}, 
-                message=f'Failed to install required packages. \n {stderr}'
+                message=f'Failed to install required packages. \n {error_msg}. \nPlease check log file for details: {logfile_path}'
                 )
         
         return {'FINISHED'}

--- a/MolecularNodes/pref.py
+++ b/MolecularNodes/pref.py
@@ -30,7 +30,6 @@ from . import pkg
 import bpy
 import os
 
-# ---------------- GLOBAL ADDON LOGGER -------------------
 
 # ------------- DEFINE ADDON PREFERENCES ----------------
 # an operator that installs the python dependencies
@@ -43,25 +42,10 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
     
     def execute(self, context):
         if not pkg.available():
-            import datetime
+            pkg.install(
+                pypi_mirror=bpy.context.scene.pypi_mirror,
+            )
             
-            # generate logfile
-            logfile_path = os.path.abspath(MolecularNodesAddon.logpath + 'side-packages-install.log')
-            logfile = open(logfile_path, 'a')
-            
-            logfile.write("-----------------------------------" + '\n')
-            logfile.write("Installer Started: " + str(datetime.datetime.now()) + '\n')
-            logfile.write("-----------------------------------" + '\n')
-            
-            pkg.install()
-            
-            logfile.write("###################################" + '\n')
-            logfile.write("Installer finished: " + str(datetime.datetime.now()) + '\n')
-            logfile.write("###################################" + '\n')
-            
-            # close the logfile
-            logfile.close()
-        
         if pkg.available():
             # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = True
             self.report(
@@ -72,7 +56,7 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
             # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = False
             self.report(
                 {'ERROR'}, 
-                message='Failed to install required packages. Please check log file: ' + logfile_path
+                message='Failed to install required packages. '
                 )
         
         return {'FINISHED'}

--- a/MolecularNodes/pref.py
+++ b/MolecularNodes/pref.py
@@ -42,7 +42,7 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
     
     def execute(self, context):
         if not pkg.available():
-            pkg.install(
+            stderr=pkg.install(
                 pypi_mirror=bpy.context.scene.pypi_mirror,
             )
             
@@ -56,7 +56,7 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
             # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = False
             self.report(
                 {'ERROR'}, 
-                message='Failed to install required packages. '
+                message=f'Failed to install required packages. \n {stderr}'
                 )
         
         return {'FINISHED'}

--- a/MolecularNodes/requirements.txt
+++ b/MolecularNodes/requirements.txt
@@ -1,0 +1,2 @@
+biotite==0.35.0
+MDAnalysis==2.2.0

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -6,7 +6,7 @@ from . import pkg
 from . import load
 from . import md
 from . import assembly
-import os
+import os,pathlib
 
 
 
@@ -39,8 +39,6 @@ class MOL_OT_Import_Protein_RCSB(bpy.types.Operator):
 
     def invoke(self, context, event):
         return self.execute(context)
-
-
 
 
 # operator that calls the function to import the structure from a local file
@@ -289,7 +287,22 @@ class MOL_MT_Default_Style(bpy.types.Menu):
 def MOL_PT_panel_ui(layout_function, scene): 
     layout_function.label(text = "Import Options", icon = "MODIFIER")
     if not pkg.available():
+        
+        col_main = layout_function.column(heading = '', align = False)
+        col_main.alert = False
+        col_main.enabled = True
+        col_main.active = True
+        col_main.use_property_split = False
+        col_main.use_property_decorate = False
+        col_main.scale_x = 1.0
+        col_main.scale_y = 1.0
+        
+        col_main.alignment = 'Expand'.upper()
+        col_main.label(text = "Set PyPI Mirror (remain blank for default)")
+        row_import = col_main.row()
+        row_import.prop(bpy.context.scene, 'pypi_mirror',text='PyPI')
         layout_function.operator('mol.install_dependencies', text = 'Install Packages')
+        
     else:
         box = layout_function.box()
         grid = box.grid_flow(columns = 2)
@@ -316,6 +329,8 @@ def MOL_PT_panel_ui(layout_function, scene):
             MOL_PT_panel_local(layout_function)
         else:
             MOL_PT_panel_md_traj(layout_function, scene)
+
+
 
 class MOL_PT_panel(bpy.types.Panel):
     bl_label = 'Molecular Nodes'

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -298,7 +298,7 @@ def MOL_PT_panel_ui(layout_function, scene):
         col_main.scale_y = 1.0
         
         col_main.alignment = 'Expand'.upper()
-        col_main.label(text = "Set PyPI Mirror (remain blank for default)")
+        col_main.label(text = "Set PyPI Mirror")
         row_import = col_main.row()
         row_import.prop(bpy.context.scene, 'pypi_mirror',text='PyPI')
         layout_function.operator('mol.install_dependencies', text = 'Install Packages')


### PR DESCRIPTION
This PR is mainly focused on improving dependencies stuff in the following ways:

1. PyPI mirror selection, which might be helpful for those get blocked from accessing the original PyPI repo.
2. Passing the `stderr` of `pip install` to Blender scripting window for detailed reminding.
3. Trying to provide a easier way to solve the `Python.h not found` error while installing MDA via `pip install` on Mac on Apple Silicon chips. This issue has been mentioned at https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 for a more elegant solution.
4. Getting `pip install` more compatible (for future dev).
5. Remove logging from dependencies installation. Just have no idea why we have to log some date &time.
6. Bring `requirements.txt` back to simplify both the `pip install` procedure and dependencies management.