### PR TITLE
refactor internals of cartoon

### DIFF
--- a/tests/snapshots/test_ops/test_op_api_mda/.select_vert.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/.select_vert.txt
@@ -1,1 +1,9 @@
-The selected attribute '.select_vert' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[ True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True False False
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True False  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True False  True  True]

--- a/tests/snapshots/test_ops/test_op_api_mda/atom_name.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/atom_name.txt
@@ -1,1 +1,3 @@
-The selected attribute 'atom_name' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 0 0 2
+ 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+ 2 2 2 2 2 0 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 0 2 2]

--- a/tests/snapshots/test_ops/test_op_api_mda/atom_types.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/atom_types.txt
@@ -1,1 +1,3 @@
-The selected attribute 'atom_types' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]

--- a/tests/snapshots/test_ops/test_op_api_mda/atomic_number.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/atomic_number.txt
@@ -1,1 +1,3 @@
-The selected attribute 'atomic_number' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 0 0 6
+ 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6
+ 6 6 6 6 6 0 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 0 6 6]

--- a/tests/snapshots/test_ops/test_op_api_mda/is_alpha_carbon.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/is_alpha_carbon.txt
@@ -1,1 +1,9 @@
-The selected attribute 'is_alpha_carbon' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[ True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True False False
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True False  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True False  True  True]

--- a/tests/snapshots/test_ops/test_op_api_mda/is_backbone.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/is_backbone.txt
@@ -1,1 +1,9 @@
-The selected attribute 'is_backbone' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[ True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True False False
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True False  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True False  True  True]

--- a/tests/snapshots/test_ops/test_op_api_mda/is_lipid.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/is_lipid.txt
@@ -1,1 +1,9 @@
-The selected attribute 'is_lipid' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False]

--- a/tests/snapshots/test_ops/test_op_api_mda/is_nucleic.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/is_nucleic.txt
@@ -1,1 +1,9 @@
-The selected attribute 'is_nucleic' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False]

--- a/tests/snapshots/test_ops/test_op_api_mda/is_peptide.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/is_peptide.txt
@@ -1,1 +1,9 @@
-The selected attribute 'is_peptide' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[ True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True False False
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True  True  True  True  True  True  True False  True  True  True  True
+  True  True  True  True  True  True  True  True  True  True  True  True
+  True False  True  True]

--- a/tests/snapshots/test_ops/test_op_api_mda/is_solvent.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/is_solvent.txt
@@ -1,1 +1,9 @@
-The selected attribute 'is_solvent' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False False False False False False False False False
+ False False False False]

--- a/tests/snapshots/test_ops/test_op_api_mda/vdw_radii.txt
+++ b/tests/snapshots/test_ops/test_op_api_mda/vdw_radii.txt
@@ -1,1 +1,9 @@
-The selected attribute 'vdw_radii' does not exist on the mesh.             Possible attributes are: attribute_names=['b_factor', 'sec_struct', 'res_name', 'chain_id', 'res_id', 'Color', 'position', 'reverse', 'atom_N', 'atom_O', 'forward', 'vec_vertical', 'vec_horizontal', 'atom_interface', 'atom_pivot', 'guide_X', 'guide_Z', 'atom_C', 'atom_CA', '.edge_verts', 'sharp_edge', 'material_index', 'sharp_face', '.corner_vert', '.corner_edge']
+[0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.    0.
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.    0.017 0.017 0.017 0.017
+ 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017 0.017
+ 0.017 0.    0.017 0.017]


### PR DESCRIPTION
Thanks to some new nodes that were introduced in 4.0, I've refactored some of the internals of the Cartoon and Ribbon nodes. Mostly thanks to the `Mesh to Points` node which greatly simplifies the number of nodes required.


| Old | New|
|--------|--------|
| ![image](https://github.com/BradyAJohnston/MolecularNodes/assets/36021261/e4306bae-87ab-4f26-9a0c-ba093bfd779c)| ![image](https://github.com/BradyAJohnston/MolecularNodes/assets/36021261/261e31ee-6351-48be-bf74-730206195a09)|

Should not change any of the resulting geometry, but this will simplify the process for updating these styles later.