### PR TITLE
Some improvements to density import

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,14 @@ jobs:
           pip install poetry
           poetry install --with=dev
       
+      - name: Install pyopenvdb
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd $(poetry run python -c "import os; import bpy; print(os.path.dirname(bpy.__file__)+'/../../../../../')")
+          svn export https://svn.blender.org/svnroot/bf-blender/trunk/lib/linux_x86_64_glibc_228/python/lib/python3.10/site-packages/pyopenvdb.so
+          pip install patchelf
+          patchelf --set-rpath '$ORIGIN/bpy/lib' pyopenvdb.so
+          
       - name: Run Tests
         run: poetry run python -m pytest --verbose --cov=molecularnodes --cov-report=xml:coverage.xml --ignore=molecularnodes/ui/panel.py
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           cd $(poetry run python -c "import os; import bpy; print(os.path.dirname(bpy.__file__)+'/../../../../../')")
-          svn export https://svn.blender.org/svnroot/bf-blender/trunk/lib/linux_x86_64_glibc_228/python/lib/python3.10/site-packages/pyopenvdb.so
+          svn export https://svn.blender.org/svnroot/bf-blender/trunk/lib/linux_x86_64_glibc_228/python/lib/python3.10/site-packages/pyopenvdb.so@r63589
           pip install patchelf
           patchelf --set-rpath '$ORIGIN/bpy/lib' pyopenvdb.so
           

--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -90,6 +90,12 @@ def set_selection(group, node, selection):
     
     return selection
 
+def create_debug_group(name = 'MolecularNodesDebugGroup'):
+    group = new_group(name = name)
+    info = group.nodes.new('GeometryNodesObjectInfo')
+    insert_last_node(group, info, link_input = False)
+    return group
+
 def add_selection(group, sel_name, input_list, attribute = 'chain_id'):
     style = style_node(group)
     sel_node = add_custom(group, chain_selection('selection', input_list, attribute=attribute).name)
@@ -103,10 +109,10 @@ def get_output(group):
 def get_input(group):
     return group.nodes[bpy.app.translations.pgettext_data("Group Input",)]
 
-def get_mod(object):
-    node_mod = object.modifiers.get('MolecularNodes')
+def get_mod(object, name = 'MolecularNodes'):
+    node_mod = object.modifiers.get(name)
     if not node_mod:
-        node_mod = object.modifiers.new("MolecularNodes", "NODES")
+        node_mod = object.modifiers.new(name, "NODES")
     object.modifiers.active = node_mod
     return node_mod
 
@@ -159,13 +165,14 @@ def get_color_node(object):
         if node.name == "MN_color_attribute_random":
             return node
 
-def insert_last_node(group, node):
+def insert_last_node(group, node, link_input = True):
     last, output = get_nodes_last_output(group)
     link = group.links.new
     location = output.location
     output.location = [location[0] + 300, location[1]]
     node.location = [location[0] - 300, location[1]]
-    link(last.outputs[0], node.inputs[0])
+    if link_input:
+        link(last.outputs[0], node.inputs[0])
     link(node.outputs[0], output.inputs[0])
 
 def realize_instances(obj):

--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -91,9 +91,9 @@ def set_selection(group, node, selection):
     return selection
 
 def create_debug_group(name = 'MolecularNodesDebugGroup'):
-    group = new_group(name = name)
-    info = group.nodes.new('GeometryNodesObjectInfo')
-    insert_last_node(group, info, link_input = False)
+    group = new_group(name = name, fallback = False)
+    info = group.nodes.new('GeometryNodeObjectInfo')
+    group.links.new(info.outputs['Geometry'], group.nodes['Group Output'].inputs[0])
     return group
 
 def add_selection(group, sel_name, input_list, attribute = 'chain_id'):

--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -327,7 +327,7 @@ def create_starting_nodes_starfile(object):
     # Need to manually set Image input to 1, otherwise it will be 0 (even though default is 1)
     node_mod['Input_3'] = 1
 
