### PR TITLE
Adds macOS ARM runner for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         blender-version: ["4.0.0"]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
macOS ARM runners have been added to GitHub actions (https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) so this adds it to the testing matrix.