### PR TITLE
Added ESMFold as structure import option

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -210,6 +210,7 @@ def register():
     bpy.utils.register_class(MOL_OT_Style_Surface_Custom)
 
     bpy.utils.register_class(MOL_OT_Import_Protein_RCSB)
+    bpy.utils.register_class(MOL_OT_Import_Protein_ESMFold)
 
     bpy.utils.register_class(MOL_OT_Import_Method_Selection)
     bpy.utils.register_class(MOL_OT_Import_Protein_Local)
@@ -251,6 +252,9 @@ def unregister():
     del bpy.types.Scene.mol_import_md_frame_end
     del bpy.types.Scene.mol_import_default_style
     
+    del bpy.types.Scene.mol_esmfold_name
+    del bpy.types.Scene.mol_esmfold_sequence
+    
     del bpy.types.Scene.trajectory_selection_list
     del bpy.types.Scene.list_index
     
@@ -281,6 +285,7 @@ def unregister():
     bpy.utils.unregister_class(MOL_OT_Import_Protein_RCSB)
     bpy.utils.unregister_class(MOL_OT_Import_Method_Selection)
     bpy.utils.unregister_class(MOL_OT_Import_Protein_Local)
+    bpy.utils.unregister_class(MOL_OT_Import_Protein_ESMFold)
     bpy.utils.unregister_class(MOL_OT_Import_Protein_MD)
     bpy.utils.unregister_class(MOL_OT_Import_Map)
     bpy.utils.unregister_class(MOL_OT_Import_Star_File)

--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -88,6 +88,14 @@ def register():
         subtype = 'NONE',
         default = 0
     )
