### PR TITLE
Enable dependency updates after MN is upgraded.

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -27,10 +27,10 @@ bl_info = {
 
 import bpy
 from . import pkg
-pkg.verify()
 from .ui import *
 from .md import *
 from .pkg import *
+from .pref import *
 
 
 def register():
@@ -184,13 +184,13 @@ def register():
     bpy.utils.register_class(MOL_OT_Color_Chain)
     bpy.utils.register_class(MOL_OT_Chain_Selection_Custom)
     bpy.utils.register_class(MOL_OT_Ligand_Selection_Custom)
-    bpy.utils.register_class(MOL_OT_install_dependencies)
+    bpy.utils.register_class(MOL_OT_Install_Package)
 
     bpy.utils.register_class(MOL_OT_Add_Custom_Node_Group)
 
     bpy.utils.register_class(MOL_OT_Residues_Selection_Custom)
-
-
+    bpy.utils.register_class(MolecularNodesPreferences)
+    
 def unregister():
     del bpy.types.Scene.mol_pdb_code
     del bpy.types.Scene.mol_md_selection
@@ -244,9 +244,10 @@ def unregister():
     bpy.utils.unregister_class(MOL_OT_Chain_Selection_Custom)
     
     bpy.utils.unregister_class(MOL_OT_Add_Custom_Node_Group)
-    bpy.utils.unregister_class(MOL_OT_install_dependencies)
+    bpy.utils.unregister_class(MOL_OT_Install_Package)
 
     bpy.utils.unregister_class(MOL_OT_Residues_Selection_Custom)
+    bpy.utils.unregister_class(MolecularNodesPreferences)
 
 if __name__=="__main__":
     register()

--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -34,10 +34,10 @@ from .pref import *
 
 
 def register():
-    bpy.types.Scene.pypi_mirror = bpy.props.StringProperty(
-        name = 'pypi_mirror', 
-        description = 'PyPI Mirror', 
-        options = {'TEXTEDIT_UPDATE'}, 
+    bpy.types.Scene.pypi_mirror_provider = bpy.props.StringProperty(
+        name = 'pypi_mirror_provider', 
+        description = 'PyPI Mirror Provider', 
+        options = {'TEXTEDIT_UPDATE','LIBRARY_EDITABLE'}, 
         default = 'Default', 
         subtype = 'NONE', 
         search = get_pypi_mirror_alias,
@@ -192,6 +192,7 @@ def register():
     bpy.utils.register_class(MolecularNodesPreferences)
     
 def unregister():
+    del bpy.types.Scene.pypi_mirror_provider
     del bpy.types.Scene.mol_pdb_code
     del bpy.types.Scene.mol_md_selection
     del bpy.types.Scene.mol_import_center

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -1,14 +1,13 @@
 import subprocess
 import sys
 import os
-import site
-from importlib.metadata import version
+import logging
+from pkg_resources import get_distribution, DistributionNotFound
 import bpy
 import pathlib
+import platform
 
 ADDON_DIR = pathlib.Path(__file__).resolve().parent
-print(ADDON_DIR)
-
 PYPI_MIRROR = {
     # the original.
     'Default':'', 
@@ -16,147 +15,303 @@ PYPI_MIRROR = {
     'BFSU (Beijing)':'https://mirrors.bfsu.edu.cn/pypi/web/simple',
     'TUNA (Beijing)':'https://pypi.tuna.tsinghua.edu.cn/simple',
     # append more if necessary.
-
 }
 
-def get_pypi_mirror_alias(self, context, edit_text):
+def start_logging(logfile_name: str = 'side-packages-install') -> logging.Logger:
+    """Configure and start logging to a file.
+
+    Args:
+        logfile_name (str, optional): The name of the log file. Defaults to 'side-packages-install'.
+
+    Returns:
+        logging.Logger: A Logger object that can be used to write log messages.
+
+    This function sets up a logging configuration with a specified log file name and logging level.
+    The log file will be created in the 'logs' subdirectory of the addon directory. If the directory
+    does not exist, it will be created. The function returns a Logger object that can be used to
+    write log messages.
+    """
+    # Create the logs directory if it doesn't exist
+    logs_dir = os.path.join(os.path.abspath(ADDON_DIR), 'logs')
+    os.makedirs(logs_dir, exist_ok=True)
+
+    # Set up logging configuration
+    logfile_path = os.path.join(logs_dir, f"{logfile_name}.log")
+    logging.basicConfig(filename=logfile_path, level=logging.INFO)
+
+    # Return logger object
+    return logging.getLogger()
+
+_is_apple_silicon = None
+
+def is_apple_silicon():
+    """Determine if the current system is running on Apple Silicon.
+
+    Returns:
+        bool: True if the system is running on Apple Silicon, False otherwise.
+
+    This function checks if the current system is running macOS and if the machine
+    architecture includes the string 'arm', which indicates that it is an Apple Silicon
+    processor. Returns True if both conditions are met, False otherwise.
+    """
+    global _is_apple_silicon
+    if _is_apple_silicon is None:
+        _is_apple_silicon = (sys.platform == "darwin") and ('arm' in platform.machine())
+    return _is_apple_silicon
+
+def get_pypi_mirror_alias(self, context, edit_text):    
     return PYPI_MIRROR.keys()
-    
 
-def verify_user_sitepackages(package_location):
-    if os.path.exists(package_location) and package_location not in sys.path:
-        sys.path.append(package_location)
+def get_pkgs(requirements: str = None) -> dict:
+    """
+    Reads a requirements file and extracts package information into a dictionary.
 
+    Args:
+        requirements (str, optional): The path to the requirements file. If not provided, the
+            function looks for a requirements.txt file in the same directory as the script.
 
-def verify(): 
-    verify_user_sitepackages(site.getusersitepackages())
+    Returns:
+        dict: A dictionary containing package information. Each element of the dictionary is 
+              a dictionary containing the package name, version, and description.
 
+    Example:
+        Given the following requirements file:
+        ```
+        Flask==1.1.2 # A micro web framework for Python
+        pandas==1.2.3 # A fast, powerful, flexible, and easy-to-use data analysis and manipulation tool
+        numpy==1.20.1 # Fundamental package for scientific computing
+        ```
+        The function would return the following dictionary:
+        ```
+        [
+            {
+                "package": "Flask",
+                "version": "1.1.2",
+                "desc": "A micro web framework for Python"
+            },
+            {
+                "package": "pandas",
+                "version": "1.2.3",
+                "desc": "A fast, powerful, flexible, and easy-to-use data analysis and manipulation tool"
+            },
+            {
+                "package": "numpy",
+                "version": "1.20.1",
+                "desc": "Fundamental package for scientific computing"
+            }
+        ]
+        """
+    import pathlib
 
-def run_pip(cmd_list=[], mirror='', timeout=600):
+    if not requirements:
+        folder_path = pathlib.Path(__file__).resolve().parent
+        requirements = f"{folder_path}/requirements.txt"
+
+    with open(requirements) as f:
+        lines = f.read().splitlines()
+        pkgs = {}
+        for line in lines:
+            try:
+                pkg, desc = line.split('#')
+                pkg_meta = pkg.split('==')
+                name = pkg_meta[0].strip()
+                pkgs[name] = {
+                    "name": name,
+                    "version": pkg_meta[1].strip(),
+                    "desc": desc.strip()
+                }
+            except ValueError:
+                # Skip line if it doesn't have the expected format
+                pass
+    return pkgs
+
+def is_current(package: str) -> bool:
+    pkg = get_pkgs().get(package)
+    return is_available(pkg.get('name'), pkg.get('version'))
+
+def is_available(package: str, version: str=None) -> bool:
+    """
+    Checks if a given package is available with the specified version.
+
+    Args:
+        package (str): The name of the package to check.
+        version (str): The version of the package to check.
+
+    Returns:
+        bool: True if the package with the specified version is available, False otherwise.
+
+    Example:
+        >>> is_available('numpy', '1.20.1')
+        True
+    """
+    try: 
+        available_version = get_distribution(package).version
+        return available_version == version
+    except DistributionNotFound:
+        return False
+
+def run_python(cmd_list=None, mirror='', timeout=600):
+    """
+    Runs pip command using the specified command list and returns the command output.
+
+    Args:
+        cmd_list (list, optional): List of pip commands to be executed. Defaults to None.
+        mirror (str, optional): URL of a package repository mirror to be used for the command. Defaults to ''.
+        timeout (int, optional): Time in seconds to wait for the command to complete. Defaults to 600.
+
+    Returns:
+        tuple: A tuple containing the command list, command return code, command standard output,
+            and command standard error.
+
+    Example:
+        ```
+        # Install numpy using pip and print the command output
+        cmd_list = ["-m", "pip", "install", "numpy"]
+        mirror_url = 'https://pypi.org/simple/'
+        cmd_output = run_python(cmd_list, mirror=mirror_url, timeout=300)
+        print(cmd_output)
+        ```
+    """
     # path to python.exe
     python_exe = os.path.realpath(sys.executable)
 
-    cmd_list=[python_exe, "-m"] + cmd_list
+    # build the command list
+    cmd_list=[python_exe] + cmd_list
 
+    # add mirror to the command list if it's valid
     if mirror and mirror.startswith('https'):
         cmd_list+=['-i', mirror]
+    
+    log = start_logging()
+    log.info(f"Running Pip: '{cmd_list}'")
 
-    print("Running pip:")
-    print(cmd_list)
-    pip_result = subprocess.run(cmd_list, timeout=timeout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    return (cmd_list,pip_result.returncode,pip_result.stdout.decode(),pip_result.stderr.decode())  
+    # run the command and capture the output
+    result = subprocess.run(cmd_list, timeout=timeout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-def install(pypi_mirror=''):
+    if result.returncode != 0:
+        log.error('Command failed: %s', cmd_list)
+        log.error('stdout: %s', result.stdout.decode())
+        log.error('stderr: %s', result.stderr.decode())
+    else:
+        log.info('Command succeeded: %s', cmd_list)
+        log.info('stdout: %s', result.stdout.decode())
+    # return the command list, return code, stdout, and stderr as a tuple
+    return result
 
-    results=[]
+def install_package(package: str, pypi_mirror: str = 'Default') -> list:
+    """
+    Install a Python package and its dependencies using pip.
 
+    Args:
+        package (str): The name of the package to install.
+        pypi_mirror (str): The name of the PyPI mirror to use. Default is 'Default'.
 
-    for result in [
-        # Get PIP upgraded
-        run_pip(['ensurepip']),
-        run_pip(['pip', 'install', '--upgrade','pip'], mirror=PYPI_MIRROR[pypi_mirror]),
-        # Install from requirements
-        run_pip(['pip', 'install', '-r', f'{ADDON_DIR}/requirements.txt'], mirror=PYPI_MIRROR[pypi_mirror])]:
-        results.append(result)
+    Returns:
+        list: A list of tuples containing the command list, return code, stdout, and stderr for each pip command run.
+
+    Raises:
+        ValueError: If package name is not provided.
+
+    Example:
+        To install the package 'requests' from the PyPI mirror 'MyMirror', use:
+        ```
+        install_package('requests', 'MyMirror')
+        ```
+    """
+    if not package:
+        raise ValueError("Package name must be provided.")
+
+    print(f"Installing {package}...")
+    print(f"Using PyPI mirror: {PYPI_MIRROR[pypi_mirror]}")
+    # print(f"Command list: {cmd_list}")
+
+    
+    run_python(["-m", "ensurepip"]),
+    run_python(["-m", "pip", "install", "--upgrade", "pip"], mirror=PYPI_MIRROR[pypi_mirror])
+    result = run_python(["-m", "pip", "install", package], mirror=PYPI_MIRROR[pypi_mirror])
+    
+    return result
+
+class InstallationError(Exception):
+    """
+    Exception raised when there is an error installing a package.
+
+    Attributes:
+        package_name (str): the name of the package that failed to install
+        error_message (str): the error message returned by pip
+    """
+
+    def __init__(self, package_name, error_message):
+        self.package_name = package_name
+        self.error_message = error_message
+        super().__init__(f"Failed to install {package_name}: {error_message}")
+
+def install_all_packages(pypi_mirror: str='Default') -> list:
+    """
+    Installs all packages listed in the 'requirements.txt' file.
+
+    Args:
+        pypi_mirror (str): Optional. The PyPI mirror to use for package installation. 
+                           Defaults to 'Default' which uses the official PyPI repository.
+
+    Returns:
+        list: A list of tuples containing the installation results for each package.
+
+    Raises:
+        InstallationError: If there is an error during package installation.
+
+    Example:
+        To install all packages listed in the 'requirements.txt' file, run the following command:
+        ```
+        install_all_packages(pypi_mirror='https://pypi.org/simple/')
+        ```
+    """
+    pkgs = get_pkgs()
+    results = []
+    for pkg in pkgs.items():
+        try:
+            result = install_package(f"{pkg.get('name')}=={pkg.get('version')}", pypi_mirror)
+            results.append(result)
+        except InstallationError as e:
+            raise InstallationError(f"Error installing package {pkg.get('name')}: {str(e)}")
     return results
 
-
-def available():
-    import pkg_resources
-    verify()
-    # compare the pinned versions of requirements.txt against the installed.
-    with open(f'{ADDON_DIR}/requirements.txt') as f:
-        requirements = f.read().splitlines()
-
-    for requirement in requirements:
-        if requirement.startswith('#') or requirement.strip() == '': continue
-        req = pkg_resources.Requirement.parse(requirement)
-        try:
-            version(req.name)
-            installed = pkg_resources.get_distribution(req.name)
-            # print to VSC console for debug
-            print(f'Required: {req}\tInstalled: {installed}\tMatch: {installed.version in req}')
-            if not installed.version in req:
-                return False
-        except Exception as e:
-            print(e)
-            return False
-
-    return True
-
-
-class MOL_OT_install_dependencies(bpy.types.Operator):
-    bl_idname = "mol.install_dependencies"
-    bl_label = "Install Dependencies"
-    bl_description = "Install the required python packages to enable import."
+class MOL_OT_Install_Package(bpy.types.Operator):
+    bl_idname = 'mol.install_package'
+    bl_label = 'Install Given Python Package'
     bl_options = {'REGISTER', 'INTERNAL'}
+    package: bpy.props.StringProperty(
+        name = 'Python Package', 
+        description = 'Python Package to Install', 
+        default = 'biotite'
+    )
+    version: bpy.props.StringProperty(
+        name = 'Python Package', 
+        description = 'Python Package to Install', 
+        default = '0.36.1'
+    )
+    
+    description: bpy.props.StringProperty(
+        name = 'Operator description', 
+        default='Install specified python package.'
+    )
+    
+    @classmethod
+    def description(cls, context, properties):
+        return properties.description
     
     def execute(self, context):
-        if not available():
-            import datetime,platform
-            
-            # generate logfile
-            logfile_path = os.path.abspath(str(ADDON_DIR) + "/logs/" + 'side-packages-install.log')
-            logfile = open(logfile_path, 'a')
-            
-            logfile.write("-----------------------------------" + '\n')
-            logfile.write("Installer Started: " + str(datetime.datetime.now()) + '\n')
-            logfile.write("-----------------------------------" + '\n')
-            install_results=install(
-                pypi_mirror=bpy.context.scene.pypi_mirror,
-            )
-            
-            # a lable to check all return codes of installation results.
-            no_errors=True
-
-            # log cmd, return code, and stdout/stderr
-            for (cmd, returncode, stdout, stderr) in install_results:
-                logfile.write(f'>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n{cmd}\n{returncode}\n===================================\n{stdout}\n===================================\n{stderr}\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n')
-                error_msg=''
-
-                # for dependency updates. if all return code is 0, then update is defined as successful.
-                # the furture call of available() will still report False, unless the Blender is restarted to reload MN
-                # no_errors is used here to check if there are any errors in the latest pip installation.
-                if returncode != 0: no_errors=False
-
-                # provide current solution for this Apple Silicon installation failure 
-                if ("fatal error: 'Python.h' file not found" in stderr) and (platform.system()== "Darwin") and ('arm' in platform.machine()):
-                    error_msg = f"ERROR: Could not find the 'Python.h' header file in version of Python bundled with Blender.\n" \
-                            "This is a problem with the Apple Silicon versions of Blender.\n" \
-                            "Please follow the link to the MolecularNodes GitHub page to solve it manually: \n" \
-                            "https://github.com/BradyAJohnston/MolecularNodes/issues/108#issuecomment-1429384983 "
-                    logfile.write(f"{error_msg}\n")
-
-                    # print this message to VSC console window
-                    print(error_msg)
-
-
-            logfile.write("###################################" + '\n')
-            logfile.write("Installer finished: " + str(datetime.datetime.now()) + '\n')
-            logfile.write("###################################" + '\n')
-            
-            # close the logfile
-            logfile.close()
-        
-        if available():
-            # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = True
+        installable = f"{self.package}=={self.version}"
+        result = install_package(installable)
+        if result.returncode == 0 and is_current(self.package):
             self.report(
                 {'INFO'}, 
-                message='Successfully Installed Required Packages'
+                f"Successfully installed {self.package} v{self.version}"
                 )
-            
-        elif no_errors:
-            # update via requirements. Ask user to restart Blender for a complete reload.
-            self.report(
-                {'ERROR'}, 
-                message=f'Successfully Installed Required Packages.\nPlease restart Blender and check log file for details: {logfile_path}'
-                )
-            
         else:
-            # bpy.context.preferences.addons['MolecularNodesPref'].preferences.packages_available = False
+            log_dir = os.path.join(os.path.abspath(ADDON_DIR), 'logs')
             self.report(
                 {'ERROR'}, 
-                message=f'Failed to install required packages. \n{error_msg}. \nPlease check log file for details: {logfile_path}'
+                f"Error installing package. Please check the log files in '{log_dir}'."
                 )
-        
         return {'FINISHED'}

--- a/MolecularNodes/pkg.py
+++ b/MolecularNodes/pkg.py
@@ -3,7 +3,6 @@ import sys
 import os
 import site
 from importlib.metadata import version
-from importlib import reload
 import bpy
 import pathlib
 
@@ -107,7 +106,7 @@ class MOL_OT_install_dependencies(bpy.types.Operator):
                 pypi_mirror=bpy.context.scene.pypi_mirror,
             )
             
-            # 
+            # a lable to check all return codes of installation results.
             no_errors=True
 
             # log cmd, return code, and stdout/stderr

--- a/MolecularNodes/pref.py
+++ b/MolecularNodes/pref.py
@@ -1,0 +1,27 @@
+import bpy
+from . import pkg
+from bpy.types import AddonPreferences
+from . import ui
+
+# Defines the preferences panel for the addon, which shows the buttons for 
+# installing and reinstalling the required python packages defined in 'requirements.txt'
+class MolecularNodesPreferences(AddonPreferences):
+    bl_idname = 'MolecularNodes'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text = "Install the required packages for MolecularNodes.")
+        pkgs = pkg.get_pkgs()
+        for package in pkgs.values():
+            row = layout.row()
+            ui.button_install_pkg(layout = row, package = package.get('name'))
+            if pkg.is_apple_silicon() and package.get('name') == "MDAnalysis":
+                row.enabled = False
+                if not pkg.is_current('MDAnalysis'):
+                    row.enabled = False
+                    box = layout.box()
+                    box.alert = True
+                    box.label(text = "On M1/M2 macOS machines, extra install steps are required.")
+                    box.operator(
+                        "wm.url_open", text = "Installation Instructions", icon = 'HELP'
+                    ).url = "https://bradyajohnston.github.io/MolecularNodes/installation.html#installing-biotite-mdanalysis"

--- a/MolecularNodes/pref.py
+++ b/MolecularNodes/pref.py
@@ -29,6 +29,11 @@ class MolecularNodesPreferences(AddonPreferences):
     def draw(self, context):
         layout = self.layout
         layout.label(text = "Install the required packages for MolecularNodes.")
+        
+        col_main = layout.column(heading = '', align = False)
+        row_import = col_main.row()
+        row_import.prop(bpy.context.scene, 'pypi_mirror_provider',text='Set PyPI Mirror')
+        
         pkgs = pkg.get_pkgs()
         for package in pkgs.values():
             row = layout.row()
@@ -38,7 +43,7 @@ class MolecularNodesPreferences(AddonPreferences):
                 version = package.get('version'), 
                 desc = package.get('desc')
                 )
-            if pkg.is_apple_silicon() and package.get('name') == "MDAnalysis":
+            if pkg._is_apple_silicon and package.get('name') == "MDAnalysis":
                 row.enabled = False
                 if not pkg.is_available('MDAnalysis', pkgs.get('MDAnalysis').get('version')):
                     row.enabled = False

--- a/MolecularNodes/pref.py
+++ b/MolecularNodes/pref.py
@@ -1,7 +1,25 @@
 import bpy
 from . import pkg
 from bpy.types import AddonPreferences
-from . import ui
+
+def button_install_pkg(layout, name, version, desc = ''):
+    layout = layout.row()
+    if pkg.is_available(name, version):
+        row = layout.row()
+        row.label(text=f"{name} version {version} is installed.")
+        op = row.operator('mol.install_package', text = f'Reinstall {name}')
+        op.package = name
+        op.version = version
+        op.description = f'Reinstall {name}'
+    else:
+        row = layout.row(heading = f"Package: {name}")
+        col = row.column()
+        col.label(text=str(desc))
+        col = row.column()
+        op = col.operator('mol.install_package', text = f'Install {name}')
+        op.package = name
+        op.version = version
+        op.description = f'Install required python package: {name}'
 
 # Defines the preferences panel for the addon, which shows the buttons for 
 # installing and reinstalling the required python packages defined in 'requirements.txt'
@@ -14,10 +32,15 @@ class MolecularNodesPreferences(AddonPreferences):
         pkgs = pkg.get_pkgs()
         for package in pkgs.values():
             row = layout.row()
-            ui.button_install_pkg(layout = row, package = package.get('name'))
+            button_install_pkg(
+                layout = row, 
+                name = package.get('name'), 
+                version = package.get('version'), 
+                desc = package.get('desc')
+                )
             if pkg.is_apple_silicon() and package.get('name') == "MDAnalysis":
                 row.enabled = False
-                if not pkg.is_current('MDAnalysis'):
+                if not pkg.is_available('MDAnalysis', pkgs.get('MDAnalysis').get('version')):
                     row.enabled = False
                     box = layout.box()
                     box.alert = True

--- a/MolecularNodes/requirements.txt
+++ b/MolecularNodes/requirements.txt
@@ -1,4 +1,2 @@
-# required by pdb and MD trajectory loading
-biotite==0.36.1
-MDAnalysis==2.2.0
-
+biotite==0.36.1   # General parsing of structural files.
+MDAnalysis==2.2.0 # Reading of molecular dynamics trajectories.

--- a/MolecularNodes/requirements.txt
+++ b/MolecularNodes/requirements.txt
@@ -1,2 +1,4 @@
+# required by pdb and MD trajectory loading
 biotite==0.35.0
 MDAnalysis==2.2.0
+

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -5,31 +5,6 @@ from . import load
 from . import md
 from . import assembly
 
-def button_install_pkg(layout, package):
-    from . import pkg
-    package = pkg.get_pkgs().get(package)
-    version = package.get('version')
-    desc = package.get('desc')
-    name = package.get('name')
-    layout = layout.row()
-    # layout.alignment= "RIGHT"
-    if pkg.is_available(name, version):
-        row = layout.row()
-        row.label(text=f"{name} version {version} is installed.")
-        op = row.operator('mol.install_package', text = f'Reinstall {name}')
-        op.package = name
-        op.version = version
-        op.description = f'Reinstall {name}'
-    else:
-        row = layout.row(heading = f"Package: {name}")
-        col = row.column()
-        col.label(text=str(desc))
-        col = row.column()
-        op = col.operator('mol.install_package', text = f'Install {name}')
-        op.package = name
-        op.version = version
-        op.description = f'Install required python package: {name}'
-
 # operator that calls the function to import the structure from the PDB
 class MOL_OT_Import_Protein_RCSB(bpy.types.Operator):
     bl_idname = "mol.import_protein_rcsb"
@@ -59,7 +34,6 @@ class MOL_OT_Import_Protein_RCSB(bpy.types.Operator):
 
     def invoke(self, context, event):
         return self.execute(context)
-
 
 # operator that calls the function to import the structure from a local file
 class MOL_OT_Import_Protein_Local(bpy.types.Operator):
@@ -355,7 +329,6 @@ def MOL_PT_panel_ui(layout_function, scene):
         MOL_PT_panel_local(box)
     else:
         if not pkg.is_current('MDAnalysis'):
-            button_install_pkg(panel, 'MDAnalysis')
             box.enabled = False
             box.alert = True
             box.label(text = "Please install MDAnalysis in the addon preferences.")

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -5,7 +5,30 @@ from . import load
 from . import md
 from . import assembly
 
-
+def button_install_pkg(layout, package):
+    from . import pkg
+    package = pkg.get_pkgs().get(package)
+    version = package.get('version')
+    desc = package.get('desc')
+    name = package.get('name')
+    layout = layout.row()
+    # layout.alignment= "RIGHT"
+    if pkg.is_available(name, version):
+        row = layout.row()
+        row.label(text=f"{name} version {version} is installed.")
+        op = row.operator('mol.install_package', text = f'Reinstall {name}')
+        op.package = name
+        op.version = version
+        op.description = f'Reinstall {name}'
+    else:
+        row = layout.row(heading = f"Package: {name}")
+        col = row.column()
+        col.label(text=str(desc))
+        col = row.column()
+        op = col.operator('mol.install_package', text = f'Install {name}')
+        op.package = name
+        op.version = version
+        op.description = f'Install required python package: {name}'
 
 # operator that calls the function to import the structure from the PDB
 class MOL_OT_Import_Protein_RCSB(bpy.types.Operator):
@@ -118,7 +141,6 @@ class MOL_OT_Import_Protein_MD(bpy.types.Operator):
         
         return {"FINISHED"}
 
-
 def MOL_PT_panel_rcsb(layout_function, ):
     col_main = layout_function.column(heading = '', align = False)
     col_main.alert = False
@@ -218,7 +240,6 @@ def MOL_PT_panel_md_traj(layout_function, scene):
         
         col.prop(item, "name")
         col.prop(item, "selection")
-    
 
 class MOL_OT_Import_Method_Selection(bpy.types.Operator):
     bl_idname = "mol.import_method_selection"
@@ -268,7 +289,6 @@ class MOL_OT_Default_Style(bpy.types.Operator):
         bpy.context.scene.mol_import_default_style = self.panel_display
         return {"FINISHED"}
 
-
 def default_style(layout, label, panel_display):
     op = layout.operator(
         'mol.default_style', 
@@ -294,56 +314,53 @@ class MOL_MT_Default_Style(bpy.types.Menu):
 
 def MOL_PT_panel_ui(layout_function, scene): 
     layout_function.label(text = "Import Options", icon = "MODIFIER")
-    if not pkg.available():
+    box = layout_function.box()
+    grid = box.grid_flow(columns = 2)
+    
+    grid.prop(bpy.context.scene, 'mol_import_center', 
+                text = 'Centre Structre', icon_value=0, emboss=True)
+    grid.prop(bpy.context.scene, 'mol_import_del_solvent', 
+                text = 'Delete Solvent', icon_value=0, emboss=True)
+    grid.prop(bpy.context.scene, 'mol_import_include_bonds', 
+                text = 'Import Bonds', icon_value=0, emboss=True)
+    grid.menu(
+        'MOL_MT_Default_Style', 
+        text = ['Atoms', 'Ribbon', 'Ball and Stick'][
+            bpy.context.scene.mol_import_default_style
+            ])
+    panel = layout_function
+    row = panel.row(heading = '', align=True)
+    row.alignment = 'EXPAND'
+    row.enabled = True
+    row.alert = False
+    MOL_change_import_interface(row, 'PDB',           0,  72)
+    MOL_change_import_interface(row, 'Local File',    1, 108)
+    MOL_change_import_interface(row, 'MD Trajectory', 2, 487)
+    
+    col = panel.column()
+    box = col.box()
+    if bpy.context.scene.mol_import_panel_selection == 0:
+        row = layout_function.row()
+        if not pkg.is_current('biotite'):
+            box.enabled = False
+            box.alert = True
+            box.label(text = "Please install biotite in the addon preferences.")
         
-        col_main = layout_function.column(heading = '', align = False)
-        col_main.alert = False
-        col_main.enabled = True
-        col_main.active = True
-        col_main.use_property_split = False
-        col_main.use_property_decorate = False
-        col_main.scale_x = 1.0
-        col_main.scale_y = 1.0
-        
-        col_main.alignment = 'Expand'.upper()
-        col_main.label(text = "Set PyPI Mirror")
-        row_import = col_main.row()
-        row_import.prop(bpy.context.scene, 'pypi_mirror',text='PyPI')
-        layout_function.operator('mol.install_dependencies', text = 'Install Packages')
-        
+        MOL_PT_panel_rcsb(box)
+    elif bpy.context.scene.mol_import_panel_selection == 1:
+        if not pkg.is_current('biotite'):
+            box.enabled = False
+            box.alert = True
+            box.label(text = "Please install biotite in the addon preferences.")
+        MOL_PT_panel_local(box)
     else:
-        box = layout_function.box()
-        grid = box.grid_flow(columns = 2)
-        
-        grid.prop(bpy.context.scene, 'mol_import_center', 
-                    text = 'Centre Structre', icon_value=0, emboss=True)
-        grid.prop(bpy.context.scene, 'mol_import_del_solvent', 
-                    text = 'Delete Solvent', icon_value=0, emboss=True)
-        grid.prop(bpy.context.scene, 'mol_import_include_bonds', 
-                    text = 'Import Bonds', icon_value=0, emboss=True)
-        grid.menu(
-            'MOL_MT_Default_Style', 
-            text = ['Atoms', 'Ribbon', 'Ball and Stick'][
-                bpy.context.scene.mol_import_default_style
-                ])
-        box = layout_function
-        row = box.row(heading = '', align=True)
-        row.alignment = 'EXPAND'
-        row.enabled = True
-        row.alert = False
-        MOL_change_import_interface(row, 'PDB',           0,  72)
-        MOL_change_import_interface(row, 'Local File',    1, 108)
-        MOL_change_import_interface(row, 'MD Trajectory', 2, 487)
-        
-        layout_function = box.box()
-        if bpy.context.scene.mol_import_panel_selection == 0:
-            MOL_PT_panel_rcsb(layout_function)
-        elif bpy.context.scene.mol_import_panel_selection == 1:
-            MOL_PT_panel_local(layout_function)
-        else:
-            MOL_PT_panel_md_traj(layout_function, scene)
-
-
+        if not pkg.is_current('MDAnalysis'):
+            button_install_pkg(panel, 'MDAnalysis')
+            box.enabled = False
+            box.alert = True
+            box.label(text = "Please install MDAnalysis in the addon preferences.")
+            
+        MOL_PT_panel_md_traj(box, scene)
 
 class MOL_PT_panel(bpy.types.Panel):
     bl_label = 'Molecular Nodes'
@@ -365,7 +382,6 @@ class MOL_PT_panel(bpy.types.Panel):
     def draw(self, context):
         
         MOL_PT_panel_ui(self.layout, bpy.context.scene)
-
 
 def mol_add_node(node_name):
     prev_context = bpy.context.area.type
@@ -425,7 +441,6 @@ class MOL_OT_Add_Custom_Node_Group(bpy.types.Operator):
     def invoke(self, context, event):
         return self.execute(context)
 
-
 def menu_item_interface(layout_function, 
                         label, 
                         node_name, 
@@ -434,7 +449,6 @@ def menu_item_interface(layout_function,
                                 text = label, emboss = True, depress=False)
     op.node_name = node_name
     op.node_description = node_description
-
 
 class MOL_OT_Style_Surface_Custom(bpy.types.Operator):
     bl_idname = "mol.style_surface_custom"
@@ -609,8 +623,6 @@ class MOL_OT_Residues_Selection_Custom(bpy.types.Operator):
     def invoke(self, context, event):
         return context.window_manager.invoke_props_dialog(self)
 
-
-
 def menu_ligand_selection_custom(layout_function):
     obj = bpy.context.view_layer.objects.active
     label = 'Ligands ' + str(obj.name)
@@ -646,7 +658,6 @@ class MOL_OT_Ligand_Selection_Custom(bpy.types.Operator):
         mol_add_node(node_chains.name)
         
         return {"FINISHED"}
-
 
 class MOL_MT_Add_Node_Menu_Properties(bpy.types.Menu):
     bl_idname = 'MOL_MT_ADD_NODE_MENU_PROPERTIES'
@@ -748,7 +759,6 @@ class MOL_MT_Add_Node_Menu_Styling(bpy.types.Menu):
                             Icospheres are instanced on atoms and cylinders for bonds. \
                             Bonds can be detected if they are not present in the \
                             structure")
-
 
 class MOL_MT_Add_Node_Menu_Selections(bpy.types.Menu):
     bl_idname = 'MOL_MT_ADD_NODE_MENU_SELECTIONS'


### PR DESCRIPTION
- refactor `run_pip` to remove redundancies and get run results fully recorded.
- reformat `side-packages-install.log` to make it looks cleaner.
- After install a newer MN, the versions of dependencies pinned at `requirements.txt` is checked against installed ones, if the version number of installed failed to match the pinned, the installation buttom will re-apeared. 
- require a restart of Blender after upgrading dependencies .
- minor fix: MN crashes with undefined `error_msg` while non-M1 error occurs.