### PR TITLE
Fix surface split

### DIFF
--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -230,14 +230,6 @@ def create_starting_node_tree(obj, coll_frames, starting_style = "atoms"):
     node_group = gn_new_group_empty("MOL_" + str(obj.name))
     node_mod.node_group = node_group
     
-    # TODO check if can delete this loop
-    # ensure the required setup nodes either already exist or append them
-    # required_setup_nodes = ['MOL_prop_setup', 'MOL_style_color']
-    # if n_frames > 1:
-    #     required_setup_nodes = ['MOL_prop_setup', 'MOL_style_color', 'MOL_animate', 'MOL_animate_frames']
-    # for node_group in required_setup_nodes:
-    #     mol_append_node(node_group)
-    
     # move the input and output nodes for the group
     node_input = node_mod.node_group.nodes[bpy.app.translations.pgettext_data("Group Input",)]
     node_input.location = [0, 0]
@@ -245,7 +237,7 @@ def create_starting_node_tree(obj, coll_frames, starting_style = "atoms"):
     node_output.location = [800, 0]
     
     # node_properties = add_custom_node_group(node_group, 'MOL_prop_setup', [0, 0])
-    node_colour = add_custom_node_group(node_mod, 'MOL_style_color', [200, 0])
+    node_colour = add_custom_node_group(node_mod, 'MOL_color_set_common', [200, 0])
     
     node_random_colour = node_group.nodes.new("FunctionNodeRandomValue")
     node_random_colour.data_type = 'FLOAT_VECTOR'

--- a/MolecularNodes/nodes.py
+++ b/MolecularNodes/nodes.py
@@ -311,16 +311,11 @@ def create_custom_surface(name, n_chains):
     
     # loop over the inputs and create an input for each
     for i in looping_node.inputs.values():
-        group.inputs.new(socket_types.get(i.type), i.name)
-    
-    
-    
-    group.inputs['Selection'].default_value = True
-    group.inputs['Selection'].hide_value = True
-    group.inputs['Resolution'].default_value = 7
-    group.inputs['Radius'].default_value = 1
-    group.inputs['Shade Smooth'].default_value = True
-    group.inputs['Color By Chain'].default_value = True
+        group_input = group.inputs.new(socket_types.get(i.type), i.name)
+        try:
+            group_input.default_value = i.default_value
+        except AttributeError:
+            pass
     
     # loop over the outputs and create an output for each
     for o in looping_node.outputs.values():

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -497,10 +497,11 @@ def mol_add_node(node_name):
     bpy.context.area.type = prev_context
     bpy.context.active_node.node_tree = bpy.data.node_groups[node_name]
     bpy.context.active_node.width = 200.0
+    
     # if added node has a 'Material' input, set it to the default MN material
     input_mat = bpy.context.active_node.inputs.get('Material')
     if input_mat:
-        input_mat = nodes.mol_base_material().name
+        input_mat.default_value = nodes.mol_base_material()
 
 class MOL_OT_Add_Custom_Node_Group(bpy.types.Operator):
     bl_idname = "mol.add_custom_node_group"

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -786,6 +786,9 @@ class MOL_MT_Add_Node_Menu_Color(bpy.types.Menu):
         layout.operator_context = "INVOKE_DEFAULT"
         menu_item_interface(layout, 'Set Color', 'MOL_color_set', 
                             "Sets a new color for the selected atoms")
+        menu_item_interface(layout, 'Set Color Common', 'MOL_color_set_common', 
+                            "Choose a color for the most common elements in PDB \
+                            structures")
         layout.separator()
         menu_item_interface(layout, 'Goodsell Colors', 'MOL_color_goodsell', 
                             "Adjusts the given colors to copy the 'Goodsell Style'.\n \
@@ -800,9 +803,6 @@ class MOL_MT_Add_Node_Menu_Color(bpy.types.Menu):
         menu_item_interface(layout, 'Color by Element', 'MOL_color_element', 
                             "Choose a color for each of the first 20 elements")
         menu_item_color_chains(layout, 'Color by Chains')
-        menu_item_interface(layout, 'Color Atomic', 'MOL_style_color', 
-                            "Choose a color for the most common elements in PDB \
-                            structures")
 
 class MOL_MT_Add_Node_Menu_Bonds(bpy.types.Menu):
     bl_idname = 'MOL_MT_ADD_NODE_MENU_BONDS'


### PR DESCRIPTION
Error when creatin `MOL_surface_split` node. There was some renaming of inputs, which broke the setting of defaults. This has been fixed by adding the defaults based on the inputs during the loop.

Additionally the default `Set Color` node has been renamed to `MOL_color_set_common` to better reflect that it is not a style, but part of the color nodes.