### PR TITLE
change docs.yml to only run on "docs-*" PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: ["main", "docs-*"]
-  pull_request:
+  pull_request: ["docs-*"]
   release:
     types: [published]
 


### PR DESCRIPTION
PR's that weren't authored by me fail the `docs.yml` workflow for building and deploying the docs. 

This changes it so this workflow is only triggered on PRs with "docs-*" in the name, so that it won't show up as falling workflows in PRs from contributors.