### PR TITLE
Cache PDB downloads

### DIFF
--- a/MolecularNodes/config.json
+++ b/MolecularNodes/config.json
@@ -1,3 +1,0 @@
-{
-    "default_cache_dir": ["~", ".MolecularNodes"]
-}

--- a/MolecularNodes/config.json
+++ b/MolecularNodes/config.json
@@ -1,0 +1,3 @@
+{
+    "default_cache_dir": ["~", ".MolecularNodes"]
+}

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -3,7 +3,6 @@ import io
 from pathlib import Path
 import bpy
 import numpy as np
-import json
 from . import coll
 import warnings
 from . import data
@@ -11,9 +10,6 @@ from . import assembly
 from . import nodes
 from . import pkg
 from . import obj
-
-with open(Path(__file__).parents[0] / 'config.json', 'r') as f:
-    config = json.load(f)
 
 bpy.types.Scene.mol_pdb_code = bpy.props.StringProperty(
     name = 'pdb_code', 
@@ -27,7 +23,7 @@ bpy.types.Scene.mol_cache_dir = bpy.props.StringProperty(
     name = 'cache_dir',
     description = 'Location to cache PDB files',
     options = {'TEXTEDIT_UPDATE'},
-    default = str(Path(*config['default_cache_dir']).expanduser()),
+    default = str(Path('~', '.MolecularNodes').expanduser()),
     subtype = 'NONE'
 )
 bpy.types.Scene.mol_import_center = bpy.props.BoolProperty(
@@ -88,7 +84,7 @@ def molecule_rcsb(
     include_bonds = True,   
     starting_style = 0,               
     setup_nodes = True,
-    cache_dir = Path(*config['default_cache_dir']).expanduser(),      
+    cache_dir = None,      
     ):
     mol, file = open_structure_rcsb(
         pdb_code = pdb_code, 
@@ -180,7 +176,7 @@ def molecule_local(
     return mol_object
 
 
-def open_structure_rcsb(pdb_code, cache_dir = Path(*config['default_cache_dir']).expanduser(), include_bonds = True):
+def open_structure_rcsb(pdb_code, cache_dir = None, include_bonds = True):
     import biotite.structure.io.mmtf as mmtf
     import biotite.database.rcsb as rcsb
     

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -1,5 +1,6 @@
 import requests
 import io
+from pathlib import Path
 import bpy
 import numpy as np
 from . import coll
@@ -19,6 +20,13 @@ bpy.types.Scene.mol_pdb_code = bpy.props.StringProperty(
     subtype = 'NONE', 
     maxlen = 4
     )
+bpy.types.Scene.mol_cache_dir = bpy.props.StringProperty(
+    name = 'cache_dir',
+    description = 'Location to cache PDB files',
+    options = {'TEXTEDIT_UPDATE'},
+    default = str(Path(Path.home(), '.molnodes')),
+    subtype = 'NONE'
+)
 bpy.types.Scene.mol_import_center = bpy.props.BoolProperty(
     name = "mol_import_centre", 
     description = "Move the imported Molecule on the World Origin",
@@ -71,16 +79,18 @@ bpy.types.Scene.mol_import_default_style = bpy.props.IntProperty(
 
 
 def molecule_rcsb(
-    pdb_code,               
+    pdb_code,             
     center_molecule = False,               
     del_solvent = True,               
     include_bonds = True,   
     starting_style = 0,               
-    setup_nodes = True              
+    setup_nodes = True,
+    cache_dir = Path(Path.home(), '.molnodes'),      
     ):
     mol, file = open_structure_rcsb(
         pdb_code = pdb_code, 
-        include_bonds=include_bonds
+        include_bonds=include_bonds,
+        cache_dir = cache_dir
         )
     
     mol_object, coll_frames = create_molecule(
@@ -167,11 +177,11 @@ def molecule_local(
     return mol_object
 
 
-def open_structure_rcsb(pdb_code, include_bonds = True):
+def open_structure_rcsb(pdb_code, cache_dir = Path(Path.home(), '.molnodes'), include_bonds = True):
     import biotite.structure.io.mmtf as mmtf
     import biotite.database.rcsb as rcsb
     
-    file = mmtf.MMTFFile.read(rcsb.fetch(pdb_code, "mmtf"))
+    file = mmtf.MMTFFile.read(rcsb.fetch(pdb_code, "mmtf", target_path = cache_dir))
     
     # returns a numpy array stack, where each array in the stack is a model in the 
     # the file. The stack will be of length = 1 if there is only one model in the file

--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -3,6 +3,7 @@ import io
 from pathlib import Path
 import bpy
 import numpy as np
+import json
 from . import coll
 import warnings
 from . import data
@@ -11,6 +12,8 @@ from . import nodes
 from . import pkg
 from . import obj
 
+with open(Path(__file__).parents[0] / 'config.json', 'r') as f:
+    config = json.load(f)
 
 bpy.types.Scene.mol_pdb_code = bpy.props.StringProperty(
     name = 'pdb_code', 
@@ -24,7 +27,7 @@ bpy.types.Scene.mol_cache_dir = bpy.props.StringProperty(
     name = 'cache_dir',
     description = 'Location to cache PDB files',
     options = {'TEXTEDIT_UPDATE'},
-    default = str(Path(Path.home(), '.molnodes')),
+    default = str(Path(*config['default_cache_dir']).expanduser()),
     subtype = 'NONE'
 )
 bpy.types.Scene.mol_import_center = bpy.props.BoolProperty(
@@ -85,7 +88,7 @@ def molecule_rcsb(
     include_bonds = True,   
     starting_style = 0,               
     setup_nodes = True,
-    cache_dir = Path(Path.home(), '.molnodes'),      
+    cache_dir = Path(*config['default_cache_dir']).expanduser(),      
     ):
     mol, file = open_structure_rcsb(
         pdb_code = pdb_code, 
@@ -177,7 +180,7 @@ def molecule_local(
     return mol_object
 
 
-def open_structure_rcsb(pdb_code, cache_dir = Path(Path.home(), '.molnodes'), include_bonds = True):
+def open_structure_rcsb(pdb_code, cache_dir = Path(*config['default_cache_dir']).expanduser(), include_bonds = True):
     import biotite.structure.io.mmtf as mmtf
     import biotite.database.rcsb as rcsb
     

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -29,7 +29,8 @@ class MOL_OT_Import_Protein_RCSB(bpy.types.Operator):
             center_molecule=bpy.context.scene.mol_import_center, 
             del_solvent=bpy.context.scene.mol_import_del_solvent,
             include_bonds=bpy.context.scene.mol_import_include_bonds,
-            starting_style=bpy.context.scene.mol_import_default_style
+            starting_style=bpy.context.scene.mol_import_default_style,
+            cache_dir=bpy.context.scene.mol_cache_dir
         )
         
         bpy.context.view_layer.objects.active = mol_object
@@ -86,10 +87,16 @@ def MOL_PT_panel_rcsb(layout_function, ):
     col_main.scale_y = 1.0
     col_main.alignment = 'Expand'.upper()
     col_main.label(text = "Download from PDB")
+    row_cache = col_main.row()
+    row_cache.prop(
+        bpy.context.scene,
+        'mol_cache_dir',
+        text = 'Cache dir',
+        icon_value = 0,
+        emboss = True)
     row_import = col_main.row()
     row_import.prop(bpy.context.scene, 'mol_pdb_code', text='PDB ID')
     row_import.operator('mol.import_protein_rcsb', text='Download', icon='IMPORT')
-
 
 
 def MOL_PT_panel_local(layout_function, ):

--- a/MolecularNodes/ui.py
+++ b/MolecularNodes/ui.py
@@ -87,13 +87,10 @@ def MOL_PT_panel_rcsb(layout_function, ):
     col_main.scale_y = 1.0
     col_main.alignment = 'Expand'.upper()
     col_main.label(text = "Download from PDB")
-    row_cache = col_main.row()
-    row_cache.prop(
+    col_main.prop(
         bpy.context.scene,
         'mol_cache_dir',
-        text = 'Cache dir',
-        icon_value = 0,
-        emboss = True)
+        text = 'Cache dir')
     row_import = col_main.row()
     row_import.prop(bpy.context.scene, 'mol_pdb_code', text='PDB ID')
     row_import.operator('mol.import_protein_rcsb', text='Download', icon='IMPORT')

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -176,3 +176,14 @@ def test_load_small_mol(snapshot):
     bond_types = mn.obj.get_attribute(obj, 'bond_type')
     edges = ''.join([str(bond_type) for bond_type in bond_types])
     snapshot.assert_match(edges, 'asn_edges.txt')
+
+def test_rcsb_cache(snapshot):
+    from pathlib import Path
+    from shutil import rmtree
+    # we want to make sure cached files are freshly downloaded, but
+    # we don't want to delete our entire real cache
+    test_cache = Path(Path.home(), '.MolecularNodesTests')
+    if test_cache.exists():
+        rmtree(test_cache)
+    _ = mn.load.molecule_rcsb('6BQN', cache_dir = test_cache)
+    assert (test_cache / '6BQN.mmtf').exists()


### PR DESCRIPTION
Adds biotite caching, resolving #256. Tested by downloading a structure, turning off wifi, and re-loading it successfully. The cache folder is also created and populated with models.

I'm mostly working on this one to figure out how to add stuff to MolNodes, but it does work. It looks like there is a lot of duplicating default values --- I tried to copy your style but I'd be happy with feedback.