### PR TITLE
Headless Rendering Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/*
 coverage.xml
 .coverage
 *.npz
+*.log

--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -116,9 +116,55 @@ class MOL_OT_Import_Protein_MD(bpy.types.Operator):
         
         return {"FINISHED"}
 
-def load_trajectory(file_top, file_traj, name="NewTrajectory", md_start=0, md_end=49, 
-                    md_step=1, world_scale=0.01, include_bonds=True, 
-                    selection="not (name H* or name OW)", custom_selections=None) -> (bpy.types.Object, bpy.types.Collection):
+def open_trajectory(
+    file_top, 
+    file_traj
+    ):
+    import MDAnalysis as mda  
+
+def load_trajectory(
+    file_top, 
+    file_traj, 
+    name="NewTrajectory", 
+    md_start=0, 
+    md_end=49, 
+    md_step=1, 
+    world_scale=0.01, 
+    include_bonds=True, 
+    selection="not (name H* or name OW)", 
+    custom_selections = None
+    ) -> (bpy.types.Object, bpy.types.Collection):
+    import MDAnalysis as mda
+    
+    # initially load in the trajectory
+    if file_traj == "":
+        univ = mda.Universe(file_top)
+    else:
+        univ = mda.Universe(file_top, file_traj)
+    
+    load_universe(
+        univ = univ, 
+        name = name, 
+        md_start = md_start, 
+        md_end = md_end, 
+        md_step = md_step, 
+        world_scale = world_scale,
+        include_bonds = include_bonds, 
+        selection = selection, 
+        custom_selections = None
+    )
+
+def load_universe(
+    univ,
+    name="NewTrajectory", 
+    md_start=0, 
+    md_end=49, 
+    md_step=1, 
+    world_scale=0.01, 
+    include_bonds=True, 
+    selection="not (name H* or name OW)", 
+    custom_selections = None
+    ) -> (bpy.types.Object, bpy.types.Collection):
     """
     Loads a molecular dynamics trajectory from the specified files.
 
@@ -162,14 +208,7 @@ def load_trajectory(file_top, file_traj, name="NewTrajectory", md_start=0, md_en
         If there is an error reading the files.
     """
     import MDAnalysis as mda
-    import MDAnalysis.transformations as trans
-    
-    # initially load in the trajectory
-    if file_traj == "":
-        univ = mda.Universe(file_top)
-    else:
-        univ = mda.Universe(file_top, file_traj)
-        
+
     # separate the trajectory, separate to the topology or the subsequence selections
     traj = univ.trajectory[md_start:md_end:md_step]
     

--- a/MolecularNodes/render.py
+++ b/MolecularNodes/render.py
@@ -1,0 +1,21 @@
+import bpy
+
+def frame_object(object: bpy.types.Object):
+    # old_active_object = bpy.data.
+    
+    # set as active object
+    object.select_set(True)
+    
+    # frame the active object
+    bpy.ops.view3d.camera_to_view_selected()
+
+def render(file_path: str = None):
+    if not file_path:
+        file_path = "/tmp/"
+    
+    bpy.context.scene.render.filepath = file_path
+    bpy.ops.render.render(write_still = True)
+
+def render_object(object: bpy.types.Object, file_path: str = None):
+    frame_object(object)
+    render(file_path)

--- a/MolecularNodes/render.py
+++ b/MolecularNodes/render.py
@@ -1,4 +1,66 @@
 import bpy
+from . import md
+from . import nodes
+import tempfile
+
+def render_universe(universe, starting_style = 2, engine = "eevee", fstop = 2):
+    from IPython.display import Image
+    obj, frames = md.load_universe(universe)
+    nodes.create_starting_node_tree(obj, frames, starting_style)
+    with tempfile.NamedTemporaryFile(suffix='.png', delete=True) as temp_file:
+        filename = temp_file.name
+        render_object(obj, filename, engine=engine, fstop = fstop)
+        return Image(filename)
+
+def camera_dof(obj = None, fstop = 2):
+    cam = bpy.context.scene.camera
+    cam.data.dof.use_dof = True
+    
+    if obj:
+        diff = obj.location - cam.location
+        cam.data.dof.focus_distance = diff.length / 2
+        cam.data.dof.aperture_fstop = fstop
+
+def default_settings_cycles(
+    samples = 128,
+    resolution_x = 1280, 
+    resolution_y = 720, 
+    device = "GPU",
+    dof = True
+    ):
+    scene = bpy.context.scene
+    scene.render.engine = "CYCLES"
+    scene.cycles.device = device
+    scene.cycles.samples = samples
+    scene.render.resolution_x = resolution_x
+    scene.render.resolution_y = resolution_y
+
+def default_settings_eevee(
+    ao: bool = True, 
+    ao_dis: float = 2, 
+    bloom: bool = True, 
+    resolution_x = 1280, 
+    resolution_y = 720
+    ):
+    """
+    Set useful default render settings for Eevee.
+
+    Parameters:
+        ao (bool): Whether to enable ambient occlusion. Defaults to True.
+        ao_dis (float): The distance for ambient occlusion. Defaults to 2.
+        bloom (bool): Whether to enable bloom. Defaults to True.
+    """
+    
+    eevee = bpy.context.scene.eevee
+    scene = bpy.context.scene
+    
+    scene.render.resolution_x = resolution_x
+    scene.render.resolution_y = resolution_y
+
+    eevee.use_gtao = ao
+    eevee.gtao_distance = ao_dis
+    eevee.gtao_factor = 2
+    eevee.use_bloom = bloom
 
 def frame_object(object: bpy.types.Object):
     # old_active_object = bpy.data.
@@ -16,6 +78,20 @@ def render(file_path: str = None):
     bpy.context.scene.render.filepath = file_path
     bpy.ops.render.render(write_still = True)
 
-def render_object(object: bpy.types.Object, file_path: str = None):
+
+
+def render_object(object: bpy.types.Object, file_path: str = None, engine = "eevee", fstop = 2):
+    # remove default cube for rendering
+    objects = bpy.data.objects
+    if objects.get('Cube'):
+        objects.remove(objects['Cube'])
+    object.select_set(True)
+    bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='MEDIAN')
     frame_object(object)
+    camera_dof(object, fstop = fstop)
+    if engine == "eevee":
+        # frame the camera and render the image
+        default_settings_eevee()
+    elif engine == "cycles":
+        default_settings_cycles()
     render(file_path)


### PR DESCRIPTION
Lots of potential for better supporting headless rendering via python scripting. 

Blender is now installable via pip, so Molecular Nodes could also be made to be installable as a `pip` package.

To make it feasible for working with, the creation of a number of convenience functions for dealing with the at times very finnicky Python API of Blender, to make it only a couple of lines to get a rendered image or animation. No idea how it might work dealing with the node trees, might be best to package a bunch of pre-made presets with the addon that can be used more easily with the API.

Todos:
- [x] Initla test with headless rendering
- [ ] Controls for dealing with camera
- [ ] Controls for dealing with protein styling
- [ ] Document dependencies in `.toml` to make installable via `pip` better

![image](https://github.com/BradyAJohnston/MolecularNodes/assets/36021261/a70b18a8-900e-4cce-a9ae-6bd6769ede38)
