### PR TITLE
Expose Bond Nodes

### DIFF
--- a/molecularnodes/ui/node_info.py
+++ b/molecularnodes/ui/node_info.py
@@ -304,13 +304,15 @@ menu_items = {
     'topology': [
         {
             'label': 'Find Bonds',
-            'name': '.MN_bonds_find',
-            'description': "Finds bonds between atoms based on distance. Based on the vdw_radii for each point, finds other points within a certain radius to create a bond to. Does not preserve the index for the points. Does not detect bond type"
+            'name': 'MN_topo_bonds_find',
+            'description': "Finds bonds between atoms based on distance. Based on the vdw_radii for each point, finds other points within a certain radius to create a bond to. Does not preserve the index for the points, detect bond type, or transfer all attributes",
+            'video_url': 'https://imgur.com/oUo5TsM'
         },
         {
             'label': 'Break Bonds',
-            'name': '.MN_bonds_break',
-            'description': "Will delete a bond between atoms that already exists based on a distance cutoff"
+            'name': 'MN_topo_bonds_break',
+            'description': "Will delete a bond between atoms that already exists based on a distance cutoff, or is selected in the `Selection` input. Leaves the atoms unaffected",
+            'video_url': 'https://imgur.com/n8cTN0k'
         },
         {
             'label': 'Edge Info',

--- a/molecularnodes/ui/node_info.py
+++ b/molecularnodes/ui/node_info.py
@@ -303,6 +303,16 @@ menu_items = {
 
     'topology': [
         {
+            'label': 'Find Bonds',
+            'name': '.MN_bonds_find',
+            'description': "Finds bonds between atoms based on distance. Based on the vdw_radii for each point, finds other points within a certain radius to create a bond to. Does not preserve the index for the points. Does not detect bond type"
+        },
+        {
+            'label': 'Break Bonds',
+            'name': '.MN_bonds_break',
+            'description': "Will delete a bond between atoms that already exists based on a distance cutoff"
+        },
+        {
             'label': 'Edge Info',
             'name': 'MN_topo_edge_info',
             'description': 'Get information for the selected edge, evaluated on the point domain. The "Edge Index" selects the edge from all possible connected edges. Edges are unfortunately stored somewhat randomly. The resulting information is between the evaluating point and the point that the edge is between. Point Index returns -1 if not connected.\n\nIn the video example, cones are instanced on each point where the Edge Index returns a valid connection. The Edge Vector can be used to align the instanced cone along that edge. The length of the edge can be used to scale the cone to the other point. As the "Edge Index" is changed, the selected edge changes. When "Edge Index" == 3, only the atoms with 4 connections are selected, which in this model (1BNA) are just the phosphates.',
@@ -359,19 +369,6 @@ menu_items = {
             'description': 'Returns the index for the atom for each unique group (from res_id) for each point in that group. Allows for example, all atoms in a group to be rotated around the position of the selected atom.\n\nIn the video example, the `atom_name` is used to select an atom within the groups. Each atom\'s position is then offset to that position, showing the group-wise selection.',
             'video_url': 'https://imgur.com/sD3jRTR'
         },
-    ],
-
-    'bonds': [
-        {
-            'label': 'Find Bonds',
-            'name': '.MN_bonds_find',
-            'description': "Finds bonds between atoms based on distance. Based on the vdw_radii for each point, finds other points within a certain radius to create a bond to. Does not preserve the index for the points. Does not detect bond type"
-        },
-        {
-            'label': 'Break Bonds',
-            'name': '.MN_bonds_break',
-            'description': "Will delete a bond between atoms that already exists based on a distance cutoff"
-        }
     ],
 
     'assembly': [

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -325,3 +325,26 @@ def test_compute_backbone(snapshot):
                 f'{node_name}_{output.name}.txt'
 
             )
+
+
+def test_topo_bonds():
+    mol = mn.io.fetch('1BNA', del_solvent=True, style=None).object
+    group = nodes.get_mod(mol).node_group = nodes.new_group()
+
+    # add the node that will break bonds, set the cutoff to 0
+    node_break = nodes.add_custom(group, 'MN_topo_bonds_break')
+    nodes.insert_last_node(group, node=node_break)
+    node_break.inputs['Cutoff'].default_value = 0
+
+    # compare the number of edges before and after deleting them with
+    bonds = mol.data.edges
+    no_bonds = utils.evaluate(mol).data.edges
+    assert len(bonds) > len(no_bonds)
+    assert len(no_bonds) == 0
+
+    # add the node to find the bonds, and ensure the number of bonds pre and post the nodes
+    # are the same (other attributes will be different, but for now this is good)
+    node_find = nodes.add_custom(group, 'MN_topo_bonds_find')
+    nodes.insert_last_node(group, node=node_find)
+    bonds_new = utils.evaluate(mol).data.edges
+    assert len(bonds) == len(bonds_new)


### PR DESCRIPTION
Properly exposes the nodes for finding and removing bonds. Adds documentation and tests for them.

- add bond nodes to topology category
- add videos and tweak bonds break
- add tests for bond nodes