-def create_starting_nodes_density(object, threshold = 0.8, style = 'surface'):
+def create_starting_nodes_density(object, threshold = 0.8, style = 'density_surface'):
     # ensure there is a geometry nodes modifier called 'MolecularNodes' that is created and applied to the object
     mod = get_mod(object)
     node_name = f"MN_density_{object.name}"

--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -333,7 +333,7 @@ def create_starting_nodes_density(object, threshold = 0.8, style = 'surface'):
     node_name = f"MN_density_{object.name}"
     
     # create a new GN node group, specific to this particular molecule
-    group = new_group(node_name)
+    group = new_group(node_name, fallback=False)
     link = group.links.new
     mod.node_group = group
     

--- a/molecularnodes/blender/obj.py
+++ b/molecularnodes/blender/obj.py
@@ -242,10 +242,10 @@ def evaluate_using_mesh(object):
     Intended for debugging only.
     """
     # create mesh an object that contains a single vertex
-    debug = create_object(np.array(0, 0, 0)) 
+    debug = create_object(locations = np.zeros((1, 3), dtype=float)) 
     mod = nodes.get_mod(debug)
     mod.node_group = nodes.create_debug_group()
-    mod.node_group.nodes['Object Info'].inputs['Object'] = object
+    mod.node_group.nodes['Object Info'].inputs['Object'].default_value = bpy.data.objects[object.name]
     
     # This is super important, otherwise the evaluated object will not be updated
     debug.update_tag()

--- a/molecularnodes/blender/obj.py
+++ b/molecularnodes/blender/obj.py
@@ -219,3 +219,48 @@ def set_position(object, locations: np.ndarray):
 
     # Update the object's data
     object.data.update()
+
+
+def evaluate_using_debug_cube(object):
+    """
+    Evaluate the object using a debug cube. This allows us to see the geometry
+    of objects that do not have teh capability to stroe geometry, such as Volumes.
+
+    Parameters
+    ----------
+    object : bpy.types.Object
+        The object to be evaluated.
+
+    Returns
+    -------
+    bpy.types.Object
+
+    Notes
+    -----
+    This function is used for debugging purposes only.
+    """
+    import os
+    from .. import pkg
+
+    MN_DATA_FILE = os.path.join(pkg.ADDON_DIR, 'assets', 'MN_data_file.blend')
+    debug_cube = bpy.data.objects.get('MNDebugCube')
+    if not debug_cube:
+        # Load the debug cube from the MN data file
+        bpy.ops.wm.append(
+                directory = os.path.join(MN_DATA_FILE, 'Object'), 
+                filename = 'MNDebugCube', 
+                link = False
+            )
+        debug_cube = bpy.data.objects['MNDebugCube']
+    
+    # Get the MN modifier of debug_cube
+    mod = debug_cube.modifiers[0]
+
+    mod['Socket_2'] = object
+    # This is super important, otherwise the evaluated object will not be updated
+    debug_cube.update_tag()
+    dg = bpy.context.evaluated_depsgraph_get()
+    evaluated = debug_cube.evaluated_get(dg)
+
+    return evaluated
+    

--- a/molecularnodes/io/density.py
+++ b/molecularnodes/io/density.py
@@ -1,7 +1,7 @@
 import bpy
 import numpy as np
 import os
-from ..blender import nodes
+from ..blender import nodes, coll
 
 bpy.types.Scene.MN_import_density_nodes = bpy.props.BoolProperty(
     name = "Setup Nodes", 
@@ -155,8 +155,7 @@ def map_to_vdb(
     with mrcfile.open(file) as mrc:
         voxel_size = np.array([mrc.voxel_size.x, mrc.voxel_size.y, mrc.voxel_size.z])
         box_size = np.array([mrc.header.nx, mrc.header.ny, mrc.header.nz])
-    print(voxel_size)
-    print(grid)
+
     # Rotate and scale the grid for import into Blender
     grid.transform.rotate(np.pi / 2, vdb.Axis(1))
     grid.transform.scale(np.array((-1, 1, 1)) * world_scale * voxel_size)
@@ -194,9 +193,15 @@ def vdb_to_volume(file: str) -> bpy.types.Object:
         scale=[1, 1, 1], 
         rotation=[0, 0, 0]
     )
-    
+
     # get reference to imported object and return
     vol = bpy.context.scene.objects[name]
+
+    # Move the object to the MolecularNodes collection
+    initial_collection = vol.users_collection[0]
+    initial_collection.objects.unlink(vol)
+    coll.mn().objects.link(vol)
+    
     return vol
 
 

--- a/molecularnodes/io/density.py
+++ b/molecularnodes/io/density.py
@@ -222,8 +222,8 @@ def vdb_to_volume(file: str) -> bpy.types.Object:
         files=[], 
     )
     # get reference to imported object and return
-    # This breaks if the same density gets improted more than once
-    vol = bpy.context.scene.objects[name]
+    # This breaks if the same density gets imported more than once
+    vol = bpy.context.selected_objects[0]
 
     # Move the object to the MolecularNodes collection
     initial_collection = vol.users_collection[0]

--- a/molecularnodes/io/density.py
+++ b/molecularnodes/io/density.py
@@ -221,8 +221,8 @@ def vdb_to_volume(file: str) -> bpy.types.Object:
         filepath=file, 
         files=[], 
     )
-    # get reference to imported object and return
-    # This breaks if the same density gets imported more than once
+    
+    # get reference to imported object
     vol = bpy.context.selected_objects[0]
 
     # Move the object to the MolecularNodes collection

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -2,6 +2,9 @@ import molecularnodes as mn
 import pytest
 import numpy as np
 from .constants import test_data_directory
+from .utils import (
+    apply_mods
+)
 try:
     import pyopenvdb
 except ImportError:
@@ -12,10 +15,39 @@ mn.register()
 
 def test_density_load():
     file = test_data_directory / "emd_24805.map.gz"
+    vdb_file = test_data_directory / "emd_24805.vdb"
+    vdb_file.unlink(missing_ok=True)
     obj = mn.io.density.load(file,style="density_surface")
+    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
 
+    pos = mn.blender.obj.get_attribute(evaluated,"position")
+
+    assert len(pos) > 1000
+    # Get the average of positions
+    avg = np.mean(pos,axis=0)
+    
+    assert np.linalg.norm(avg) > 0.1    
     assert obj.mn.molecule_type == "density"
     assert obj.users_collection[0] == mn.blender.coll.mn()
+
+def test_density_centered():
+    file = test_data_directory / "emd_24805.map.gz"
+    vdb_file = test_data_directory / "emd_24805.vdb"
+    vdb_file.unlink(missing_ok=True)
+    obj = mn.io.density.load(file,style="density_surface")
+    # Need to load an empty file to reset vdb file
+    mn.bpy.ops.wm.read_factory_settings()
+    obj2 = mn.io.density.load(file,style="density_surface",center=True)
+    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj2)
+
+    pos = mn.blender.obj.get_attribute(evaluated,"position")
+
+    assert len(pos) > 1000
+    # Get the average of positions
+    avg = np.mean(pos,axis=0)
+    
+    assert np.linalg.norm(avg) < 0.1
+    assert not np.allclose(avg,[0.0,0.0,0.0])
 
 def test_density_multiple_load():
     file = test_data_directory / "emd_24805.map.gz"

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,0 +1,13 @@
+import molecularnodes as mn
+import pytest
+import numpy as np
+from .constants import test_data_directory
+
+mn.unregister()
+mn.register()
+
+def test_density_load():
+    file = test_data_directory / "emd_24805.map.gz"
+    obj = mn.io.density.load(file)
+    assert False
+   

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -27,7 +27,7 @@ def density_file():
 def test_density_load(density_file):
     
     obj = mn.io.density.load(density_file,style="density_surface")
-    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+    evaluated = mn.blender.obj.evaluate_using_mesh(obj)
     pos = mn.blender.obj.get_attribute(evaluated,"position")
 
     assert len(pos) > 1000
@@ -46,7 +46,7 @@ def test_density_centered(density_file):
     mn.bpy.data.objects.remove(o,do_unlink=True)
 
     obj = mn.io.density.load(density_file,style="density_surface",center=True)
-    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+    evaluated = mn.blender.obj.evaluate_using_mesh(obj)
 
     pos = mn.blender.obj.get_attribute(evaluated,"position")
 
@@ -65,7 +65,7 @@ def test_density_invert(density_file):
     obj = mn.io.density.load(density_file,style="density_surface",invert=True)
     style_node = mn.blender.nodes.get_style_node(obj)
     style_node.inputs["Threshold"].default_value = 0.01
-    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+    evaluated = mn.blender.obj.evaluate_using_mesh(obj)
 
     pos = mn.blender.obj.get_attribute(evaluated,"position")    
     # At this threshold after inverting we should have a cube the size of the volume
@@ -83,7 +83,7 @@ def test_density_normalize(density_file):
     obj = mn.io.density.load(density_file,style="density_surface",normalize=True)
     style_node = mn.blender.nodes.get_style_node(obj)
     assert style_node.inputs["Threshold"].default_value == 0.25
-    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+    evaluated = mn.blender.obj.evaluate_using_mesh(obj)
     pos = mn.blender.obj.get_attribute(evaluated,"position")
     assert len(pos) > 1000
 

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -13,4 +13,16 @@ mn.register()
 def test_density_load():
     file = test_data_directory / "emd_24805.map.gz"
     obj = mn.io.density.load(file,style="density_surface")
+
     assert obj.mn.molecule_type == "density"
+    assert obj.users_collection[0] == mn.blender.coll.mn()
+
+def test_density_multiple_load():
+    file = test_data_directory / "emd_24805.map.gz"
+    obj = mn.io.density.load(file,style="density_surface")
+    obj2 = mn.io.density.load(file,style="density_surface")
+
+    assert obj.mn.molecule_type == "density"
+    assert obj2.mn.molecule_type == "density"
+    assert obj.users_collection[0] == mn.blender.coll.mn()
+    assert obj2.users_collection[0] == mn.blender.coll.mn()

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -2,12 +2,15 @@ import molecularnodes as mn
 import pytest
 import numpy as np
 from .constants import test_data_directory
+try:
+    import pyopenvdb
+except ImportError:
+    pytest.skip("pyopenvdb not installed", allow_module_level=True)
 
 mn.unregister()
 mn.register()
 
 def test_density_load():
     file = test_data_directory / "emd_24805.map.gz"
-    obj = mn.io.density.load(file)
-    assert False
-   
+    obj = mn.io.density.load(file,style="density_surface")
+    assert obj.mn.molecule_type == "density"

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,4 +1,5 @@
 import molecularnodes as mn
+import bpy
 import pytest
 import numpy as np
 from .constants import test_data_directory
@@ -19,9 +20,9 @@ def density_file():
     vdb_file = test_data_directory / "emd_24805.vdb"
     vdb_file.unlink(missing_ok=True)
     # Make all densities are removed
-    for o in mn.bpy.data.objects:
+    for o in bpy.data.objects:
         if o.mn.molecule_type == "density":
-            mn.bpy.data.objects.remove(o,do_unlink=True)
+            bpy.data.objects.remove(o,do_unlink=True)
     return file
 
 def test_density_load(density_file):
@@ -43,7 +44,7 @@ def test_density_centered(density_file):
     # First load using standar parameters to test recreation of vdb
     o = mn.io.density.load(density_file,style="density_surface")
     # Then refresh the scene
-    mn.bpy.data.objects.remove(o,do_unlink=True)
+    bpy.data.objects.remove(o,do_unlink=True)
 
     obj = mn.io.density.load(density_file,style="density_surface",center=True)
     evaluated = mn.blender.obj.evaluate_using_mesh(obj)
@@ -60,7 +61,7 @@ def test_density_invert(density_file):
     # First load using standar parameters to test recreation of vdb
     o = mn.io.density.load(density_file,style="density_surface")
     # Then refresh the scene
-    mn.bpy.data.objects.remove(o,do_unlink=True)
+    bpy.data.objects.remove(o,do_unlink=True)
 
     obj = mn.io.density.load(density_file,style="density_surface",invert=True)
     style_node = mn.blender.nodes.get_style_node(obj)
@@ -72,20 +73,6 @@ def test_density_invert(density_file):
     assert pos[:,0].max() > 2.0
     assert pos[:,1].max() > 2.0
     assert pos[:,2].max() > 2.0
-
-def test_density_normalize(density_file):
-
-    # First load using standar parameters to test recreation of vdb
-    o = mn.io.density.load(density_file,style="density_surface")
-    # Then refresh the scene
-    mn.bpy.data.objects.remove(o,do_unlink=True)
-
-    obj = mn.io.density.load(density_file,style="density_surface",normalize=True)
-    style_node = mn.blender.nodes.get_style_node(obj)
-    assert style_node.inputs["Threshold"].default_value == 0.25
-    evaluated = mn.blender.obj.evaluate_using_mesh(obj)
-    pos = mn.blender.obj.get_attribute(evaluated,"position")
-    assert len(pos) > 1000
 
 def test_density_multiple_load():
     file = test_data_directory / "emd_24805.map.gz"

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -18,8 +18,10 @@ def density_file():
     file = test_data_directory / "emd_24805.map.gz"
     vdb_file = test_data_directory / "emd_24805.vdb"
     vdb_file.unlink(missing_ok=True)
-    # Make sure this vdb file is not already loaded
-    mn.bpy.ops.wm.read_factory_settings()
+    # Make all densities are removed
+    for o in mn.bpy.data.objects:
+        if o.mn.molecule_type == "density":
+            mn.bpy.data.objects.remove(o,do_unlink=True)
     return file
 
 def test_density_load(density_file):
@@ -39,9 +41,9 @@ def test_density_load(density_file):
 def test_density_centered(density_file):
 
     # First load using standar parameters to test recreation of vdb
-    mn.io.density.load(density_file,style="density_surface")
+    o = mn.io.density.load(density_file,style="density_surface")
     # Then refresh the scene
-    mn.bpy.ops.wm.read_factory_settings()
+    mn.bpy.data.objects.remove(o,do_unlink=True)
 
     obj = mn.io.density.load(density_file,style="density_surface",center=True)
     evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
@@ -56,9 +58,9 @@ def test_density_centered(density_file):
 def test_density_invert(density_file):
 
     # First load using standar parameters to test recreation of vdb
-    mn.io.density.load(density_file,style="density_surface")
+    o = mn.io.density.load(density_file,style="density_surface")
     # Then refresh the scene
-    mn.bpy.ops.wm.read_factory_settings()
+    mn.bpy.data.objects.remove(o,do_unlink=True)
 
     obj = mn.io.density.load(density_file,style="density_surface",invert=True)
     style_node = mn.blender.nodes.get_style_node(obj)
@@ -74,9 +76,9 @@ def test_density_invert(density_file):
 def test_density_normalize(density_file):
 
     # First load using standar parameters to test recreation of vdb
-    mn.io.density.load(density_file,style="density_surface")
+    o = mn.io.density.load(density_file,style="density_surface")
     # Then refresh the scene
-    mn.bpy.ops.wm.read_factory_settings()
+    mn.bpy.data.objects.remove(o,do_unlink=True)
 
     obj = mn.io.density.load(density_file,style="density_surface",normalize=True)
     style_node = mn.blender.nodes.get_style_node(obj)

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -13,41 +13,77 @@ except ImportError:
 mn.unregister()
 mn.register()
 
-def test_density_load():
+@pytest.fixture
+def density_file():
     file = test_data_directory / "emd_24805.map.gz"
     vdb_file = test_data_directory / "emd_24805.vdb"
     vdb_file.unlink(missing_ok=True)
-    obj = mn.io.density.load(file,style="density_surface")
+    # Make sure this vdb file is not already loaded
+    mn.bpy.ops.wm.read_factory_settings()
+    return file
+
+def test_density_load(density_file):
+    
+    obj = mn.io.density.load(density_file,style="density_surface")
+    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+    pos = mn.blender.obj.get_attribute(evaluated,"position")
+
+    assert len(pos) > 1000
+
+    avg = np.mean(pos,axis=0)
+    assert np.linalg.norm(avg) > 0.5 
+
+    assert obj.mn.molecule_type == "density"
+    assert obj.users_collection[0] == mn.blender.coll.mn()
+
+def test_density_centered(density_file):
+
+    # First load using standar parameters to test recreation of vdb
+    mn.io.density.load(density_file,style="density_surface")
+    # Then refresh the scene
+    mn.bpy.ops.wm.read_factory_settings()
+
+    obj = mn.io.density.load(density_file,style="density_surface",center=True)
     evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
 
     pos = mn.blender.obj.get_attribute(evaluated,"position")
 
     assert len(pos) > 1000
-    # Get the average of positions
+
     avg = np.mean(pos,axis=0)
-    
-    assert np.linalg.norm(avg) > 0.1    
-    assert obj.mn.molecule_type == "density"
-    assert obj.users_collection[0] == mn.blender.coll.mn()
-
-def test_density_centered():
-    file = test_data_directory / "emd_24805.map.gz"
-    vdb_file = test_data_directory / "emd_24805.vdb"
-    vdb_file.unlink(missing_ok=True)
-    obj = mn.io.density.load(file,style="density_surface")
-    # Need to load an empty file to reset vdb file
-    mn.bpy.ops.wm.read_factory_settings()
-    obj2 = mn.io.density.load(file,style="density_surface",center=True)
-    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj2)
-
-    pos = mn.blender.obj.get_attribute(evaluated,"position")
-
-    assert len(pos) > 1000
-    # Get the average of positions
-    avg = np.mean(pos,axis=0)
-    
     assert np.linalg.norm(avg) < 0.1
-    assert not np.allclose(avg,[0.0,0.0,0.0])
+
+def test_density_invert(density_file):
+
+    # First load using standar parameters to test recreation of vdb
+    mn.io.density.load(density_file,style="density_surface")
+    # Then refresh the scene
+    mn.bpy.ops.wm.read_factory_settings()
+
+    obj = mn.io.density.load(density_file,style="density_surface",invert=True)
+    style_node = mn.blender.nodes.get_style_node(obj)
+    style_node.inputs["Threshold"].default_value = 0.01
+    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+
+    pos = mn.blender.obj.get_attribute(evaluated,"position")    
+    # At this threshold after inverting we should have a cube the size of the volume
+    assert pos[:,0].max() > 2.0
+    assert pos[:,1].max() > 2.0
+    assert pos[:,2].max() > 2.0
+
+def test_density_normalize(density_file):
+
+    # First load using standar parameters to test recreation of vdb
+    mn.io.density.load(density_file,style="density_surface")
+    # Then refresh the scene
+    mn.bpy.ops.wm.read_factory_settings()
+
+    obj = mn.io.density.load(density_file,style="density_surface",normalize=True)
+    style_node = mn.blender.nodes.get_style_node(obj)
+    assert style_node.inputs["Threshold"].default_value == 0.25
+    evaluated = mn.blender.obj.evaluate_using_debug_cube(obj)
+    pos = mn.blender.obj.get_attribute(evaluated,"position")
+    assert len(pos) > 1000
 
 def test_density_multiple_load():
     file = test_data_directory / "emd_24805.map.gz"

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -26,3 +26,10 @@ def test_set_position():
     
     assert not np.isclose(pos_a, pos_b).all()
     assert np.isclose(pos_a, pos_b - 10, rtol = 0.001).all()
+
+def test_eval_mesh():
+    a = mn.blender.obj.create_object(np.zeros((3, 3)))
+    assert len(a.data.vertices) == 3
+    b = mn.blender.obj.create_object(np.zeros((5, 3)))
+    assert len(b.data.vertices) == 5
+    assert len(mn.blender.obj.evaluate_using_mesh(b).data.vertices) == 5


### PR DESCRIPTION
Hi Brady,

here are some improvements for the density import:

- Density can optionally be centered on import
- Object is added to the MN collection
- Option to smooth the surface
- Option to hide the dust that is typical in highly sharpened maps:

[Screencast from 2023-12-15 09-58-59.webm](https://github.com/BradyAJohnston/MolecularNodes/assets/6081039/67ed2d88-47c0-4b71-afe3-093066edc06c)


There are some changes coming to the volume system in geometry nodes, so I understand if you want to hold up on this for now.

Best,

Johannes