+    bpy.types.Scene.mol_esmfold_sequence = bpy.props.StringProperty(
+        name = 'amino_acid_sequence', 
+        description = 'Amino acid sequence of the structure to open', 
+        options = {'TEXTEDIT_UPDATE'}, 
+        default = '', 
+        subtype = 'FILE_PATH', 
+        maxlen = 0
+        )
     bpy.types.Scene.mol_import_local_path = bpy.props.StringProperty(
         name = 'path_pdb', 
         description = 'File path of the structure to open', 
@@ -137,6 +145,14 @@ def register():
         maxlen = 0
         )
     bpy.types.Scene.mol_import_local_name = bpy.props.StringProperty(
+        name = 'mol_name', 
+        description = 'Name of the molecule on import', 
+        options = {'TEXTEDIT_UPDATE'}, 
+        default = 'NewMolecule', 
+        subtype = 'NONE', 
+        maxlen = 0
+        )
+    bpy.types.Scene.mol_esmfold_name = bpy.props.StringProperty(
         name = 'mol_name', 
         description = 'Name of the molecule on import', 
         options = {'TEXTEDIT_UPDATE'}, 

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -1,3 +1,4 @@
+import subprocess
 import bpy
 import numpy as np
 from . import coll
@@ -111,6 +112,25 @@ def open_structure_rcsb(pdb_code, include_bonds = True):
     # returns a numpy array stack, where each array in the stack is a model in the 
     # the file. The stack will be of length = 1 if there is only one model in the file
     mol = mmtf.get_structure(file, extra_fields = ["b_factor", "charge"], include_bonds = include_bonds) 
+    return mol, file
+
+def open_structure_esm_fold(amino_acid_sequence, include_bonds=True):
+    import biotite.structure.io.pdb as pdb
+    
+    esm_folded_pdb_file = subprocess.call([
+    'curl',
+    '-X',
+    'POST',
+    '--data',
+    amino_acid_sequence,
+    'https://api.esmatlas.com/foldSequence/v1/pdb/'
+    ])
+    
+    file = pdb.PDBFile.read(esm_folded_pdb_file)
+    
+    # returns a numpy array stack, where each array in the stack is a model in the 
+    # the file. The stack will be of length = 1 if there is only one model in the file
+    mol = pdb.get_structure(file, extra_fields = ['b_factor', 'charge'], include_bonds = include_bonds)
     return mol, file
 
 

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -43,6 +43,7 @@ def molecule_rcsb(
 
 def molecule_esmfold(
     amino_acid_sequence,               
+    mol_name = "Name",                   
     center_molecule = False,               
     del_solvent = True,               
     include_bonds = True,   
@@ -56,7 +57,7 @@ def molecule_esmfold(
     
     mol_object, coll_frames = create_molecule(
         mol_array = mol,
-        mol_name = amino_acid_sequence,
+        mol_name = mol_name,
         file = file,
         calculate_ss = False,
         center_molecule = center_molecule,

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -165,18 +165,22 @@ def open_structure_esm_fold(amino_acid_sequence, include_bonds=True):
 
     r = requests.post('https://api.esmatlas.com/foldSequence/v1/pdb/', data=amino_acid_sequence)
     
-    esm_folded_pdb_str = r.text
-    with io.StringIO() as f:
-        f.write(esm_folded_pdb_str)
-        f.seek(0)
-        file = pdb.PDBFile.read(f)
+    if r.ok:
     
-    # returns a numpy array stack, where each array in the stack is a model in the 
-    # the file. The stack will be of length = 1 if there is only one model in the file
-    mol = pdb.get_structure(file, extra_fields = ['b_factor', 'charge'], include_bonds = include_bonds)
-    return mol, file
+        esm_folded_pdb_str = r.text
+        with io.StringIO() as f:
+            f.write(esm_folded_pdb_str)
+            f.seek(0)
+            file = pdb.PDBFile.read(f)
+    
+        # returns a numpy array stack, where each array in the stack is a model in the 
+        # the file. The stack will be of length = 1 if there is only one model in the file
+        mol = pdb.get_structure(file, extra_fields = ['b_factor', 'charge'], include_bonds = include_bonds)
+        return mol, file
 
-
+    else:
+        raise ValueError(f'ESMFold returned an error for the amino acid sequence input. This is the error message: {r.text}')
+    
 def open_structure_local_pdb(file_path, include_bonds = True):
     import biotite.structure.io.pdb as pdb
     

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -1,5 +1,5 @@
+import requests
 import io
-import subprocess
 import bpy
 import numpy as np
 from . import coll
@@ -150,19 +150,24 @@ def open_structure_rcsb(pdb_code, include_bonds = True):
 def open_structure_esm_fold(amino_acid_sequence, include_bonds=True):
     import biotite.structure.io.pdb as pdb
     
-    output_of_subprocess = subprocess.Popen([
-    'curl',
-    '-X',
-    'POST',
-    '--data',
-    amino_acid_sequence,
-    'https://api.esmatlas.com/foldSequence/v1/pdb/'
-    ], stdout=subprocess.PIPE)
-
-    (esm_folded_pdb_str, err) = output_of_subprocess.communicate()
     
+    
+    # output_of_subprocess = subprocess.Popen([
+    # 'curl',
+    # '-X',
+    # 'POST',
+    # '--data',
+    # amino_acid_sequence,
+    # 'https://api.esmatlas.com/foldSequence/v1/pdb/'
+    # ], stdout=subprocess.PIPE)
+
+    # (esm_folded_pdb_str, err) = output_of_subprocess.communicate()
+
+    r = requests.post('https://api.esmatlas.com/foldSequence/v1/pdb/', data=amino_acid_sequence)
+    
+    esm_folded_pdb_str = r.text
     with io.StringIO() as f:
-        f.write(esm_folded_pdb_str.decode("utf-8"))
+        f.write(esm_folded_pdb_str)
         f.seek(0)
         file = pdb.PDBFile.read(f)
     

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -41,6 +41,40 @@ def molecule_rcsb(
     
     return mol_object
 
+def molecule_esmfold(
+    amino_acid_sequence,               
+    center_molecule = False,               
+    del_solvent = True,               
+    include_bonds = True,   
+    starting_style = 0,               
+    setup_nodes = True              
+    ):
+    mol, file = open_structure_esm_fold(
+        amino_acid_sequence = amino_acid_sequence, 
+        include_bonds=include_bonds
+        )
+    
+    mol_object, coll_frames = create_molecule(
+        mol_array = mol,
+        mol_name = amino_acid_sequence,
+        file = file,
+        calculate_ss = False,
+        center_molecule = center_molecule,
+        del_solvent = del_solvent, 
+        include_bonds = include_bonds
+        )
+    
+    if setup_nodes:
+        nodes.create_starting_node_tree(
+            obj = mol_object, 
+            coll_frames=coll_frames, 
+            starting_style = starting_style
+            )
+    
+    mol_object['bio_transform_dict'] = file['bioAssemblyList']
+    
+    return mol_object
+
 def molecule_local(
     file_path,                    
     mol_name = "Name",                   

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -175,8 +175,10 @@ def MOL_PT_panel_esmfold(layout_function, ):
     row_name = col_main.row(align = False)
     row_name.prop(bpy.context.scene, 'mol_esmfold_name', 
                     text = "Name", icon_value = 0, emboss = True)
-    row_import = col_main.row()
-    row_import.prop(
+    row_name.operator('mol.import_protein_esmfold', text='Generate', icon='IMPORT')
+    
+    row_seq = col_main.row()
+    row_seq.prop(
         bpy.context.scene, 'mol_esmfold_sequence', 
         text = "Amino acid sequence", 
         icon_value = 0, 
@@ -466,10 +468,11 @@ def MOL_PT_panel_ui(layout_function, scene):
     
     
     MOL_change_import_interface(row, 'PDB',           0,  "URL")
-    MOL_change_import_interface(row, 'Local File',    1, 108)
-    MOL_change_import_interface(row, 'MD Trajectory', 2, 487)
-    MOL_change_import_interface(row, 'EM Map', 3, 'LIGHTPROBE_CUBEMAP')
-    MOL_change_import_interface(row, 'Star File',     4, 487)
+    MOL_change_import_interface(row, 'ESMFold',       1,  "URL")
+    MOL_change_import_interface(row, 'Local File',    2, 108)
+    MOL_change_import_interface(row, 'MD Trajectory', 3, 487)
+    MOL_change_import_interface(row, 'EM Map', 4, 'LIGHTPROBE_CUBEMAP')
+    MOL_change_import_interface(row, 'Star File',     5, 487)
     
     panel_selection = bpy.context.scene.mol_import_panel_selection
     col = panel.column()

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -134,6 +134,23 @@ def MOL_PT_panel_rcsb(layout_function, ):
     row_import.prop(bpy.context.scene, 'mol_pdb_code', text='PDB ID')
     row_import.operator('mol.import_protein_rcsb', text='Download', icon='IMPORT')
 
+def MOL_PT_panel_esmfold(layout_function, ):
+    col_main = layout_function.column(heading = '', align = False)
+    col_main.alert = False
+    col_main.enabled = True
+    col_main.active = True
+    col_main.label(text = "Generate Structure from ESMFold")
+    row_name = col_main.row(align = False)
+    row_name.prop(bpy.context.scene, 'mol_esmfold_name', 
+                    text = "Name", icon_value = 0, emboss = True)
+    row_import = col_main.row()
+    row_import.prop(
+        bpy.context.scene, 'mol_esmfold_sequence', 
+        text = "Amino acid sequence", 
+        icon_value = 0, 
+        emboss = True
+    )
+
 def MOL_PT_panel_local(layout_function, ):
     col_main = layout_function.column(heading = '', align = False)
     col_main.alert = False
@@ -439,21 +456,27 @@ def MOL_PT_panel_ui(layout_function, scene):
             box.enabled = False
             box.alert = True
             box.label(text = "Please install biotite in the addon preferences.")
-        MOL_PT_panel_local(box)
+        MOL_PT_panel_esmfold(box)
     elif panel_selection == 2:
+        if not pkg.is_current('biotite'):
+            box.enabled = False
+            box.alert = True
+            box.label(text = "Please install biotite in the addon preferences.")
+        MOL_PT_panel_local(box)
+    elif panel_selection == 3:
         if not pkg.is_current('MDAnalysis'):
             box.enabled = False
             box.alert = True
             box.label(text = "Please install MDAnalysis in the addon preferences.")
             
         MOL_PT_panel_md_traj(box, scene)
-    elif panel_selection == 3:
+    elif panel_selection == 4:
         if not pkg.is_current('mrcfile'):
             box.enabled = False
             box.alert = True
             box.label(text = "Please intall 'mrcfile' in the addon preferences.")
         MOL_PT_panel_map(box, scene)
-    elif panel_selection == 4:
+    elif panel_selection == 5:
         for name in ['starfile', 'eulerangles']:
             if not pkg.is_current(name):
                 box.enabled = False

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -57,7 +57,7 @@ class MOL_OT_Import_Protein_ESMFold(bpy.types.Operator):
             include_bonds=bpy.context.scene.mol_import_include_bonds, 
             center_molecule=bpy.context.scene.mol_import_center, 
             del_solvent=bpy.context.scene.mol_import_del_solvent, 
-            default_style=bpy.context.scene.mol_import_default_style, 
+            starting_style=bpy.context.scene.mol_import_default_style, 
             setup_nodes=True
             )
         

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -36,7 +36,39 @@ class MOL_OT_Import_Protein_RCSB(bpy.types.Operator):
 
     def invoke(self, context, event):
         return self.execute(context)
+    
+# operator that calls the function to import the structure from ESMFold
+class MOL_OT_Import_Protein_ESMFold(bpy.types.Operator):
+    bl_idname = "mol.import_protein_esmfold"
+    bl_label = "import_protein_esmfold"
+    bl_description = "Generate structure from ESMFold"
+    bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return not False
+
+    def execute(self, context):
+        amino_acid_sequence = bpy.context.scene.mol_esmfold_sequence
+        
+        mol_object = load.molecule_esmfold(
+            amino_acid_sequence=amino_acid_sequence, 
+            mol_name=bpy.context.scene.mol_esmfold_name,
+            include_bonds=bpy.context.scene.mol_import_include_bonds, 
+            center_molecule=bpy.context.scene.mol_import_center, 
+            del_solvent=bpy.context.scene.mol_import_del_solvent, 
+            default_style=bpy.context.scene.mol_import_default_style, 
+            setup_nodes=True
+            )
+        
+        # return the good news!
+        bpy.context.view_layer.objects.active = mol_object
+        self.report({'INFO'}, message=f"Generated protein '{amino_acid_sequence}' as {mol_object.name}")
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+    
 # operator that calls the function to import the structure from a local file
 class MOL_OT_Import_Protein_Local(bpy.types.Operator):
     bl_idname = "mol.import_protein_local"

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -180,7 +180,7 @@ def MOL_PT_panel_esmfold(layout_function, ):
     row_seq = col_main.row()
     row_seq.prop(
         bpy.context.scene, 'mol_esmfold_sequence', 
-        text = "Amino acid sequence", 
+        text = "Sequence", 
         icon_value = 0, 
         emboss = True
     )


### PR DESCRIPTION
Seeing that ESMFold has been implemented in ChimeraX as well as an optional plug-in for PyMol, I figured I'd add this to MolecularNodes as well :)

Just a simple text input box to paste in an amino acid sequence, which calls the ESMFold API via `curl`.

I just saw that there is a UI rework in progress (#201 ) so that will have to be accounted for but the underlying function calling ESMFold should work - let me know if I should add in any extra warnings/guardrails to prevent improper use!

![Screenshot 2023-04-27 at 20 30 42](https://user-images.githubusercontent.com/17111438/234971496-cda7a2cb-513e-4377-a2ba-e14cefd6c18f.png)
