### PR TITLE
Clean up molecule class

### DIFF
--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -288,35 +288,6 @@ class Molecule(metaclass=ABCMeta):
 
         return assemblies_info
 
-    def __str__(self):
-        return f"Molecule with {len(self.data)} atoms"
-
-    def __repr__(self):
-        return f"Molecule({self.data})"
-
-    def __eq__(self, other):
-        if isinstance(other, Molecule):
-            return self.data == other.data
-        return False
-
-    def __hash__(self):
-        return hash(tuple(self.data))
-
-    def __len__(self):
-        return len(self.object.data.vertices)
-
-    def __getitem__(self, index):
-        return self.get_attribute(index)
-
-    def __setitem__(self, index, value):
-        self.data[index] = value
-
-    def __iter__(self):
-        return iter(self.data)
-
-    def __contains__(self, value):
-        return value in self.data
-
 
 def _create_model(array,
                   name=None,

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -288,6 +288,8 @@ class Molecule(metaclass=ABCMeta):
 
         return assemblies_info
 
+    def __repr__(self) -> str:
+        return f"<Molecule object: {self.name}>"
 
 def _create_model(array,
                   name=None,


### PR DESCRIPTION
Fix Issue: #459

Changes:
- remove template functions, which throw errors
- suggest a __repr__ method, which is especially for notebooks a nice to have

