### PR TITLE
Convert cryoEM eulerangles in GeoNodes

### DIFF
--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -137,6 +137,20 @@ def get_style_node(object):
     group = object.modifiers['MolecularNodes'].node_group
     return style_node(group)
 
+def star_node(group):
+    prev = previous_node(get_output(group))
+    is_star_node = ("MN_starfile_instances" in prev.name)
+    while not is_star_node:
+        print(prev.name)
+        prev = previous_node(prev)
+        is_star_node = ("MN_starfile_instances" in prev.name)
+    return prev
+
+def get_star_node(object):
+    "Walk back through the primary node connections until you find the first style node"
+    group = object.modifiers['MolecularNodes'].node_group
+    return star_node(group)
+
 def get_color_node(object):
     "Walk back through the primary node connections until you find the first style node"
     group = object.modifiers['MolecularNodes'].node_group

--- a/molecularnodes/blender/obj.py
+++ b/molecularnodes/blender/obj.py
@@ -153,6 +153,8 @@ def get_attribute(obj: bpy.types.Object, att_name='position') -> np.array:
         att_array = np.array(list(map(lambda x: x.vector, att.data.values())))
     elif att.data_type == "FLOAT_COLOR":
         att_array = np.array(list(map(lambda x: x.color, att.data.values())))
+    elif att.data_type == "QUATERNION":
+        att_array = np.array(list(map(lambda x: x.value, att.data.values())))
     else:
         # Unsupported data type, return an empty NumPy array
         att_array = np.array([])

--- a/molecularnodes/io/load.py
+++ b/molecularnodes/io/load.py
@@ -48,6 +48,11 @@ class MolecularNodesObjectProperties(bpy.types.PropertyGroup):
         maxlen = 4,
         options={'HIDDEN'}
     )
+    star_type: bpy.props.StringProperty(
+        name = "Star Type", 
+        description = "The type of star file that was imported.", 
+        default = ""
+    )
 
 
 

