### PR TITLE
fix panel not showing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ template:
 release:
 	git clean -dfX
 	make template
-	zip -r MolecularNodes_$(version).zip MolecularNodes -x *pycache* *.blend1 "molecularnodes/assets/template/MolecularNodes/*"
+	zip -r molecularnodes_$(version).zip molecularnodes -x *pycache* *.blend1 "molecularnodes/assets/template/MolecularNodes/*"

--- a/molecularnodes/io/mda.py
+++ b/molecularnodes/io/mda.py
@@ -33,7 +33,7 @@ from ..blender import (
 )
 from ..util.utils import lerp
 
-log = start_logging(logfile_name="mda")
+
 
 class AtomGroupInBlender:
     def __init__(self,
@@ -412,6 +412,7 @@ class MDAnalysisSession:
         memory : bool, optional
             Whether the old import is used (default: False).
         """
+        log = start_logging(logfile_name="mda")
         if not HAS_mda:
             raise ImportError("MDAnalysis is not installed.")
         
@@ -503,6 +504,7 @@ class MDAnalysisSession:
             frames as individual objects.
             (default: False)
         """
+        log = start_logging(logfile_name="mda")
         if in_memory:
             mol_object = self.in_memory(
                 atoms=atoms,
@@ -673,7 +675,7 @@ class MDAnalysisSession:
         verbose : bool, optional
             Whether to print the progress (default: False).
         """
-
+        log = start_logging(logfile_name="mda")
         warnings.warn(
             "The trajectories in this session \n"
             "is transferred to memory. \n"
@@ -889,6 +891,7 @@ class MDAnalysisSession:
         """
         Dump the session as a pickle file 
         """
+        log = start_logging(logfile_name="mda")
         # get blender_save_loc
         blender_save_loc = blender_save_loc.split(".blend")[0]
         with open(f"{blender_save_loc}.mda_session", "wb") as f:
@@ -902,6 +905,7 @@ class MDAnalysisSession:
         Rejuvenate the session from a pickle file in the default location
         (`~/.blender_mda_session/`).
         """
+        log = start_logging(logfile_name="mda")
 
         # get session name from mol_objects dictionary
         blend_file_name = bpy.data.filepath.split(".blend")[0]


### PR DESCRIPTION
Fixes #360 #348 #350 

 I believe I have tracked down the source of the error, which is the zipping of the file with capitalisation. The add-on preferences panel has to exactly match the add-on name (and thus the folder name). 