### PR TITLE
Fix consistency in load_trajectory function call

### DIFF
--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -71,7 +71,8 @@ def load_trajectory(file_top,
                     include_bonds = False, 
                     del_solvent = False,
                     selection = "not (name H* or name OW)",
-                    name = "default"
+                    name = "default",
+                    custom_selections = None,
                     ):
     
     import MDAnalysis as mda
@@ -235,7 +236,6 @@ def load_trajectory(file_top,
             warnings.warn(f"Unable to add attribute: {att['name']}.")
 
     # add the custom selections if they exist
-    custom_selections = bpy.context.scene.trajectory_selection_list
     if custom_selections:
         for sel in custom_selections:
             try:

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -90,6 +90,7 @@ class MOL_OT_Import_Protein_MD(bpy.types.Operator):
         md_end =   bpy.context.scene.mol_import_md_frame_end
         del_solvent = bpy.context.scene.mol_import_del_solvent
         include_bonds = bpy.context.scene.mol_import_include_bonds
+        custom_selections = bpy.context.scene.trajectory_selection_list
         
         mol_object, coll_frames = md.load_trajectory(
             file_top    = file_top, 
@@ -100,7 +101,8 @@ class MOL_OT_Import_Protein_MD(bpy.types.Operator):
             name        = name, 
             del_solvent = del_solvent, 
             selection   = selection,
-            include_bonds=include_bonds
+            include_bonds=include_bonds,
+            custom_selections = custom_selections,
         )
         n_frames = len(coll_frames.objects)
         


### PR DESCRIPTION
Hi @BradyAJohnston - thanks so much for providing this software package!

This is a small PR that changes how the `custom_selections` are obtained for the `load_trajectory` function. For all of the other function variables, the parameters are passed from the GUI in `ui.py` as function arguments. However, `custom_selections`,  it is obtained from the GUI in the function itself. This prevents the use of the `load_trajectory` function with a custom selection outside of the context of the GUI and makes the function less flexible.

This PR adds an additional argument to `load_trajectory` called `custom_selections`. It is set to `None` by default. Another change is made in `ui.py` so that the value is obtained from the GUI and passed into the function here, similar to the other variables used to load in an MD trajectory.

I think this doesn't change the behavior of anything, but makes the code more internally consistent and flexible. @kimjoyc and I are working on some visualizations for solvation shells and we'd like to be able to use the `load_trajectory` function and pass in some custom selections using Python.

Thanks! Let me know if there is some design choice I'm missing on this.