--- a/molecularnodes/io/star.py
+++ b/molecularnodes/io/star.py
@@ -62,6 +62,9 @@ def load(
             shifts_ang = df[shift_column_names].to_numpy()
             xyz = xyz - shifts_ang 
         euler_angles = df[['rlnAngleRot', 'rlnAngleTilt', 'rlnAnglePsi']].to_numpy()
+        df['MNAnglePhi'] = df['rlnAngleRot']
+        df['MNAngleTheta'] = df['rlnAngleTilt']
+        df['MNAnglePsi'] = df['rlnAnglePsi']
         image_id = df['rlnMicrographName'].astype('category').cat.codes.to_numpy()
         
     elif star_type == 'cistem':
@@ -69,27 +72,15 @@ def load(
         df['cisTEMZFromDefocus'] = (df['cisTEMDefocus1'] + df['cisTEMDefocus2']) / 2
         df['cisTEMZFromDefocus'] = df['cisTEMZFromDefocus'] - df['cisTEMZFromDefocus'].median()
         xyz = df[['cisTEMOriginalXPosition', 'cisTEMOriginalYPosition', 'cisTEMZFromDefocus']].to_numpy()
-        euler_angles = df[['cisTEMAnglePhi', 'cisTEMAngleTheta', 'cisTEMAnglePsi']].to_numpy()
+        df['MNAnglePhi'] = df['cisTEMAnglePhi']
+        df['MNAngleTheta'] = df['cisTEMAngleTheta']
+        df['MNAnglePsi'] = df['cisTEMAnglePsi']
         image_id = df['cisTEMOriginalImageFilename'].astype('category').cat.codes.to_numpy()
-
-    # coerce starfile Euler angles to Blender convention
-    
-    target_metadata = ConversionMeta(name='output', 
-                                    axes='xyz', 
-                                    intrinsic=False,
-                                    right_handed_rotation=True,
-                                    active=True)
-    eulers = np.deg2rad(convert_eulers(euler_angles, 
-                               source_meta='relion', 
-                               target_meta=target_metadata))
 
     ensemble = obj.create_object(xyz * world_scale, collection=coll.mn(), name=name)
 
-    # create the attribute and add the data for the rotations
-    obj.add_attribute(ensemble, 'MOLRotation', eulers, 'FLOAT_VECTOR', 'POINT')
-
     # create the attribute and add the data for the image id
-    obj.add_attribute(ensemble, 'MOLIMageId', image_id, 'INT', 'POINT')
+    obj.add_attribute(ensemble, 'MNImageId', image_id, 'INT', 'POINT')
     
     # create attribute for every column in the STAR file
     for col in df.columns:

--- a/molecularnodes/io/star.py
+++ b/molecularnodes/io/star.py
@@ -27,8 +27,6 @@ def load(
     world_scale =  0.01 
     ):
     import starfile
-    from pandas import DataFrame
-    from eulerangles import ConversionMeta, convert_eulers
     
     star = starfile.read(file_path)
     star_type = None
@@ -61,7 +59,6 @@ def load(
         if all([col in df.columns for col in shift_column_names]):
             shifts_ang = df[shift_column_names].to_numpy()
             xyz = xyz - shifts_ang 
-        euler_angles = df[['rlnAngleRot', 'rlnAngleTilt', 'rlnAnglePsi']].to_numpy()
         df['MNAnglePhi'] = df['rlnAngleRot']
         df['MNAngleTheta'] = df['rlnAngleTilt']
         df['MNAnglePsi'] = df['rlnAnglePsi']

--- a/molecularnodes/io/star.py
+++ b/molecularnodes/io/star.py
@@ -79,6 +79,10 @@ def load(
 
     ensemble = obj.create_object(xyz * world_scale, collection=coll.mn(), name=name)
 
+    ensemble.mn['molecule_type'] = 'star'
+    ensemble.mn['star_type'] = star_type
+
+
     # create the attribute and add the data for the image id
     obj.add_attribute(ensemble, 'MNImageId', image_id, 'INT', 'POINT')
     

--- a/molecularnodes/requirements.txt
+++ b/molecularnodes/requirements.txt
@@ -2,6 +2,5 @@ biotite==0.37.0     # General parsing of structural files.
 MDAnalysis==2.6.1   # Reading of molecular dynamics trajectories.
 mrcfile==1.4.3      # Importing EM density files.
 starfile==0.5.1     # Importing star files.
-eulerangles==1.0.2  # Handling euler angle in starfiles. 
 scipy==1.11.4       # Converting rotations.
 msgpack==1.0.7      # Converting rotations.

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -41,7 +41,7 @@ chosen_panel = {
 
 packages = {
     'pdb': ['biotite'], 
-    'star': ['starfile', 'eulerangles'], 
+    'star': ['starfile'], 
     'local': ['biotite'], 
     'cellpack': ['biotite', 'msgpack', 'scipy'], 
     'md': ['MDAnalysis'], 

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -130,6 +130,11 @@ def panel_object(layout, context):
         layout.label(text = f"PDB: {object.mn.pdb_code.upper()}")
     if mol_type == "md":
         layout.prop(object.mn, 'subframes')
+    if mol_type == "star":
+        layout.label(text = f"{object.mn.star_type} starfile")
+        box = layout.box()
+        ui_from_node(box, nodes.get_star_node(object))
+        return
         
     
     row = layout.row(align=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ bpy = ">=4.0"
 MDAnalysis = "==2.6.1"
 biotite = "==0.37.0"
 mrcfile = "*"
-eulerangles = "*"
 starfile = "*"
 msgpack = "*"
 scipy = "*"
@@ -25,6 +24,8 @@ scipy = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-snapshot = "*"
+scipy = "*"
+
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]

--- a/tests/test_pkg.py
+++ b/tests/test_pkg.py
@@ -10,6 +10,6 @@ def test_is_current():
     assert mn.pkg.is_current('biotite')
 
 def test_get_pkgs():
-    names = ['biotite', 'MDAnalysis', 'mrcfile', 'eulerangles', 'starfile', 'scipy', 'msgpack']
+    names = ['biotite', 'MDAnalysis', 'mrcfile', 'starfile', 'scipy', 'msgpack']
     for name in mn.pkg.get_pkgs().keys():
         assert name in names

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -1,15 +1,44 @@
 import molecularnodes as mn
 import pytest
 import numpy as np
-from .utils import sample_attribute_to_string
+from scipy.spatial.transform import Rotation as R
+import starfile
 from .constants import test_data_directory
 
-def test_starfile_attributes(snapshot):
-    for type in ["cistem", "relion"]:
-        file = test_data_directory / f"{type}.star"
-        obj = mn.io.star.load(file)
-        for attribute in obj.data.attributes.keys():
-            snapshot.assert_match(
-                sample_attribute_to_string(obj, attribute, n = 200), 
-                f"{type}_{attribute}_values"
-            )
+mn.unregister()
+mn.register()
+
+@pytest.mark.parametrize("type", ["cistem", "relion"])
+def test_starfile_attributes(type, snapshot):
+    file = test_data_directory / f"{type}.star"
+    obj = mn.io.star.load(file)
+    
+    star = starfile.read(file)
+
+    if type == 'relion':
+        df = star['particles'].merge(star['optics'], on='rlnOpticsGroup')       
+        euler_angles = df[['rlnAngleRot', 'rlnAngleTilt', 'rlnAnglePsi']].to_numpy()
+        
+    elif type == 'cistem':
+        df = star
+        euler_angles = df[['cisTEMAnglePhi', 'cisTEMAngleTheta', 'cisTEMAnglePsi']].to_numpy()
+    
+    #Calculate Scipy rotation from the euler angles
+    rot_from_euler = quats = R.from_euler(
+        seq='ZYZ', angles=euler_angles, degrees=True
+    ).inv()
+
+    # Activate the rotation debug mode in the nodetreee and get the quaternion attribute
+    star_node_group = mn.blender.nodes.get_star_node(obj)
+    debugnode = star_node_group.node_tree.nodes['Switch.001']
+    debugnode.inputs[1].default_value = True
+    evaluated = obj.evaluated_get(mn.bpy.context.evaluated_depsgraph_get())
+    quat_attribute = mn.blender.obj.get_attribute(evaluated, 'MNDEBUGEuler')
+
+    #Convert from blender to scipy conventions and then into Scipy rotation
+    rot_from_geo_nodes = R.from_quat(quat_attribute[:, [1, 2, 3, 0]])
+
+    # To compare the two rotation with multiply one with the inverse of the other
+    assert (rot_from_euler * rot_from_geo_nodes.inv()).magnitude().max() < 1e-5
+
+   


### PR DESCRIPTION
This addresses #366 by converting ZYZ eulerangles into blender rotations inside of a nodegroup. This removes the dependency on `eulerangles` and is not dependent on `scipy`. The correctness of the conversion is, however, tested against `scipy`. As such I added it as a dev-dependency.

The testing gave me a bit of trouble, so I'll explain it here. The main obstacle was that the rotation attribute of instances is not available from python (at least to my knowledge after ~30 min of researching). I therefore implemented a debug switch into the star nodetree, that when activated output the original points with the quaternion stored as a named attribute.

![image](https://github.com/BradyAJohnston/MolecularNodes/assets/6081039/1659aa8a-63b4-4641-85f3-8d09ba30095b)

During testing this switch is activated, the quaternion values are read and compared against a rotation calculated from the euler angles by scipy. (Of course the conventions is opposite. `scipy` is x, y, z, w.  Blender doc claims to use the same. but in my test it produced w, x, y, z).

I also tried to hook up the starfile object to the "Object" Panel, but the object-input slot is broken. This seems to be a blender issue to me. I noticed that the color of the object socket changed in 4.0, maybe something is not hooked up yet...

![image](https://github.com/BradyAJohnston/MolecularNodes/assets/6081039/f3e5ed1d-5aa2-4bbc-a08f-e3495d43b94c)


