### PR TITLE
Take secondary structure from `.mmtf` file instead of calculating

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     "author"      : "Brady Johnston", 
     "description" : "Importer and nodes for working with structural biology data in Blender.",
     "blender"     : (3, 5, 0),
-    "version"     : (2, 5, 4),
+    "version"     : (2, 5, 5),
     "location"    : "Scene Properties -> MolecularNodes",
     "warning"     : "",
     "doc_url"     : "https://bradyajohnston.github.io/MolecularNodes/", 

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -14,11 +14,16 @@ def molecule_rcsb(pdb_code,
                   setup_nodes=True
                   ):
     
-    mol, file = open_structure_rcsb(pdb_code = pdb_code, include_bonds=include_bonds)
+    mol, file = open_structure_rcsb(
+        pdb_code = pdb_code, 
+        include_bonds=include_bonds
+        )
+    
     mol_object, coll_frames = create_molecule(
         mol_array = mol,
         mol_name = pdb_code,
         file = file,
+        calculate_ss = False,
         center_molecule = center_molecule,
         del_solvent = del_solvent, 
         include_bonds = include_bonds
@@ -75,6 +80,7 @@ def molecule_local(file_path,
         mol_array = mol,
         mol_name = mol_name,
         file = file,
+        calculate_ss = True,
         center_molecule = center_molecule,
         del_solvent = del_solvent, 
         include_bonds = include_bonds
@@ -250,9 +256,15 @@ def comp_secondary_structure(mol_array):
         
     return atom_sse
 
-def create_molecule(mol_array, mol_name, center_molecule = False, 
+def create_molecule(mol_array, 
+                    mol_name, 
+                    center_molecule = False, 
                     file = None,
-                    del_solvent = False, include_bonds = False, collection = None):
+                    calculate_ss = False,
+                    del_solvent = False, 
+                    include_bonds = False, 
+                    collection = None
+                    ):
     import biotite.structure as struc
     
     if np.shape(mol_array)[0] > 1:
@@ -384,8 +396,10 @@ def create_molecule(mol_array, mol_name, center_molecule = False,
         return struc.filter_carbohydrates(mol_array)
 
     def att_sec_struct():
-        # return comp_secondary_structure(mol_array)
-        return get_secondary_structure(mol_array, file)
+        if calculate_ss or not file:
+            return comp_secondary_structure(mol_array)
+        else:
+            return get_secondary_structure(mol_array, file)
     
 
     # Add information about the bond types to the model on the edge domain

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -6,14 +6,14 @@ from . import data
 from . import assembly
 from . import nodes
 
-def molecule_rcsb(pdb_code, 
-                  center_molecule=False, 
-                  del_solvent=True, 
-                  include_bonds=True, 
-                  starting_style=0, 
-                  setup_nodes=True
-                  ):
-    
+def molecule_rcsb(
+    pdb_code,               
+    center_molecule = False,               
+    del_solvent = True,               
+    include_bonds = True,               
+    starting_style = 0,               
+    setup_nodes = True              
+    ):
     mol, file = open_structure_rcsb(
         pdb_code = pdb_code, 
         include_bonds=include_bonds
@@ -40,18 +40,19 @@ def molecule_rcsb(pdb_code,
     
     return mol_object
 
-def molecule_local(file_path, 
-                   mol_name="Name",
-                   include_bonds=True, 
-                   center_molecule=False, 
-                   del_solvent=True, 
-                   default_style=0, 
-                   setup_nodes=True
-                   ): 
+def molecule_local(
+    file_path,                    
+    mol_name = "Name",                   
+    include_bonds = True,                    
+    center_molecule = False,                    
+    del_solvent = True,                    
+    default_style = 0,                    
+    setup_nodes = True
+    ): 
+    
     import biotite.structure as struc
-    
-    
     import os
+    
     file_path = os.path.abspath(file_path)
     file_ext = os.path.splitext(file_path)[1]
     
@@ -85,8 +86,6 @@ def molecule_local(file_path,
         del_solvent = del_solvent, 
         include_bonds = include_bonds
         )
-    
-        
     
     # setup the required initial node tree on the object 
     if setup_nodes:

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -18,6 +18,7 @@ def molecule_rcsb(pdb_code,
     mol_object, coll_frames = create_molecule(
         mol_array = mol,
         mol_name = pdb_code,
+        file = file,
         center_molecule = center_molecule,
         del_solvent = del_solvent, 
         include_bonds = include_bonds
@@ -160,6 +161,70 @@ def pdb_get_b_factors(file):
         atoms = file.get_structure(model = model + 1, extra_fields = ['b_factor'])
         b_factors.append(atoms.b_factor)
     return b_factors
+
+def get_secondary_structure(mol_array, file) -> np.array:
+    """
+    Gets the secondary structure annotation that is included in mmtf files and returns it as a numerical numpy array.
+
+    Parameters:
+    -----------
+    mol_array : numpy.array
+        The molecular coordinates array, from mmtf.get_structure()
+    file : mmtf.MMTFFile
+        The MMTF file containing the secondary structure information, from mmtf.MMTFFile.read()
+
+    Returns:
+    --------
+    atom_sse : numpy.array
+        Numerical numpy array representing the secondary structure of the molecule.
+    
+    Description:
+    ------------
+    This function uses the biotite.structure package to extract the secondary structure information from the MMTF file.
+    The resulting secondary structures are `1: Alpha Helix, 2: Beta-sheet, 3: loop`.
+    """
+    
+    from biotite.structure import spread_residue_wise
+    
+    sec_struct_codes = {
+        -1: "X",
+        0 : "I",
+        1 : "S",
+        2 : "H",
+        3 : "E",
+        4 : "G",
+        5 : "B",
+        6 : "T",
+        7 : "C"
+    }
+    
+    dssp_to_abc = {
+        "X" : 0,
+        "I" : 3, #"c",
+        "S" : 3, #"c",
+        "H" : 1, #"a",
+        "E" : 2, #"b",
+        "G" : 3, #"c",
+        "B" : 2, #"b",
+        "T" : 3, #"c",
+        "C" : 3 #"c"
+    }
+    
+    try:
+        sse = file["secStructList"]
+    except KeyError:
+        ss_int = np.full(len(mol_array), 3)
+        print('Warning: "secStructList" field missing from MMTF file. Defaulting \
+            to "loop" for all residues.')
+    else:
+        ss_int = np.array(
+            [dssp_to_abc.get(sec_struct_codes.get(ss)) for ss in sse], 
+            dtype = int
+        )
+    atom_sse = spread_residue_wise(mol_array, ss_int)
+    
+    return atom_sse
+
 
 def comp_secondary_structure(mol_array):
     """Use dihedrals to compute the secondary structure of proteins
@@ -319,7 +384,8 @@ def create_molecule(mol_array, mol_name, center_molecule = False,
         return struc.filter_carbohydrates(mol_array)
 
     def att_sec_struct():
-        return comp_secondary_structure(mol_array)
+        # return comp_secondary_structure(mol_array)
+        return get_secondary_structure(mol_array, file)
     
 
     # Add information about the bond types to the model on the edge domain

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -11,17 +11,17 @@ def property_exists(prop_path, glob, loc):
         return False
 
 socket_types = {
-        'BOOLEAN'  : 'NodeSocketBool', 
-        'GEOMETRY' : 'NodeSocketGeometry', 
-        'INT'      : 'NodeSocketInt', 
-        'MATERIAL' : 'NodeSocketMaterial', 
-        'VECTOR'   : 'NodeSocketVector', 
-        'STRING'   : 'NodeSocketString', 
-        'VALUE'    : 'NodeSocketFloat', 
-        'COLLETION': 'NodeSocketCollection', 
-        'TEXTURE'  : 'NodeSocketTexture', 
-        'COLOR'    : 'NodeSocketColor', 
-        'IMAGE'    : 'NodeSocketImage'
+        'BOOLEAN'   : 'NodeSocketBool', 
+        'GEOMETRY'  : 'NodeSocketGeometry', 
+        'INT'       : 'NodeSocketInt', 
+        'MATERIAL'  : 'NodeSocketMaterial', 
+        'VECTOR'    : 'NodeSocketVector', 
+        'STRING'    : 'NodeSocketString', 
+        'VALUE'     : 'NodeSocketFloat', 
+        'COLLECTION': 'NodeSocketCollection', 
+        'TEXTURE'   : 'NodeSocketTexture', 
+        'COLOR'     : 'NodeSocketColor', 
+        'IMAGE'     : 'NodeSocketImage'
     }
 
 def mol_append_node(node_name):

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -2,14 +2,6 @@ import bpy
 import os
 from . import pkg
 
-# check if a particular property already exists or not
-def property_exists(prop_path, glob, loc):
-    try:
-        eval(prop_path, glob, loc)
-        return True
-    except:
-        return False
-
 socket_types = {
         'BOOLEAN'   : 'NodeSocketBool', 
         'GEOMETRY'  : 'NodeSocketGeometry', 

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -273,7 +273,12 @@ def create_starting_node_tree(obj, coll_frames, starting_style = "atoms"):
     link(node_random_colour.outputs['Value'], node_colour.inputs['Carbon'])
     link(node_chain_id.outputs[4], node_random_colour.inputs['ID'])
     
-    styles = ['MOL_style_atoms_cycles', 'MOL_style_ribbon_protein', 'MOL_style_ball_and_stick']
+    styles = [
+        'MOL_style_atoms_cycles', 
+        'MOL_style_cartoon', 
+        'MOL_style_ribbon_protein', 
+        'MOL_style_ball_and_stick'
+        ]
     
     # if starting_style == "atoms":
     

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -1,5 +1,6 @@
 import bpy
 import os
+from . import pkg
 
 # check if a particular property already exists or not
 def property_exists(prop_path, glob, loc):
@@ -24,34 +25,33 @@ socket_types = {
     }
 
 def mol_append_node(node_name):
-    if bpy.data.node_groups.get(node_name):
-        pass
-    else:
-        before_data = list(bpy.data.node_groups)
+    node = bpy.data.node_groups.get(node_name)
+    if not node:
         bpy.ops.wm.append(
             directory = os.path.join(
-                    os.path.dirname(__file__), 'assets', 'node_append_file.blend' + r'/NodeTree'), 
+                    pkg.ADDON_DIR, 'assets', 'node_append_file.blend' + r'/NodeTree'), 
                     filename = node_name, 
                     link = False
-                )   
-        new_data = list(filter(lambda d: not d in before_data, list(bpy.data.node_groups)))
+                )
     
     return bpy.data.node_groups[node_name]
 
 def mol_base_material():
     """Append MOL_atomic_material to the .blend file it it doesn't already exist, and return that material."""
-    mat = bpy.data.materials.get('MOL_atomic_material')
+    
+    mat_name = 'MOL_atomic_material'
+    mat = bpy.data.materials.get(mat_name)
     
     if not mat:
-        mat = bpy.ops.wm.append(
+        bpy.ops.wm.append(
             directory=os.path.join(
-                mn_folder, 'assets', 'node_append_file.blend' + r'/Material'
+                pkg.ADDON_DIR, 'assets', 'node_append_file.blend' + r'/Material'
             ), 
             filename='MOL_atomic_material', 
             link=False
         )
     
-    return mat
+    return bpy.data.materials[mat_name]
 
 def gn_new_group_empty(name = "Geometry Nodes"):
     group = bpy.data.node_groups.get(name)

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -784,6 +784,8 @@ class MOL_MT_Add_Node_Menu_Color(bpy.types.Menu):
                             the same color. Highlights differences without being too \
                             visually busy")
         layout.separator()
+        menu_item_interface(layout, 'Color by SS', 'MOL_color_sec_struct', 
+                            "Specify colors based on the secondary structure")
         menu_item_interface(layout, 'Color by Atomic Number', 'MOL_color_atomic_number',
                             "Creates a color based on atomic_number field")
         menu_item_interface(layout, 'Color by Element', 'MOL_color_element', 
@@ -877,6 +879,8 @@ class MOL_MT_Add_Node_Menu_Selections(bpy.types.Menu):
         menu_chain_selection_custom(layout)
         menu_ligand_selection_custom(layout)
         layout.separator()
+        menu_item_interface(layout, 'Backbone', 'MOL_sel_backbone', 
+                            "Select atoms it they are part of the side chains or backbone.")
         menu_item_interface(layout, 'Atom Properties', 'MOL_sel_atom_propeties', 
                             "Create a selection based on the properties of the atom.\n\
                             Fields for is_alpha_carbon, is_backbone, is_peptide, \

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -833,6 +833,9 @@ class MOL_MT_Add_Node_Menu_Styling(bpy.types.Menu):
                             'A sphere atom representation, visible in EEVEE and \
                             Cycles. Based on mesh instancing which slows down viewport \
                             performance')
+        menu_item_interface(layout, 'Cartoon', 'MOL_style_cartoon', 
+                            'Create a cartoon representation, highlighting secondary \
+                            structure through arrows and ribbons.')
         menu_item_interface(layout, 'Ribbon Protein', 'MOL_style_ribbon_protein', 
                             'Create a ribbon mesh based off of the alpha-carbons of \
                             the structure')
@@ -1028,6 +1031,7 @@ class MOL_MT_Add_Node_Menu_Utilities(bpy.types.Menu):
         menu_item_interface(layout, 'Booelean Chain', 'MOL_utils_bool_chain')
         menu_item_interface(layout, 'Rotation Matrix', 'MOL_utils_rotation_matrix')
         menu_item_interface(layout, 'Curve Resample', 'MOL_utils_curve_resample')
+        menu_item_interface(layout, 'Determine Secondary Structure', 'MOL_utils_dssp')
 
 class MOL_MT_Add_Density_Menu(bpy.types.Menu):
     bl_idname = 'MOL_MT_ADD_DENSITY_MENU'

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -381,8 +381,9 @@ class MOL_MT_Default_Style(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout.column_flow(columns = 1)
         default_style(layout, 'Atoms', 0)
-        default_style(layout, 'Ribbon', 1)
-        default_style(layout, 'Ball and Stick', 2)
+        default_style(layout, 'Cartoon', 1)
+        default_style(layout, 'Ribbon', 2)
+        default_style(layout, 'Ball and Stick', 3)
 
 def MOL_PT_panel_ui(layout_function, scene): 
     layout_function.label(text = "Import Options", icon = "MODIFIER")
@@ -390,14 +391,14 @@ def MOL_PT_panel_ui(layout_function, scene):
     grid = box.grid_flow(columns = 2)
     
     grid.prop(bpy.context.scene, 'mol_import_center', 
-                text = 'Centre Structre', icon_value=0, emboss=True)
+                text = 'Centre Structure', icon_value=0, emboss=True)
     grid.prop(bpy.context.scene, 'mol_import_del_solvent', 
                 text = 'Delete Solvent', icon_value=0, emboss=True)
     grid.prop(bpy.context.scene, 'mol_import_include_bonds', 
                 text = 'Import Bonds', icon_value=0, emboss=True)
     grid.menu(
         'MOL_MT_Default_Style', 
-        text = ['Atoms', 'Ribbon', 'Ball and Stick'][
+        text = ['Atoms', 'Cartoon', 'Ribbon', 'Ball and Stick'][
             bpy.context.scene.mol_import_default_style
             ])
     panel = layout_function


### PR DESCRIPTION
Changes SSE to be extracted from the `mmtf` file instead of calculated. The SS detection algorithm in `Biotite` is somewhat limited. It also shouldn't be calculated when the data will already be present inside of `mmtf` files when downloading from the PDB.

This will enable more accurate SS information for creating cartoons through nodes.

Addressed issues in #197 , enabling SS to be used that was assigned by the PDB rather than calculated locally. Also fixes #92 by finally adding secondary structure cartoons as an option.

TODO: 
- [x] Enable extraction and spreading of SS from `.mmtf` files
- [x] Switch to calculated when not `.mmtf` file

Additionally this PR introduces the nodes that can handle the secondary structure information, to build secondary structure cartoon styles. Two major nodes are introduce: 
- `MOL_style_cartoon` which builds the required meshes for the cartoon style.
- `MOL_utils_dssp` which can perform some rough SS assignment if SS information does not exist, or during playback for a MD simulation.

Example showing secondary structure, with side chains as ball and stick. Everything is coloured based on B-factor. Beta-sheets additionally have the option for arrows, and alpha-helices also have the option to be cylinders.

![image](https://user-images.githubusercontent.com/36021261/234216736-ce01a31e-4088-4fe4-bc27-41a561d9c576.png)
