### PR TITLE
Fix m1 mac dependency

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -36,7 +36,7 @@ from .pkg import *
 def register():
     bpy.types.Scene.mirror = bpy.props.StringProperty(
         name = 'mirror', 
-        description = 'PyPI/Conda Mirror', 
+        description = 'PyPI Mirror', 
         options = {'TEXTEDIT_UPDATE'}, 
         default = 'Default', 
         subtype = 'NONE', 

--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -34,13 +34,13 @@ from .pkg import *
 
 
 def register():
-    bpy.types.Scene.pypi_mirror = bpy.props.StringProperty(
-        name = 'pypi_mirror', 
-        description = 'PyPI Mirror', 
+    bpy.types.Scene.mirror = bpy.props.StringProperty(
+        name = 'mirror', 
+        description = 'PyPI/Conda Mirror', 
         options = {'TEXTEDIT_UPDATE'}, 
         default = 'Default', 
         subtype = 'NONE', 
-        search = get_pypi_mirror_alias,
+        search = get_mirror_alias,
         )
     bpy.types.Scene.mol_pdb_code = bpy.props.StringProperty(
         name = 'pdb_code', 

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -128,7 +128,7 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
     
     def execute(self, context):
         if not available():
-            import datetime,platform
+            import datetime
             
             # generate logfile
             logfile_path = os.path.abspath(str(ADDON_DIR) + "/logs/" + 'side-packages-install.log')

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -66,11 +66,11 @@ def install(pypi_mirror=''):
         
         # basic pkg managements
         CONDA_PATH_EXEC=pathlib.Path(os.environ['CONDA_EXE']).resolve() if os.environ['CONDA_EXE'] else ''
-        install_commands.append('CONDA detection')
+        install_commands.append('CONDA detection..')
         install_logs.append(CONDA_PATH_EXEC)
         
         if not CONDA_PATH_EXEC:
-            raise RuntimeError(f'Conda is required for dependency installation.')
+            raise RuntimeError(f'Conda is required for dependency installation, as the \'Python.h\' header file is missing in Python bundled with the Apple Silicon versions of Blender.')
 
         print(f'Conda exec: {CONDA_PATH_EXEC}')
         
@@ -78,7 +78,7 @@ def install(pypi_mirror=''):
             CONDA_PATH=CONDA_PATH_EXEC.parent.parent
             CONDA_MN_PREFIX='MN_PY310'
             SUPPOSED_PYTHONPATH=CONDA_PATH.joinpath('envs',CONDA_MN_PREFIX,'bin','python3.10')
-            install_commands.append(f'Detect Conda env with python3.10')
+            install_commands.append(f'Detect Conda env with python3.10..')
             # if a conda env has already been created before.
             if pathlib.Path.exists(SUPPOSED_PYTHONPATH):
                 install_logs.append(SUPPOSED_PYTHONPATH)
@@ -89,7 +89,7 @@ def install(pypi_mirror=''):
                 conda_cmd_new_env=[ CONDA_PATH_EXEC,'create','-n',CONDA_MN_PREFIX, 'python=3.10', '-y']
                 conda_install_run=subprocess.run(conda_cmd_new_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={'CONDA_SUBDIR':'osx-arm64'})
                 install_commands.append(conda_cmd_new_env)
-                install_logs.append([conda_install_run.stdout.decode(),conda_install_run.stderr.decode()])
+                install_logs.append(conda_install_run.stdout.decode()+ conda_install_run.stderr.decode())
                 
                 # check the installation
                 if conda_install_run.returncode == 0 and pathlib.Path.exists(SUPPOSED_PYTHONPATH):

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -19,6 +19,24 @@ PYPI_MIRROR = {
 
 }
 
+CONDA_MIRROR_MAC_ARM = {
+    'Default': 'https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh',
+    'BFSU (Beijing)': 'https://mirrors.bfsu.edu.cn/anaconda/miniconda/Miniconda3-latest-MacOSX-arm64.sh',
+    'TUNA (Beijing)': 'https://mirrors.bfsu.edu.cn/anaconda/miniconda/Miniconda3-latest-MacOSX-arm64.sh'
+}
+
+def does_it_ARMed(binary_path):
+    assert pathlib.Path.exists(binary_path)
+    test_cmd_run=subprocess.run(['file',binary_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout=test_cmd_run.stdout.decode().strip()
+    stderr=test_cmd_run.stderr.decode().strip()
+    if test_cmd_run.returncode != 0:
+        return ('arm64' in stdout)
+    else:
+        raise RuntimeError(f'Failed on determine the architechture of {binary_path}: \nFull error: {stderr}')
+    
+        
+
 def get_pypi_mirror_alias(self, context, edit_text):
     return PYPI_MIRROR.keys()
     
@@ -61,20 +79,36 @@ def install(pypi_mirror=''):
 
     if (platform.system()== "Darwin") and ('arm' in platform.machine()):
         # M1 issue
-        # find default conda path
-        SYSTEM_PYTHON310 = ''
+        # find default conda path and py310
         
+        TEST_SYSTEM_PYTHON310_CFG = subprocess.run(['which','python3.10-config'],stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+        SYSTEM_PYTHON310=pathlib.Path(TEST_SYSTEM_PYTHON310_CFG.stdout.decode().strip().replace('-config','')).resolve() if TEST_SYSTEM_PYTHON310_CFG.returncode==0 else ''
+
         # basic pkg managements
-        CONDA_PATH_EXEC=pathlib.Path(os.environ['CONDA_EXE']).resolve() if os.environ['CONDA_EXE'] else ''
+        CONDA_PATH_EXEC=pathlib.Path(os.environ['CONDA_EXE']).resolve() if 'CONDA_EXE' in os.environ.keys() else ''
         install_commands.append('CONDA detection..')
         install_logs.append(CONDA_PATH_EXEC)
         
-        if not CONDA_PATH_EXEC:
-            raise RuntimeError(f'Conda is required for dependency installation, as the \'Python.h\' header file is missing in Python bundled with the Apple Silicon versions of Blender.')
-
-        print(f'Conda exec: {CONDA_PATH_EXEC}')
         
-        if not SYSTEM_PYTHON310:
+        if not (SYSTEM_PYTHON310 and does_it_ARMed(SYSTEM_PYTHON310)):
+            if not CONDA_PATH_EXEC:
+                print(f'Conda is required for dependency installation, as the \'Python.h\' header file is missing in Python bundled with the Apple Silicon versions of Blender.')
+
+                # install a new miniconda and apply it
+                MINICONDA_INSTALLER_URL = CONDA_MIRROR_MAC_ARM[pypi_mirror]
+                MINICONDA_INSTALLER_PATH = '/tmp/miniconda_installer.sh'
+                MINICONDA_INSTALL_PATH=pathlib.Path(sys.executable).resolve().parent.parent.parent.joinpath('miniconda_mn_py310')
+                subprocess.run(['curl', '-o', MINICONDA_INSTALLER_PATH, '-L', MINICONDA_INSTALLER_URL], check=True)
+                subprocess.run(['sh', MINICONDA_INSTALLER_PATH, '-b','-f', '-p', MINICONDA_INSTALL_PATH], check=True)
+                CONDA_PATH_EXEC = pathlib.Path(f'{MINICONDA_INSTALL_PATH}/bin/conda').resolve()
+                install_commands.append('Miniconda installation..')
+                install_logs.append(f'Installed Miniconda to {MINICONDA_INSTALL_PATH}.')
+                os.environ['CONDA_EXE'] = str(CONDA_PATH_EXEC)
+                os.environ['PATH'] = f'{str(CONDA_PATH_EXEC.parent)}/bin:{os.environ["PATH"]}'
+                install_commands.append('Set up environment variables..')
+                install_logs.append(f'CONDA_EXE={os.environ["CONDA_EXE"]}, PATH={os.environ["PATH"]}')
+        
+
             CONDA_PATH=CONDA_PATH_EXEC.parent.parent
             CONDA_MN_PREFIX='MN_PY310'
             SUPPOSED_PYTHONPATH=CONDA_PATH.joinpath('envs',CONDA_MN_PREFIX,'bin','python3.10')
@@ -83,6 +117,7 @@ def install(pypi_mirror=''):
             if pathlib.Path.exists(SUPPOSED_PYTHONPATH):
                 install_logs.append(SUPPOSED_PYTHONPATH)
                 print(f'Found Python 3.10 via Conda: {SUPPOSED_PYTHONPATH}')
+                SYSTEM_PYTHON310=SUPPOSED_PYTHONPATH
             else:
                 install_logs.append('Not found...')
                 # run a new conda environment setup
@@ -106,7 +141,7 @@ def install(pypi_mirror=''):
                 install_commands.append(system_python310_cmd)
                 install_logs.append(SYSTEM_PYTHON310_INCLUDED)
                 # reading the results
-                CPATH_ANOUNCEMENT={'CPATH':SYSTEM_PYTHON310_INCLUDED.replace('-I',':').replace(' ','')}
+                CPATH_ANOUNCEMENT={'CPATH':SYSTEM_PYTHON310_INCLUDED.replace('-I',':').replace(' ',''),'PATH':os.environ['PATH']}
                 print(f'PIP w/ ENV: {CPATH_ANOUNCEMENT}')
             else:
                 print(f'Python 3.10 is not installed before dependency installation.')

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -35,7 +35,7 @@ def does_it_ARMed(binary_path):
     test_cmd_run=subprocess.run(['file',binary_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout=test_cmd_run.stdout.decode().strip()
     stderr=test_cmd_run.stderr.decode().strip()
-    if test_cmd_run.returncode != 0:
+    if test_cmd_run.returncode == 0:
         return ('arm64' in stdout)
     else:
         raise RuntimeError(f'Failed on determine the architechture of {binary_path}: \nFull error: {stderr}')

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -19,29 +19,6 @@ PYPI_MIRROR = {
 
 }
 
-# for M1 installation issue. 
-# the keys should be exactly as those in `PYPI_MIRROR`
-CONDA_MIRROR_MAC_ARM = {
-    # the original.
-    'Default': 'https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh',
-    # two mirrors in China Mainland to help those poor victims under GFW.
-    'BFSU (Beijing)': 'https://mirrors.bfsu.edu.cn/anaconda/miniconda/Miniconda3-latest-MacOSX-arm64.sh',
-    'TUNA (Beijing)': 'https://mirrors.bfsu.edu.cn/anaconda/miniconda/Miniconda3-latest-MacOSX-arm64.sh'
-    # append more if necessary.
-}
-
-# check if a given binary is built in ARM64 arch for MacOS
-# This will be used only when M1/M2 issue occurs.
-def does_it_ARMed(binary_path):
-    assert pathlib.Path.exists(binary_path)
-    test_cmd_run=subprocess.run(['file',binary_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout=test_cmd_run.stdout.decode().strip()
-    stderr=test_cmd_run.stderr.decode().strip()
-    if test_cmd_run.returncode == 0:
-        return ('arm64' in stdout)
-    else:
-        print(f'Failed on determine the architechture of {binary_path}: \nFull error: {stderr}')
-        return False
 
 
 def get_mirror_alias(self, context, edit_text):
@@ -78,6 +55,20 @@ def install(mirror=''):
     install_commands=[]
     install_logs=[]
 
+    # check if a given binary is built in ARM64 arch for MacOS
+    # This will be used only when M1/M2 issue occurs.
+    def does_it_ARMed(binary_path):
+        assert pathlib.Path.exists(binary_path)
+        test_cmd_run=subprocess.run(['file',binary_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout=test_cmd_run.stdout.decode().strip()
+        stderr=test_cmd_run.stderr.decode().strip()
+        if test_cmd_run.returncode == 0:
+            return ('arm64' in stdout)
+        else:
+            print(f'Failed on determine the architechture of {binary_path}: \nFull error: {stderr}')
+            return False
+
+
     CPATH_ANOUNCEMENT={}
 
     # M1 issue caused by missing 'Python.h'(python-dev) in bundled python package of Blender itself.
@@ -85,92 +76,35 @@ def install(mirror=''):
     # please see the phenotype solution at https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 
     # and a shell helper script in https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1442794000.
     # in this circunstance, system-wide Python is firstly checked by looking for `python3.10-config`. 
-    # If it doesn't exist, a miniconda will be downloaded and installed for creating a new Python 3.10 installation.
+    # If it doesn't exist, an error will be raised.
     # Since GCC is required for building MDAnaysis(Numpy?) from scratch, Xcode commandline tools should be installed before this installation.
     if (platform.system()== "Darwin") and ('arm' in platform.machine()):
         # good luck guys.
 
-        # find default conda path and py310
+        # detect py310
         TEST_SYSTEM_PYTHON310_CFG = subprocess.run(['which','python3.10-config'],stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
         SYSTEM_PYTHON310=pathlib.Path(TEST_SYSTEM_PYTHON310_CFG.stdout.decode().strip().replace('-config','')).resolve() if TEST_SYSTEM_PYTHON310_CFG.returncode==0 else ''
         install_commands.append('System-wide detection..')
         install_logs.append(f"{(SYSTEM_PYTHON310 != '')}: {SYSTEM_PYTHON310}")
 
-        # basic pkg managements: conda
-        CONDA_PATH_EXEC=pathlib.Path(os.environ['CONDA_EXE']).resolve() if 'CONDA_EXE' in os.environ.keys() else ''
-        install_commands.append('CONDA detection..')
-        install_logs.append(f"{(CONDA_PATH_EXEC != '')}: {CONDA_PATH_EXEC}")
-        
-        # If system-wide Python3.10 in arm64 is not available, install it via miniconda
-        if not (SYSTEM_PYTHON310 and does_it_ARMed(SYSTEM_PYTHON310)):
-            # If miniconda is not available, install it.
-            if not CONDA_PATH_EXEC:
-                print(f'Conda is required for dependency installation, as the \'Python.h\' header file is missing in Python bundled with the Apple Silicon versions of Blender.')
-
-                # install a new miniconda and apply it (this will not modify the $HOME/.$(basename $SHELL)rc profile)
-                MINICONDA_INSTALLER_URL = CONDA_MIRROR_MAC_ARM[mirror]
-                MINICONDA_INSTALLER_PATH = '/tmp/miniconda_installer.sh'
-                MINICONDA_INSTALL_PATH=pathlib.Path(sys.executable).resolve().parent.parent.parent.joinpath('miniconda_mn_py310')
-                
-                # download miniconda
-                miniconda_download_cmd=['curl', '-o', MINICONDA_INSTALLER_PATH, '-L', MINICONDA_INSTALLER_URL]
-                install_commands.append(miniconda_download_cmd)
-                download_miniconda_run=subprocess.run(miniconda_download_cmd, check=True,stdout=subprocess.PIPE)
-                install_logs.append(f'Miniconda is dowloaded from {MINICONDA_INSTALLER_URL} and will be stored at {MINICONDA_INSTALLER_PATH}\n{download_miniconda_run.stdout.decode()}\n')
-                
-                # install miniconda in bacth mode (accept the license and no error report even it the prefix has already been occupied.)
-                miniconda_install_cmd=['sh', MINICONDA_INSTALLER_PATH, '-b','-f', '-p', MINICONDA_INSTALL_PATH]
-                install_commands.append(miniconda_install_cmd)
-                install_miniconda_run=subprocess.run(miniconda_install_cmd, check=True,stdout=subprocess.PIPE)
-                CONDA_PATH_EXEC = pathlib.Path(f'{MINICONDA_INSTALL_PATH}/bin/conda').resolve()
-                install_logs.append(f'Miniconda has been installed successfully to {MINICONDA_INSTALL_PATH}.\n{install_miniconda_run.stdout.decode()}\n')
-
-                # apply new conda exe to PATH
-                os.environ['CONDA_EXE'] = str(CONDA_PATH_EXEC)
-                os.environ['PATH'] = f'{str(CONDA_PATH_EXEC.parent)}:{os.environ["PATH"]}'
-                install_commands.append('Set up environment variables..')
-                install_logs.append(f'CONDA_EXE={os.environ["CONDA_EXE"]}, PATH={os.environ["PATH"]}')
-        
-            # prepare to set up a new conda environment.
-            CONDA_PATH=CONDA_PATH_EXEC.parent.parent
-            CONDA_MN_PREFIX='MN_PY310'
-            SUPPOSED_PYTHONPATH=CONDA_PATH.joinpath('envs',CONDA_MN_PREFIX,'bin','python3.10')
-            install_commands.append(f'Detecting Conda env with python3.10..')
-
-            # if a conda env has already been created before.
-            if pathlib.Path.exists(SUPPOSED_PYTHONPATH):
-                install_logs.append(f'Found previously installed Python 3.10 via Miniconda: {SUPPOSED_PYTHONPATH}')
-                SYSTEM_PYTHON310=SUPPOSED_PYTHONPATH
-            else:
-                install_logs.append('Not found... Now we try to create it.')
-                # run a new conda environment setup
-                conda_cmd_new_env=[ CONDA_PATH_EXEC,'create','-n',CONDA_MN_PREFIX, 'python=3.10', '-y']
-                install_commands.append(f'Installing a new conda env {CONDA_MN_PREFIX}: {conda_cmd_new_env}')
-                conda_install_run=subprocess.run(conda_cmd_new_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={'CONDA_SUBDIR':'osx-arm64'})
-                install_logs.append(f"STDOUT: {conda_install_run.stdout.decode()}\nSTDERR: {conda_install_run.stderr.decode()}")
-                
-                install_commands.append('Checking Python3.10 again after conda create new env ...')
-                # check the conda installation
-                if conda_install_run.returncode == 0 and pathlib.Path.exists(SUPPOSED_PYTHONPATH):
-                    SYSTEM_PYTHON310=SUPPOSED_PYTHONPATH
-                    install_logs.append(f'Python 3.10 installed: {SYSTEM_PYTHON310}')
-                else:
-                    install_logs.append(f'Failed to setup new conda environment {CONDA_MN_PREFIX}. Further installation may fail.')
-            
         # now we determine the python cpath include
         if SYSTEM_PYTHON310 and does_it_ARMed(SYSTEM_PYTHON310):
             system_python310_cmd=[f'{SYSTEM_PYTHON310}-config','--include']
             install_commands.append(f'Detect External Python include path: {system_python310_cmd}')
             SYSTEM_PYTHON310_INCLUDED=subprocess.run(system_python310_cmd,stdout=subprocess.PIPE,stderr=subprocess.PIPE,).stdout.decode().strip()
             install_logs.append(SYSTEM_PYTHON310_INCLUDED)
-            # reading the results
+
             # PATH is required by biopython for (--use-pep517) issue (?)
             # gcc is required for building the dependency MDAnaysis from scratch.
             CPATH_ANOUNCEMENT={'CPATH':SYSTEM_PYTHON310_INCLUDED.replace('-I',':').replace(' ',''),'PATH':os.environ['PATH']}
             install_commands.append("Final CPATH_ANOUNCEMENT for M1/M2 issue")
             install_logs.append(CPATH_ANOUNCEMENT)
         else:
-            print(f'Python 3.10 is not installed before dependency installation.')
+            # TODO: add guideline url to both logfile and error message.
+            install_commands.append("Error: ")
+            install_logs.append("System-wide Python3.10 should be available. Please see the GitHub page of MolecularNodes for more information.")
+            # If system-wide Python3.10 in arm64 is not available, raise an error.
+            raise RuntimeError("System-wide Python3.10 should be available. Please see the GitHub page of MolecularNodes for more information.")
     
     for cmd_list,stdouterr in [
         # Get PIP installed and upgraded

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -306,9 +306,9 @@ def MOL_PT_panel_ui(layout_function, scene):
         col_main.scale_y = 1.0
         
         col_main.alignment = 'Expand'.upper()
-        col_main.label(text = "Set PyPI Mirror")
+        col_main.label(text = "Set Installation Mirror of PyPI/Conda")
         row_import = col_main.row()
-        row_import.prop(bpy.context.scene, 'pypi_mirror',text='PyPI')
+        row_import.prop(bpy.context.scene, 'mirror',text='Mirror Name')
         layout_function.operator('mol.install_dependencies', text = 'Install Packages')
         
     else:

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -306,7 +306,7 @@ def MOL_PT_panel_ui(layout_function, scene):
         col_main.scale_y = 1.0
         
         col_main.alignment = 'Expand'.upper()
-        col_main.label(text = "Set Installation Mirror of PyPI/Conda")
+        col_main.label(text = "Set Installation Mirror of PyPI")
         row_import = col_main.row()
         row_import.prop(bpy.context.scene, 'mirror',text='Mirror Name')
         layout_function.operator('mol.install_dependencies', text = 'Install Packages')


### PR DESCRIPTION
This PR is focus on fixing the dependency failure on M1 mac seamlessly.

**Xcode commandline tools are required**: `xcode-select --install`

example `logs/side-packages-install.log`: https://gist.github.com/YaoYinYing/005ccba9efbd05db97c7d19fca4cf694