### PR TITLE
add testing for built versions of blender not bpy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: ["main", "docs-*"]
-  pull_request: ["docs-*"]
+  pull_request: 
+    branches: ["docs-*"]
   release:
     types: [published]
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,4 +1,4 @@
-name: test-new-releases
+name: test-builds
 
 on: 
     push:
@@ -15,7 +15,7 @@ jobs:
       strategy:
         matrix:
           platform: ['ubuntu-latest', 'macos-latest']
-          blender-version: ['3.5.0', '3.6.5']
+          blender-version: ['3.6.5']
       steps:
         - uses: actions/checkout@v3
         - name: Set up Python v3.10

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,56 @@
+name: test-new-releases
+
+on: 
+    push:
+      branches: 
+        - main
+    pull_request:
+      branches:
+        - main
+
+jobs:
+    test:
+      name: Test
+      runs-on: ${{ matrix.platform }}
+      strategy:
+        matrix:
+          platform: ['ubuntu-latest', 'macos-latest']
+          blender-version: ['3.5.0', '3.6.5']
+      steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python v3.10
+          uses: actions/setup-python@v3
+          with:
+            python-version: "3.10"
+        - name: Upgrade PIP
+          run: python -m pip install --upgrade pip
+        - name: Cache Blender ${{ matrix.blender-version }}
+          uses: actions/cache@v3
+          id: cache-blender
+          with:
+            path: |
+              blender-*
+              _blender-executable-path.txt
+            key: ${{ runner.os }}-${{ matrix.blender-version }}
+        - name: Download Blender ${{ matrix.blender-version }}
+          if: steps.cache-blender.outputs.cache-hit != 'true'
+          id: download-blender
+          run: |
+            python -m pip install --upgrade blender-downloader
+            printf "%s" "$(blender-downloader \
+            ${{ matrix.blender-version }} --extract --remove-compressed \
+            --quiet --print-blender-executable)" > _blender-executable-path.txt
+        - name: Install dependencies
+          id: install-dependencies
+          run: |
+            python -m pip install -r requirements.txt
+            python -m pip install pytest-blender
+            blender_executable="$(< _blender-executable-path.txt)"
+            python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
+            $python_blender_executable -m ensurepip
+            $python_blender_executable -m pip install pytest
+            $python_blender_executable -m pip install pytest-blender
+            $python_blender_executable -m pip install -r requirements.txt
+            echo "blender-executable=$blender_executable" >> $GITHUB_OUTPUT
+        - name: Test with pytest
+          run: pytest -v --blender-executable "${{ steps.install-dependencies.outputs.blender-executable }}" tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ logs/
 /.luarc.json
 dist
 poetry.lock
+blender*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-snapshot
 pytest-cov
-bpy
+# bpy
 biotite==0.37.0     # General parsing of structural files.
 MDAnalysis==2.6.1   # Reading of molecular dynamics trajectories.
 mrcfile==1.4.3      # Importing EM density files.


### PR DESCRIPTION
Adds testing of the actual Blender downloadables using [`pytest-blender`](https://github.com/mondeja/pytest-blender).

Enables testing of nightly builds for catching breaking changes. 

Currntly implementing 3.6, will be switched for 4.0 and daily builds after implemented.