### PR TITLE
Add `release` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ docs-build:
 	quarto render docs
 
 test:
-	pip3 install .
+	pip install .
 	pytest -vv
 
 version := $(shell grep -o -E "\b[0-9]+\.[0-9]+\.[0-9]+\b" pyproject.toml)

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,9 @@ docs-build:
 test:
 	pip3 install .
 	pytest -vv
+
+version := $(shell grep -o -E "\b[0-9]+\.[0-9]+\.[0-9]+\b" pyproject.toml)
+
+release:
+	git clean -dfX
+	zip -r MolecularNodes_$(version).zip MolecularNodes -x *pycache* *.blend1


### PR DESCRIPTION
Adds `make release` to the Makefile which cleans the untracked git files and zips a
MolecularNodes_*.*.*.zip based on the version in pyproject.toml

- add `release` to Makefile
- change pip in Makefile
