### PR TITLE
Dev: Re-enable node-add menu

### DIFF
--- a/MolecularNodes/__init__.py
+++ b/MolecularNodes/__init__.py
@@ -26,10 +26,14 @@ bl_info = {
 }
 
 from . import auto_load
+from .ui import mol_add_node_menu
+import bpy
 
 auto_load.init()
 
 def register():
     auto_load.register()
+    bpy.types.NODE_MT_add.append(mol_add_node_menu)
 def unregister():
+    bpy.types.NODE_MT_add.remove(mol_add_node_menu)
     auto_load.unregister()

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -856,8 +856,8 @@ class MOL_MT_Add_Node_Menu_Utilities(bpy.types.Menu):
         menu_item_interface(layout, 'Curve Resample', 'MOL_utils_curve_resample')
         menu_item_interface(layout, 'Determine Secondary Structure', 'MOL_utils_dssp')
 
-class MOL_MT_Add_Density_Menu(bpy.types.Menu):
-    bl_idname = 'MOL_MT_ADD_DENSITY_MENU'
+class MOL_MT_Add_Node_Menu_Density(bpy.types.Menu):
+    bl_idname = 'MOL_MT_ADD_NODE_MENU_DENSITY'
     bl_label = ''
     
     @classmethod
@@ -886,7 +886,7 @@ class MOL_MT_Add_Node_Menu(bpy.types.Menu):
                     text='Style', icon_value=77)
         layout.menu('MOL_MT_ADD_NODE_MENU_COLOR', 
                     text='Color', icon = 'COLORSET_07_VEC')
-        layout.menu('MOL_MT_ADD_DENSITY_MENU', icon = "LIGHTPROBE_CUBEMAP", 
+        layout.menu('MOL_MT_ADD_NODE_MENU_DENSITY', icon = "LIGHTPROBE_CUBEMAP", 
                     text = "Density")
         layout.menu('MOL_MT_ADD_NODE_MENU_BONDS', 
                     text='Bonds', icon = 'FIXED_SIZE')

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,26 @@
+import MolecularNodes as mn
+import bpy
+import pytest
+
+def test_menus_registered():
+    
+    menu_names = (
+        "MOL_MT_Add_Node_Menu_Properties",
+        "MOL_MT_Add_Node_Menu_Color",
+        "MOL_MT_Add_Node_Menu_Bonds",
+        "MOL_MT_Add_Node_Menu_Styling",
+        "MOL_MT_Add_Node_Menu_Selections",
+        "MOL_MT_Add_Node_Menu_Assembly",
+        "MOL_MT_Add_Node_Menu_Membranes",
+        "MOL_MT_Add_Node_Menu_DNA",
+        "MOL_MT_Add_Node_Menu_Animation",
+        "MOL_MT_Add_Node_Menu_Utilities", 
+        "MOL_MT_Add_Node_Menu_Density", 
+        "MOL_MT_Add_Node_Menu"
+    )
+    
+    menus = bpy.types.Menu.__subclasses__()
+    menu_is_present = True
+    
+    for name in menu_names:
+        assert (f"<class 'MolecularNodes.ui.{name}'>" in [str(menu) for menu in menus]) == True


### PR DESCRIPTION
Re-adds the node-add menu inside of the geometry nodes editor. Managed to delete with the refactor.