### PR TITLE
add function for creating selection from solvation-analysis

### DIFF
--- a/MolecularNodes/requirements.txt
+++ b/MolecularNodes/requirements.txt
@@ -1,3 +1,4 @@
 biotite==0.36.1   # General parsing of structural files.
 MDAnalysis==2.2.0 # Reading of molecular dynamics trajectories.
 mrcfile==1.4.3    # Importing EM density files.
+solvation-analysis==0.1.5


### PR DESCRIPTION
This PR adds a function called `build_selections` to `md.py`. This function takes in arguments about solvent and solvation shells and builds objects that can be used as custom selections in `load_trajectory`. The function calls an unmodified `load_trajectory` at the end.

Test with this script by modifying with appropriate file paths for file_traj and file_top. Run it as a script in Blender (available under "Scripting" menu)

```
from collections import namedtuple

from MolecularNodes.md import build_selections

file_top = "FULL/PATH/TO/ea_fec.pdb"
file_traj = "FULL/PATH/TO/ea_fec.dcd"

selection = namedtuple("custom_selection", ["name", "selection", "shell_number"])

solute = selection("solute", "element Li", 0)

solvents = [
    selection("EA", "resid 1:235", 3),
    selection("FEC", "resid 236:600", 1),
    selection("PF6", "byres element P", 0),
]

build_selections(file_top, 
                    file_traj,
                    solute, 
                    solvents, 
                    0,
                    world_scale = 0.01, 
                    include_bonds = False, 
                    del_solvent = False)

```