### PR TITLE
fix loading animated trajectories

### DIFF
--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -411,9 +411,11 @@ def create_starting_node_tree(object, coll_frames=None, style="spheres", name=No
         node_style.location = [800, 0]
         
         node_animate_frames = add_custom(group, 'MN_animate_frames', [500, 0])
-        node_animate_frames.inputs['Frames'].default_value = coll_frames
-        
         node_animate = add_custom(group, 'MN_animate_value', [500, -300])
+        
+        node_animate_frames.inputs['Frames'].default_value = coll_frames
+        node_animate.inputs['To Max'].default_value = len(coll_frames.objects) - 1
+        
         link(to_animate.outputs[0], node_animate_frames.inputs[0])
         link(node_animate_frames.outputs[0], node_style.inputs[0])
         link(node_animate.outputs[0], node_animate_frames.inputs['Frame'])

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -62,6 +62,7 @@ def test_rcsb_nmr(snapshot):
     obj = mn.io.pdb.load(CODE)
     coll_frames = bpy.data.collections[f"{CODE}_frames"]
     assert len(coll_frames.objects) == 10
+    assert obj.modifiers['MolecularNodes'].node_group.nodes['MN_animate_value'].inputs['To Max'].default_value == 9
     
     verts = get_verts(obj, apply_modifiers = False)
     snapshot.assert_match(verts, 'rcsb_nmr_2M6Q.txt')


### PR DESCRIPTION
Fixes #375 #373

The `Animate Value` node was createad without the correct initial mapping of frames output.

The `Aniamte Frames` node interpolated between the 0th and 1st frame, but not for the later frames. Interpolation now correctly works for all frame values.
