### PR TITLE
Dev entity fix

### DIFF
--- a/MolecularNodes/load.py
+++ b/MolecularNodes/load.py
@@ -190,34 +190,27 @@ def molecule_local(
 
 def get_chain_entity_id(file):
     entities = file['entityList']
-    chain_names = file['chainIdList']
-    n_chains = len(chain_names)
+    chain_names = file['chainNameList']
     
-    arr_entity = np.zeros(n_chains, dtype = int)
-    
+    ent_dic = {}
     counter = 0
-    for i, entity in enumerate(entities):
-        chain_idxs = entity['chainIndexList']
-        
-        mask = np.array(range(len(chain_idxs))) + counter
-        
-        arr_entity[mask] = i
-        # arr_entity[mask, 1] = chain_idxs
-        counter += len(chain_idxs)
+    for i, ent in enumerate(entities):
+        for chain_id in ent['chainIndexList']:
+            ent_dic[chain_names[chain_id]] = counter
+        counter += 1
     
-    return arr_entity
+    return ent_dic
 
 def set_atom_entity_id(mol, file):
     mol.add_annotation('entity_id', int)
-    chain_names = file['chainNameList']
-    chain_entity_id = get_chain_entity_id(file)
+    ent_dic = get_chain_entity_id(file)
     
-    chain_ids = np.array(list(map(
-        lambda x: np.where(x == chain_names)[0][0], 
+    entity_ids = np.array(list(map(
+        lambda x: ent_dic[x], 
         mol.chain_id
         )))
     
-    entity_ids = chain_entity_id[chain_ids]
+    # entity_ids = chain_entity_id[chain_ids]
     mol.set_annotation('entity_id', entity_ids)
     return entity_ids
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -6,4 +6,12 @@ def test_entity_id():
     ents = mn.obj.get_attribute(mol, 'entity_id')
     
     assert np.all(np.isin(ents, np.array(range(4))))
+
+def test_entity_id_range():
+    mol = mn.load.molecule_rcsb('6n2y')
+    ents = mn.obj.get_attribute(mol, 'entity_id')
+    chain_idx = mn.obj.get_attribute(mol, 'chain_id')
+    chain_id = np.array(mol['chain_id_unique'])[chain_idx]
     
+    assert max(ents) == 8
+    assert np.all(np.array(['A', 'B', 'C']) == np.unique(chain_id[ents == 0]))


### PR DESCRIPTION
Fixes adding of the `entity` that was getting mixed up on some structures because of author-defined chain names for ions etc.

Also adds some diagnostic console printing for debugging opening of structures