### PR TITLE
Molecule class

### DIFF
--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -88,27 +88,27 @@ class MoleculeInBlender:
 
 
     
-    #def __setattr__(self, name: str, value: Any) -> None:
-    #    """
-    #    Set attr to the instance of the class, if the attr is in the __slots__, 
-    #    else to the molecule object of the instance.
-    #    """
-#
-    #    if name in self.__slots__:
-    #        object.__setattr__(self, name, value )
-    #    else:
-    #        set_attribute(object=self.molecule, name=name, data=value)
-    #
-    #def __getattr__(self, name):
-    #    """
-    #    Get attr from the instance's obejct of the class, if the attr was not found in the __slots__ by the __getattribute__ method.
-#
-    #    Raises:
-    #    ---
-    #    AttributeError: If the attribute is not found in the instance of the class nor in the molecule object.
-    #    """
-#
-    #    return get_attribute(object=self.molecule, name=name)
+    def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Set attr to the instance of the class, if the attr is in the __slots__, 
+        else to the molecule object of the instance.
+        """
+
+        if name in self.__slots__:
+            object.__setattr__(self, name, value )
+        else:
+            set_attribute(object=self.object, name=name, data=value)
+    
+    def __getattr__(self, name):
+        """
+        Get attr from the instance's obejct of the class, if the attr was not found in the __slots__ by the __getattribute__ method.
+
+        Raises:
+        ---
+        AttributeError: If the attribute is not found in the instance of the class nor in the molecule object.
+        """
+
+        return get_attribute(object=self.object, name=name)
     
     def list_attributes(self, evaluate=False) -> list | None:
         """

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -2,12 +2,15 @@ from typing import Optional, Any, Union, List, Tuple, Dict
 import warnings
 import time
 import numpy as np
+from functools import singledispatchmethod
+
 import biotite.structure as struc
 from biotite import InvalidFileError
 
-import bpy
+import bpy 
 
-from ..io.parse.molecule import Molecule
+from ..io.parse.molecule import MoleculeAtomArray
+from ..io.parse.mda import MDA
 
 from .obj import set_attribute, get_attribute, create_object
 from .nodes import assembly_insert, create_starting_node_tree
@@ -38,9 +41,16 @@ class MoleculeInBlender:
         self.name = name
         self.object = object # würde es gerne von object to molecule umbennen, sodass von namen klarer wird, was es ist
         self.frames = frames
-
+    
+    
+    @singledispatchmethod
     @classmethod
-    def from_molecule(cls, molecule: Molecule, 
+    def from_molecule(cls, molecule, **kwargs):
+        raise NotImplementedError(f"Class {molecule.__class__=} is not registrated")
+    
+    @from_molecule.register
+    @classmethod
+    def _(cls, molecule: MoleculeAtomArray, 
                       style: str = 'spheres', 
                       selection: np.ndarray = None, 
                       build_assembly: bool = False, 
@@ -48,7 +58,7 @@ class MoleculeInBlender:
                       del_solvent: bool= True, 
                       collection : bpy.types.Collection = None, 
                       verbose: bool = False
-                    ) -> 'MoleculeInBlender':
+                    ):
         
         if selection:
             array = molecule[selection]._atoms

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -48,14 +48,6 @@ class MoleculeInBlender:
         if not log:
             log = start_logging(logfile_name=name)
 
-        # if the session already exists, load the existing session
-        if hasattr(bpy.types.Scene, "mda_session"):
-            warnings.warn("The existing mda session is loaded.")
-            log.warning("The existing mda session is loaded.")
-            existing_session = bpy.types.Scene.mda_session
-            self.__dict__ = existing_session.__dict__
-            return
-
         self.name:str = name
         self.object: bpy.types.Object = object #TODO: rename object, so its function is clearer
         self.frames: bpy.types.Collection = frames #TODO: rename frames, so its function is clearer s. Issue #454
@@ -74,6 +66,21 @@ class MoleculeInBlender:
             self._update_style_handler_wrapper()
         )
         self.log.info("MDAnalysis session is initialized.")
+    
+    @classmethod
+    def from_existing_scene(cls, molecule_name = "mda_session"):
+
+        # if the session already exists, load the existing session
+        if not hasattr(bpy.types.Scene, molecule_name):
+            warnings.warn("The existing mda session is loaded.")
+            raise AttributeError("No existing mda session found.")
+        molecule = getattr(bpy.types.Scene, molecule_name)
+
+        molecule.log.warning("The existing mda session is loaded")
+
+        return cls(name=molecule.name, object=molecule.object, frames=molecule.frames, log=molecule.log, in_memory=molecule.in_memory)
+        
+
 
 
     @singledispatchmethod

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -1,0 +1,427 @@
+from typing import Optional, Any, Union, List, Tuple, Dict
+import warnings
+import time
+import numpy as np
+import biotite.structure as struc
+from biotite import InvalidFileError
+
+import bpy
+
+from ..io.parse.molecule import Molecule
+
+from .obj import set_attribute, get_attribute, create_object
+from .nodes import assembly_insert, create_starting_node_tree
+from .obj import evaluated as evaluate, create_object
+from .coll import mn as coll_mn, data as coll_data, frames as coll_frames
+
+from ..data import elements, residues, atom_names, lipophobicity, atom_charge
+from ..color import color_chains
+
+class MoleculeInBlender:
+    """
+    Represents a molecule in Blender.
+
+    Converts a given molecule into a Blender object.
+    Long term goal to use molecule as data twin. So that any changes in molecule will be reflected in blender object.
+    
+    Attributes:
+    ----
+    name (str): Name of the molecule.
+    molecule (bpy.types.Object): 3d object in blender. 
+    frame_collection (bpy.types.Collection) : s. issue #454
+    """
+
+    __slots__ = ["name", "object", "frames"]
+
+    def __init__(self, name : str, object : bpy.types.Object, frames : bpy.types.Collection):
+
+        self.name = name
+        self.object = object # würde es gerne von object to molecule umbennen, sodass von namen klarer wird, was es ist
+        self.frames = frames
+
+    @classmethod
+    def from_molecule(cls, molecule: Molecule, 
+                      style: str = 'spheres', 
+                      selection: np.ndarray = None, 
+                      build_assembly: bool = False, 
+                      centre : bool = False, 
+                      del_solvent: bool= True, 
+                      collection : bpy.types.Collection = None, 
+                      verbose: bool = False
+                    ) -> 'MoleculeInBlender':
+        
+        if selection:
+            array = molecule[selection]._atoms
+        else:
+            array = molecule._atoms
+
+        model, frames = _create_model(
+            array=array,
+            name=molecule.name,
+            centre=centre,
+            del_solvent=del_solvent,
+            style=style,
+            collection=collection,
+            verbose=verbose,
+        )
+
+        #if style:
+        #    create_starting_node_tree(object=model,
+        #                                    coll_frames=frames,
+        #                                    style=style,
+        #                                    )
+
+        #try:
+        #    model['entity_ids'] = molecule.entity_ids
+        #except AttributeError:
+        #    model['entity_ids'] = None
+
+        #try:
+        #    model['biological_assemblies'] = molecule.assemblies()
+        #except InvalidFileError:
+        #    pass
+
+        #if build_assembly and style:
+        #    assembly_insert(model)
+
+        return cls(name=molecule.name, object=model, frames=frames)
+
+
+    
+    #def __setattr__(self, name: str, value: Any) -> None:
+    #    """
+    #    Set attr to the instance of the class, if the attr is in the __slots__, 
+    #    else to the molecule object of the instance.
+    #    """
+#
+    #    if name in self.__slots__:
+    #        object.__setattr__(self, name, value )
+    #    else:
+    #        set_attribute(object=self.molecule, name=name, data=value)
+    #
+    #def __getattr__(self, name):
+    #    """
+    #    Get attr from the instance's obejct of the class, if the attr was not found in the __slots__ by the __getattribute__ method.
+#
+    #    Raises:
+    #    ---
+    #    AttributeError: If the attribute is not found in the instance of the class nor in the molecule object.
+    #    """
+#
+    #    return get_attribute(object=self.molecule, name=name)
+    
+    def list_attributes(self, evaluate=False) -> list | None:
+        """
+        Returns a list of attribute names for the object.
+
+        Parameters
+        ----------
+        evaluate : bool, optional
+            Whether to first evaluate the modifiers on the object before listing the 
+            available attributes.
+
+        Returns
+        -------
+        list[str] | None
+            A list of attribute names if the molecule object exists, None otherwise.
+        """
+        if not self.object:
+            warnings.warn("No object created")
+            return None
+        if evaluate:
+            return list(evaluate(self.object).data.attributes.keys())
+
+        return list(self.object.data.attributes.keys())
+    
+
+def _create_model(array,
+                  name=None,
+                  centre=False,
+                  del_solvent=False,
+                  style='spherers',
+                  collection=None,
+                  world_scale=0.01,
+                  verbose=False
+                  ) -> Tuple[bpy.types.Object, bpy.types.Collection]:
+    import biotite.structure as struc
+    frames = None
+
+    if isinstance(array, struc.AtomArrayStack):
+        if array.stack_depth() > 1:
+            frames = array
+        array = array[0]
+
+    # remove the solvent from the structure if requested
+    if del_solvent:
+        array = array[np.invert(struc.filter_solvent(array))]
+
+    locations = array.coord * world_scale
+
+    centroid = np.array([0, 0, 0])
+    if centre:
+        centroid = struc.centroid(array) * world_scale
+
+
+    # subtract the centroid from all of the positions to localise the molecule on the world origin
+    if centre:
+        locations = locations - centroid
+
+    if not collection:
+        collection = coll_mn()
+
+
+    bonds_array = []
+    bond_idx = []
+
+    if array.bonds:
+        bonds_array = array.bonds.as_array()
+        bond_idx = bonds_array[:, [0, 1]]
+        # the .copy(order = 'C') is to fix a weird ordering issue with the resulting array
+        bond_types = bonds_array[:, 2].copy(order='C')
+
+    mol = create_object(name=name, collection=collection,
+                               vertices=locations, edges=bond_idx)
+
+    # Add information about the bond types to the model on the edge domain
+    # Bond types: 'ANY' = 0, 'SINGLE' = 1, 'DOUBLE' = 2, 'TRIPLE' = 3, 'QUADRUPLE' = 4
+    # 'AROMATIC_SINGLE' = 5, 'AROMATIC_DOUBLE' = 6, 'AROMATIC_TRIPLE' = 7
+    # https://www.biotite-python.org/apidoc/biotite.structure.BondType.html#biotite.structure.BondType
+    if array.bonds:
+        set_attribute(mol, name='bond_type', data=bond_types,
+                             type="INT", domain="EDGE")
+
+    # The attributes for the model are initially defined as single-use functions. This allows
+    # for a loop that attempts to add each attibute by calling the function. Only during this
+    # loop will the call fail if the attribute isn't accessible, and the warning is reported
+    # there rather than setting up a try: except: for each individual attribute which makes
+    # some really messy code.
+
+    # I still don't like this as an implementation, and welcome any cleaner approaches that
+    # anybody might have.
+
+    def att_atomic_number():
+        atomic_number = np.array([
+            elements.get(x, {'atomic_number': -1}).get("atomic_number")
+            for x in np.char.title(array.element)
+        ])
+        return atomic_number
+
+    def att_atom_id():
+        return array.atom_id
+
+    def att_res_id():
+        return array.res_id
+
+    def att_res_name():
+        other_res = []
+        counter = 0
+        id_counter = -1
+        res_names = array.res_name
+        res_ids = array.res_id
+        res_nums = []
+
+        for name in res_names:
+            res_num = residues.get(
+                name, {'res_name_num': -1}).get('res_name_num')
+
+            if res_num == 9999:
+                if res_names[counter - 1] != name or res_ids[counter] != res_ids[counter - 1]:
+                    id_counter += 1
+
+                unique_res_name = str(id_counter + 100) + "_" + str(name)
+                other_res.append(unique_res_name)
+
+                num = np.where(np.isin(np.unique(other_res), unique_res_name))[
+                    0][0] + 100
+                res_nums.append(num)
+            else:
+                res_nums.append(res_num)
+            counter += 1
+
+        mol['ligands'] = np.unique(other_res)
+        return np.array(res_nums)
+
+    def att_chain_id():
+        return np.unique(array.chain_id, return_inverse=True)[1]
+
+    def att_entity_id():
+        return array.entity_id
+
+    def att_b_factor():
+        return array.b_factor
+
+    def att_occupancy():
+        return array.occupancy
+
+    def att_vdw_radii():
+        vdw_radii = np.array(list(map(
+            # divide by 100 to convert from picometres to angstroms which is what all of coordinates are in
+            lambda x: elements.get(
+                x, {'vdw_radii': 100}).get('vdw_radii', 100) / 100,
+            np.char.title(array.element)
+        )))
+        return vdw_radii * world_scale
+
+    def att_atom_name():
+        atom_name = np.array(list(map(
+            lambda x: atom_names.get(x, -1),
+            array.atom_name
+        )))
+
+        return atom_name
+
+    def att_lipophobicity():
+        lipo = np.array(list(map(
+            lambda x, y: lipophobicity.get(x, {"0": 0}).get(y, 0),
+            array.res_name, array.atom_name
+        )))
+
+        return lipo
+
+    def att_charge():
+        charge = np.array(list(map(
+            lambda x, y: atom_charge.get(x, {"0": 0}).get(y, 0),
+            array.res_name, array.atom_name
+        )))
+        return charge
+
+    def att_color():
+        return color_chains(att_atomic_number(), att_chain_id())
+
+    def att_is_alpha():
+        return np.isin(array.atom_name, 'CA')
+
+    def att_is_solvent():
+        return struc.filter_solvent(array)
+
+    def att_is_backbone():
+        """
+        Get the atoms that appear in peptide backbone or nucleic acid phosphate backbones.
+        Filter differs from the Biotite's `struc.filter_peptide_backbone()` in that this
+        includes the peptide backbone oxygen atom, which biotite excludes. Additionally 
+        this selection also includes all of the atoms from the ribose in nucleic acids, 
+        and the other phosphate oxygens.
+        """
+        backbone_atom_names = [
+            'N', 'C', 'CA', 'O',                    # peptide backbone atoms
+            "P", "O5'", "C5'", "C4'", "C3'", "O3'",  # 'continuous' nucleic backbone atoms
+            "O1P", "OP1", "O2P", "OP2",             # alternative names for phosphate O's
+            "O4'", "C1'", "C2'", "O2'"              # remaining ribose atoms
+        ]
+
+        is_backbone = np.logical_and(
+            np.isin(array.atom_name, backbone_atom_names),
+            np.logical_not(struc.filter_solvent(array))
+        )
+        return is_backbone
+
+    def att_is_nucleic():
+        return struc.filter_nucleotides(array)
+
+    def att_is_peptide():
+        aa = struc.filter_amino_acids(array)
+        con_aa = struc.filter_canonical_amino_acids(array)
+
+        return aa | con_aa
+
+    def att_is_hetero():
+        return array.hetero
+
+    def att_is_carb():
+        return struc.filter_carbohydrates(array)
+
+    def att_sec_struct():
+        return array.sec_struct
+
+    # these are all of the attributes that will be added to the structure
+    # TODO add capcity for selection of particular attributes to include / not include to potentially
+    # boost performance, unsure if actually a good idea of not. Need to do some testing.
+    attributes = (
+        {'name': 'res_id',          'value': att_res_id,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'res_name',        'value': att_res_name,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'atomic_number',   'value': att_atomic_number,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'b_factor',        'value': att_b_factor,
+            'type': 'FLOAT',   'domain': 'POINT'},
+        {'name': 'occupancy',       'value': att_occupancy,
+            'type': 'FLOAT',   'domain': 'POINT'},
+        {'name': 'vdw_radii',       'value': att_vdw_radii,
+            'type': 'FLOAT',   'domain': 'POINT'},
+        {'name': 'chain_id',        'value': att_chain_id,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'entity_id',       'value': att_entity_id,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'atom_id',         'value': att_atom_id,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'atom_name',       'value': att_atom_name,
+            'type': 'INT',     'domain': 'POINT'},
+        {'name': 'lipophobicity',   'value': att_lipophobicity,
+            'type': 'FLOAT',   'domain': 'POINT'},
+        {'name': 'charge',          'value': att_charge,
+            'type': 'FLOAT',   'domain': 'POINT'},
+        {'name': 'Color',           'value': att_color,
+            'type': 'FLOAT_COLOR',   'domain': 'POINT'},
+
+        {'name': 'is_backbone',     'value': att_is_backbone,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'is_alpha_carbon', 'value': att_is_alpha,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'is_solvent',      'value': att_is_solvent,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'is_nucleic',      'value': att_is_nucleic,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'is_peptide',      'value': att_is_peptide,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'is_hetero',       'value': att_is_hetero,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'is_carb',         'value': att_is_carb,
+            'type': 'BOOLEAN', 'domain': 'POINT'},
+        {'name': 'sec_struct',      'value': att_sec_struct,
+            'type': 'INT',     'domain': 'POINT'}
+    )
+
+    # assign the attributes to the object
+    for att in attributes:
+        if verbose:
+            start = time.process_time()
+        try:
+            set_attribute(mol, name=att['name'], data=att['value'](
+            ), type=att['type'], domain=att['domain'])
+            if verbose:
+                print(
+                    f'Added {att["name"]} after {time.process_time() - start} s')
+        except:
+            if verbose:
+                warnings.warn(f"Unable to add attribute: {att['name']}")
+                print(
+                    f'Failed adding {att["name"]} after {time.process_time() - start} s')
+
+    coll_frames = None
+    if frames:
+
+        coll_frames = coll_frames(mol.name, parent=coll_data())
+        for i, frame in enumerate(frames):
+            frame = create_object(
+                name=mol.name + '_frame_' + str(i),
+                collection=coll_frames,
+                vertices=frame.coord * world_scale - centroid
+            )
+            # TODO if update_attribute
+            # bl.obj.set_attribute(attribute)
+
+    mol.mn['molcule_type'] = 'pdb'
+
+    # add custom properties to the actual blender object, such as number of chains, biological assemblies etc
+    # currently biological assemblies can be problematic to holding off on doing that
+    try:
+        mol['chain_ids'] = list(np.unique(array.chain_id))
+    except AttributeError:
+        mol['chain_ids'] = None
+        warnings.warn('No chain information detected.')
+
+    return mol, coll_frames
+
+
+    

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -43,7 +43,7 @@ class MoleculeInBlender:
 
     __slots__ = ["name", "object", "frames", "universe_reps", "atom_reps", "in_memory", "log"]
 
-    def __init__(self, name : str, object : bpy.types.Object, frames : bpy.types.Collection, log, in_memory : bool = False, ):
+    def __init__(self, name : str, object : bpy.types.Object, frames : bpy.types.Collection, log, in_memory : bool = False, universe_reps : Dict = dict(), atom_reps : Dict = dict()):
 
         if not log:
             log = start_logging(logfile_name=name)
@@ -67,6 +67,17 @@ class MoleculeInBlender:
         )
         self.log.info("MDAnalysis session is initialized.")
     
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "object": self.object,
+            "frames": self.frames,
+            "universe_reps": self.universe_reps,
+            "atom_reps": self.atom_reps,
+            "in_memory": self.in_memory,
+            "log": self.log
+        }
+    
     @classmethod
     def from_existing_scene(cls, molecule_name = "mda_session"):
 
@@ -74,11 +85,12 @@ class MoleculeInBlender:
         if not hasattr(bpy.types.Scene, molecule_name):
             warnings.warn("The existing mda session is loaded.")
             raise AttributeError("No existing mda session found.")
+        
         molecule = getattr(bpy.types.Scene, molecule_name)
 
         molecule.log.warning("The existing mda session is loaded")
 
-        return cls(name=molecule.name, object=molecule.object, frames=molecule.frames, log=molecule.log, in_memory=molecule.in_memory)
+        return cls(**molecule.to_dict())
         
 
 

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -93,6 +93,8 @@ class MoleculeInBlender:
         """
         Set attr to the instance of the class, if the attr is in the __slots__, 
         else to the molecule object of the instance.
+
+        Warning: Does not work as it should.
         """
 
         if name in self.__slots__:

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -86,7 +86,8 @@ class MoleculeInBlender:
 
         return cls(name=molecule.name, object=model, frames=frames)
 
-
+    def __repr__(self) -> str:
+        return f"<MoleculeInBlender: {self.name}>"
     
     def __setattr__(self, name: str, value: Any) -> None:
         """

--- a/molecularnodes/blender/molecule.py
+++ b/molecularnodes/blender/molecule.py
@@ -65,24 +65,24 @@ class MoleculeInBlender:
             verbose=verbose,
         )
 
-        #if style:
-        #    create_starting_node_tree(object=model,
-        #                                    coll_frames=frames,
-        #                                    style=style,
-        #                                    )
+        if style:
+            create_starting_node_tree(object=model,
+                                      coll_frames=frames,
+                                      style=style,
+                                    )
+            
+        try:
+            model['entity_ids'] = molecule.entity_ids
+        except AttributeError:
+            model['entity_ids'] = None
 
-        #try:
-        #    model['entity_ids'] = molecule.entity_ids
-        #except AttributeError:
-        #    model['entity_ids'] = None
+        try:
+            model['biological_assemblies'] = molecule.assemblies()
+        except InvalidFileError:
+            pass
 
-        #try:
-        #    model['biological_assemblies'] = molecule.assemblies()
-        #except InvalidFileError:
-        #    pass
-
-        #if build_assembly and style:
-        #    assembly_insert(model)
+        if build_assembly and style:
+            assembly_insert(model)
 
         return cls(name=molecule.name, object=model, frames=frames)
 

--- a/molecularnodes/blender/obj.py
+++ b/molecularnodes/blender/obj.py
@@ -20,7 +20,8 @@ TYPES = {key: AttributeTypeInfo(*values) for key, values in {
     'INT': ('value', int, 1),
     'FLOAT': ('value', float, 1),
     'INT32_2D': ('value', int, 2),
-    'BOOLEAN': ('value', bool, 1)
+    'BOOLEAN': ('value', bool, 1),
+    'BOOL': ('value', bool, 1),
 }.items()}
 
 

--- a/molecularnodes/io/parse/__init__.py
+++ b/molecularnodes/io/parse/__init__.py
@@ -9,5 +9,5 @@ from .pdb import PDB
 from .cellpack import CellPack
 from .star import StarFile
 from .sdf import SDF
-from .mda import MDAnalysisSession
+from .mda import MDAnalysisSession, MDA
 from .mrc import MRC

--- a/molecularnodes/io/parse/mda.py
+++ b/molecularnodes/io/parse/mda.py
@@ -1,6 +1,3 @@
-import bpy
-from bpy.app.handlers import persistent
-
 try:
     import MDAnalysis as mda
 except ImportError:
@@ -34,6 +31,9 @@ from ...blender import (
 from ...utils import lerp
 from .molecule import Molecule, AtomAttribute
 
+import bpy
+from bpy.app.handlers import persistent
+
 class MDAnalysisSession:
     """mock class in order that the module not breaks"""
     pass
@@ -58,6 +58,10 @@ class MDA(Molecule): # consistent namingy
 
     def __len__(self) -> int:
         return len(self._atoms)
+    
+    @property
+    def universe(self) -> mda.Universe:
+        return self._atoms.universe
     
     @staticmethod
     def bool_selection(_atoms, selection) -> np.ndarray:
@@ -119,7 +123,7 @@ class MDA(Molecule): # consistent namingy
 
     @property
     def res_id(self) -> np.ndarray:
-        return self.ag.resnums
+        return self._atoms.resnums
 
     @property
     def res_name(self) -> np.ndarray:

--- a/molecularnodes/io/parse/mda.py
+++ b/molecularnodes/io/parse/mda.py
@@ -35,31 +35,16 @@ from ...utils import lerp
 from .molecule import Molecule, AtomAttribute
 
 class MDAnalysisSession:
+    """mock class in order that the module not breaks"""
     pass
 
-class MDA(Molecule):
+class MDA(Molecule): # consistent namingy
     """
     "sibling" class MoleculeAtomArray
     """
 
-    def __init__(self,atoms: mda.AtomGroup, name="MDAnalysisSession", world_scale: float = 0.01, style:str= "vdw", in_memory: bool = False, **kwargs):
-        """
-        Initialize a MDAnalysisSession.
+    def __init__(self, atoms: mda.AtomGroup, name="MDAnalysisSession", world_scale: float = 0.01, style:str= "vdw", in_memory: bool = False, **kwargs):
 
-        During saving, the session is pickled/serialized to the same
-        location as the blend file with the extension .mda_session.
-        The session is loaded when Blender is restarted.
-
-        #TODO: Is it possible to start blender only when
-        #a session is initialized? (Probably not for now)
-
-        Parameters:
-        ----------
-        world_scale : float, optional
-            The scaling factor for the world coordinates (default: 0.01).
-        memory : bool, optional
-            Whether the old import is used (default: False).
-        """
         log = start_logging(logfile_name=name)
         if not HAS_mda:
             raise ImportError("MDAnalysis is not installed.")

--- a/molecularnodes/io/parse/mda.py
+++ b/molecularnodes/io/parse/mda.py
@@ -69,7 +69,26 @@ class MDA(Molecule): # consistent namingy
 
     @property
     def positions(self) -> np.ndarray:
-        return self._atoms.positions * self.world_scale
+        return self._atoms.positions
+    
+    @property
+    def coord(self) -> np.ndarray:
+        return self.positions
+    
+
+    def select_atoms(self, selection: str) -> "MDA":
+
+        if not isinstance(selection, (str, dict)):
+            raise ValueError(f"Selection must be a string or a dictionary not {type(selection)=}.")
+
+        # if multiple selections are given, apply all and save their indices, which idicate their positions in the original AtomGroup
+        # after that merge the indices and return the new MDA Class
+
+        # if a single selection is given, apply it, and return the new MDA Class from their indices
+
+        ag = self.universe.select_atoms(selection)
+        
+        return MDA(name=self.name, atoms=ag, world_scale=self.world_scale, style=self.style, in_memory=self.in_memory)
 
     @property
     def bonds(self) -> List[List[int]]:

--- a/molecularnodes/io/parse/mda.py
+++ b/molecularnodes/io/parse/mda.py
@@ -32,117 +32,65 @@ from ...blender import (
     coll, obj, nodes
 )
 from ...utils import lerp
+from .molecule import Molecule, AtomAttribute
 
+class MDAnalysisSession:
+    pass
 
-class AtomGroupInBlender:
-    def __init__(self,
-                 ag: mda.AtomGroup,
-                 style: str = "vdw",
-                 world_scale: float = 0.01):
+class MDA(Molecule):
+    """
+    "sibling" class MoleculeAtomArray
+    """
+
+    def __init__(self,atoms: mda.AtomGroup, name="MDAnalysisSession", world_scale: float = 0.01, style:str= "vdw", in_memory: bool = False, **kwargs):
         """
-        AtomGroup in Blender.
-        It will be dynamically updated when the frame changes or
-        when the topology of the underlying atoms changes.
+        Initialize a MDAnalysisSession.
+
+        During saving, the session is pickled/serialized to the same
+        location as the blend file with the extension .mda_session.
+        The session is loaded when Blender is restarted.
+
+        #TODO: Is it possible to start blender only when
+        #a session is initialized? (Probably not for now)
 
         Parameters:
         ----------
-        ag : MDAnalysis.AtomGroup
-            The atomgroup to add in the scene.
-        style : str, optional
-            The style of the atoms (default: "vdw").
         world_scale : float, optional
             The scaling factor for the world coordinates (default: 0.01).
-
-        Attributes:
-        ----------
-        ag : MDAnalysis.AtomGroup
-            The atomgroup to add in the scene.
-        world_scale : float
-            The scaling factor for the world coordinates.
-        style : str
-            The style of the atoms in Blender.
-        n_atoms : int
-            The number of atoms in the atomgroup.
-        positions : np.ndarray
-            The positions of the atoms in the atomgroup.
-        elements : list
-            The elements of the atoms in the atomgroup.
-            If the elements are not available,
-            then the elements are guessed from the atom names.
-        atomic_number : np.ndarray
-            The atomic numbers of the atoms in the atomgroup
-            based on their elements.
-        vdw_radii : np.ndarray
-            The van der Waals radii of the atoms in the atomgroup
-            based on their elements.
-        res_id : np.ndarray
-            The residue ids of the atoms in the atomgroup.
-        res_name : np.ndarray
-            The residue names of the atoms in the atomgroup.
-        res_num : np.ndarray
-            The residue numbers of the atoms in the atomgroup
-            The residue numbers are based on the residue names
-            and are stored in the data.residues dictionary.
-        b_factor : np.ndarray
-            The B-factors of the atoms in the atomgroup.
-        chain_id : np.ndarray
-            The chain ids of the atoms in the atomgroup.
-        chain_id_num : np.ndarray
-            The chain id numbers of the atoms in the atomgroup.
-            It is the index of the unique chain ids.
-        atom_type : np.ndarray
-            The atom types of the atoms in the atomgroup.
-        atom_type_unique : np.ndarray
-            The unique atom types of the atoms in the atomgroup.
-        atom_type_num : np.ndarray
-            The atom type numbers of the atoms in the atomgroup.
-            It is the index of the unique atom types.
-        is_nucleic : np.ndarray
-            Whether the atoms in the atomgroup are nucleic.
-        is_peptide : np.ndarray
-            Whether the atoms in the atomgroup are peptide.
-        is_backbone : np.ndarray
-            Whether the atoms in the atomgroup are backbone.
-        is_alpha_carbon : np.ndarray
-            Whether the atoms in the atomgroup are alpha carbon.
-        is_solvent : np.ndarray
-            Whether the atoms in the atomgroup are solvent.
+        memory : bool, optional
+            Whether the old import is used (default: False).
         """
+        log = start_logging(logfile_name=name)
         if not HAS_mda:
             raise ImportError("MDAnalysis is not installed.")
-        self.ag = ag
+            exit(1)
+
+        super().__init__(name=name, atoms=atoms, **kwargs)
+
         self.world_scale = world_scale
         self.style = style
+        self.in_memory = in_memory
 
-    @property
-    def n_atoms(self) -> int:
-        return self.ag.n_atoms
-
-    @property
-    def style(self) -> str:
-        return self._style
-
-    @style.setter
-    def style(self, style):
-        self._style = style
-
+    def __len__(self) -> int:
+        return len(self._atoms)
+    
     @staticmethod
-    def bool_selection(ag, selection) -> np.ndarray:
-        return np.isin(ag.ix, ag.select_atoms(selection).ix).astype(bool)
+    def bool_selection(_atoms, selection) -> np.ndarray:
+        return np.isin(_atoms.ix, _atoms.select_atoms(selection).ix).astype(bool)
 
     @property
     def positions(self) -> np.ndarray:
-        return self.ag.positions * self.world_scale
+        return self._atoms.positions * self.world_scale
 
     @property
     def bonds(self) -> List[List[int]]:
-        if hasattr(self.ag, "bonds"):
-            bond_indices = self.ag.bonds.indices
-            atm_indices = self.ag.indices
+        if hasattr(self._atoms, "bonds"):
+            bond_indices = self._atoms.bonds.indices
+            atm_indices = self._atoms.indices
             bond_filtering = np.all(np.isin(bond_indices, atm_indices), axis=1)
             bond_indices = bond_indices[bond_filtering]
 
-            index_map = {index: i for i, index in enumerate(self.ag.indices)}
+            index_map = {index: i for i, index in enumerate(self._atoms.indices)}
 
             bonds = [[index_map[bond[0]], index_map[bond[1]]]
                      for bond in bond_indices]
@@ -153,7 +101,7 @@ class AtomGroupInBlender:
     @property
     def elements(self) -> List[str]:
         try:
-            elements = self.ag.elements.tolist()
+            elements = self._atoms.elements.tolist()
         except:
             try:
                 elements = [
@@ -161,11 +109,11 @@ class AtomGroupInBlender:
                     "SC" if x.startswith("SC") else
                     "GL" if x.startswith("GL") else
                     "CD" if x.startswith("D") else
-                    mda.topology.guessers.guess_atom_element(x) for x in self.ag.atoms.names
+                    mda.topology.guessers.guess_atom_element(x) for x in self._atoms.atoms.names
                 ]
 
             except:
-                elements = ['X'] * self.ag.n_atoms
+                elements = ['X'] * self._atoms.n_atoms
         return elements
 
     @property
@@ -190,7 +138,7 @@ class AtomGroupInBlender:
 
     @property
     def res_name(self) -> np.ndarray:
-        return np.array(list(map(lambda x: x[0:3], self.ag.resnames)))
+        return np.array(list(map(lambda x: x[0:3], self._atoms.resnames)))
 
     @property
     def res_num(self) -> np.ndarray:
@@ -202,17 +150,17 @@ class AtomGroupInBlender:
 
     @property
     def b_factor(self) -> np.ndarray:
-        if hasattr(self.ag, "tempfactors"):
-            return self.ag.tempfactors
+        if hasattr(self._atoms, "tempfactors"):
+            return self._atoms.tempfactors
         else:
-            return np.zeros(self.ag.n_atoms)
+            return np.zeros(self._atoms.n_atoms)
 
     @property
     def chain_id(self) -> np.ndarray:
-        if hasattr(self.ag, "chainIDs"):
-            return self.ag.chainIDs
+        if hasattr(self._atoms, "chainIDs"):
+            return self._atoms.chainIDs
         else:
-            return np.zeros(self.ag.n_atoms)
+            return np.zeros(self._atoms.n_atoms)
 
     @property
     def chain_ids(self) -> np.ndarray:
@@ -226,7 +174,7 @@ class AtomGroupInBlender:
 
     @property
     def atom_type(self) -> np.ndarray:
-        return self.ag.types
+        return self._atoms.types
 
     @property
     def atom_type_unique(self) -> np.ndarray:
@@ -240,41 +188,41 @@ class AtomGroupInBlender:
 
     @property
     def atom_name(self) -> np.ndarray:
-        if hasattr(self.ag, "names"):
-            return self.ag.names
+        if hasattr(self._atoms, "names"):
+            return self._atoms.names
         else:
-            return np.zeros(self.ag.n_atoms)
+            return np.zeros(self._atoms.n_atoms)
 
     @property
     def atom_name_num(self) -> np.ndarray:
-        if hasattr(self.ag, "names"):
+        if hasattr(self._atoms, "names"):
             return np.array(list(map(lambda x: data.atom_names.get(x, -1), self.atom_name)))
         else:
-            return np.repeat(-1, self.ag.n_atoms)
+            return np.repeat(-1, self._atoms.n_atoms)
 
     @property
     def is_nucleic(self) -> np.ndarray:
-        return self.bool_selection(self.ag, "nucleic")
+        return self.bool_selection(self._atoms, "nucleic")
 
     @property
     def is_peptide(self) -> np.ndarray:
-        return self.bool_selection(self.ag, "protein or (name BB SC*)")
+        return self.bool_selection(self._atoms, "protein or (name BB SC*)")
 
     @property
     def is_lipid(self) -> np.ndarray:
-        return np.isin(self.ag.resnames, data.lipid_names)
+        return np.isin(self._atoms.resnames, data.lipid_names)
 
     @property
     def is_backbone(self) -> np.ndarray:
-        return self.bool_selection(self.ag, "backbone or nucleicbackbone or name BB")
+        return self.bool_selection(self._atoms, "backbone or nucleicbackbone or name BB")
 
     @property
     def is_alpha_carbon(self) -> np.ndarray:
-        return self.bool_selection(self.ag, "name CA or name BB")
+        return self.bool_selection(self._atoms, "name CA or name BB")
 
     @property
     def is_solvent(self) -> np.ndarray:
-        return self.bool_selection(self.ag, "name OW or name HW1 or name HW2 or resname W or resname PW")
+        return self.bool_selection(self._atoms, "name OW or name HW1 or name HW2 or resname W or resname PW")
 
     @property
     def _attributes_2_blender(self):
@@ -353,581 +301,6 @@ class AtomGroupInBlender:
                 "domain": "POINT",
             },
         }
-
-
-class MDAnalysisSession:
-    """
-    The MDAnalysis session.
-
-    The MDAnalysis session is the main class that stores the
-    MDAnalysis data in Blender.
-    It is a singleton class that is initialized when the first
-    MDAnalysis data is loaded in Blender.
-    The MDAnalysis session is loaded when Blender is restarted.
-    The MDAnalysis session is updated when the frame changes.
-    When a Blender file is saved, the MDAnalysis session will be
-    dumped (with pickle) to the same place as the Blender file
-    with .mda_session extension.
-
-    Parameters:
-    ----------
-    world_scale : float, optional
-        The scaling factor for the world coordinates (default: 0.01).
-
-    Attributes:
-    ----------
-    world_scale : float
-        The scaling factor for the world coordinates.
-    universe_reps : dict
-        A dictionary of the universes in the session.
-    atom_reps : dict
-        A dictionary of the atom styles in the session.
-    rep_names : list
-        A list of the names of the styles in the session.
-
-    Methods:
-    -------
-    show(atoms, style, selection, name, custom_selections, frame_offset)
-        Display an `MDAnalysis.Universe` or `MDAnalysis.Atomgroup` in Blender.
-    in_memory(atoms, style, selection, name, custom_selections)
-        Display an `MDAnalysis.Universe` or `MDAnalysis.Atomgroup` in Blender by loading all the
-        frames as individual objects. Animation depends on the machinery inside geometric node.
-    transfer_to_memory(start, stop, step, verbose, **kwargs)
-        Transfer the trajectories in the session to memory.
-    """
-
-    def __init__(self, world_scale: float = 0.01, in_memory: bool = False):
-        """
-        Initialize a MDAnalysisSession.
-
-        During saving, the session is pickled/serialized to the same
-        location as the blend file with the extension .mda_session.
-        The session is loaded when Blender is restarted.
-
-        #TODO: Is it possible to start blender only when
-        #a session is initialized? (Probably not for now)
-
-        Parameters:
-        ----------
-        world_scale : float, optional
-            The scaling factor for the world coordinates (default: 0.01).
-        memory : bool, optional
-            Whether the old import is used (default: False).
-        """
-        log = start_logging(logfile_name="mda")
-        if not HAS_mda:
-            raise ImportError("MDAnalysis is not installed.")
-
-        # if the session already exists, load the existing session
-        if hasattr(bpy.types.Scene, "mda_session"):
-            warnings.warn("The existing mda session is loaded.")
-            log.warning("The existing mda session is loaded.")
-            existing_session = bpy.types.Scene.mda_session
-            self.__dict__ = existing_session.__dict__
-            return
-
-        self.world_scale = world_scale
-        self.universe_reps = {}
-        self.atom_reps = {}
-        self.rep_names = []
-
-        if in_memory:
-            return
-        bpy.types.Scene.mda_session = self
-        bpy.app.handlers.frame_change_post.append(
-            self._update_trajectory_handler_wrapper()
-        )
-        bpy.app.handlers.depsgraph_update_pre.append(
-            self._update_style_handler_wrapper()
-        )
-        log.info("MDAnalysis session is initialized.")
-
-    @property
-    def universe(self) -> mda.Universe:
-        """
-        The universe of the current active object.
-        If the current active object is not an atom style,
-        then the first atom style is used.
-        """
-        name = bpy.context.view_layer.objects.active.name
-        try:
-            return self.universe_reps[name]["universe"]
-        except KeyError:
-            return self.universe_reps[self.rep_names[0]]["universe"]
-
-    def show(
-        self,
-        atoms: Union[mda.Universe, mda.AtomGroup],
-        style: str = "vdw",
-        selection: str = "all",
-        name: str = "atoms",
-        custom_selections: Dict[str, str] = {},
-        frame_mapping: np.ndarray = None,
-        subframes: int = 0,
-        in_memory: bool = False
-    ):
-        """
-        Display an `MDAnalysis.Universe` or
-       `MDAnalysis.Atomgroup` in Blender.
-
-        Parameters:
-        ----------
-        atoms : MDAnalysis.Universe or MDAnalysis.Atomgroup
-            The universe to load into blender.
-        style : str, optional
-            The style to represent the atoms inside of Blender
-            (default: "vdw").
-        selection : str, optional
-            The selection string for atom filtering
-            (default: "all").
-            Uses MDAnalysis selection syntax.
-        name : str, optional
-            The name of the default atoms
-            (default: "atoms").
-        custom_selections : dict, optional
-            A dictionary of custom selections for atom filtering with
-            {'name' : 'selection string'}
-            (default: {}).
-            Uses MDAnalysis selection syntax.
-        frame_mapping : np.ndarray, optional
-            A mapping from the frame indices in the Blender frame indices.
-            for example a frame_mapping of [0, 0, 1, 1, 2, 3] will map
-            the 1st frame (index 0) in the trajectory to the 1st and 2nd frames
-            in Blender and so on.
-            Note a subframes other than 1 will expand the frame_mapping from its
-            original length to (subframes + 1) * original length.
-            (default: None) which will map the frames in the trajectory
-            to the frames in Blender one-to-one.
-        subframes : int, optional
-            The number of subframes to interpolate between each frame.
-            (default: 0).
-        in_memory : bool, optional
-            Whether load the display in Blender by loading all the
-            frames as individual objects.
-            (default: False)
-        """
-        log = start_logging(logfile_name="mda")
-        if in_memory:
-            mol_object = self.in_memory(
-                atoms=atoms,
-                style=style,
-                selection=selection,
-                name=name,
-                custom_selections=custom_selections
-            )
-            if frame_mapping is not None:
-                warnings.warn("Custom frame_mapping not supported"
-                              "when in_memory is on.")
-            if subframes != 0:
-                warnings.warn("Custom subframes not supported"
-                              "when in_memory is on.")
-            log.info(f"{atoms} is loaded in memory.")
-            return mol_object
-        if isinstance(atoms, mda.Universe):
-            atoms = atoms.select_atoms(selection)
-
-        universe = atoms.universe
-
-        # if any frame_mapping is out of range, then raise an error
-        if frame_mapping and (len(frame_mapping) > universe.trajectory.n_frames):
-            raise ValueError("one or more mapping values are"
-                             "out of range for the trajectory")
-
-        mol_object = self._process_atomgroup(
-            ag=atoms,
-            frame_mapping=frame_mapping,
-            subframes=subframes,
-            name=name,
-            style=style,
-            return_object=True)
-
-        # add the custom selections if they exist
-        for sel_name, sel in custom_selections.items():
-            try:
-                ag = universe.select_atoms(sel)
-                if ag.n_atoms == 0:
-                    raise ValueError("Selection is empty")
-                self._process_atomgroup(
-                    ag=ag,
-                    frame_mapping=frame_mapping,
-                    subframes=subframes,
-                    name=sel_name,
-                    style=style,
-                    return_object=False
-                )
-            except ValueError:
-                warnings.warn(
-                    "Unable to add custom selection: {}".format(name))
-
-        bpy.context.view_layer.objects.active = mol_object
-        log.info(f"{atoms} is loaded.")
-        return mol_object
-
-    def in_memory(
-        self,
-        atoms: Union[mda.Universe, mda.AtomGroup],
-        style: str = "vdw",
-        selection: str = "all",
-        name: str = "atoms",
-        custom_selections: Dict[str, str] = {},
-        node_setup: bool = True
-    ):
-        """
-        Display an `MDAnalysis.Universe` or
-        `MDAnalysis.Atomgroup` in Blender by loading all the
-        frames as individual objects. Animation depends on the machinery inside geometric node.
-
-        Parameters:
-        ----------
-        atoms : MDAnalysis.Universe or MDAnalysis.Atomgroup
-            The universe to load into blender.
-        style : str, optional
-            The style used to represent the atoms inside of Blender
-            (default: "vdw").
-        selection : str, optional
-            The selection string for atom filtering
-            (default: "all").
-            Uses MDAnalysis selection syntax.
-        name : str, optional
-            The name of the default atoms
-            (default: "atoms").
-        custom_selections : dict, optional
-            A dictionary of custom selections for atom filtering with
-            {'name' : 'selection string'}
-            (default: {}).
-            Uses MDAnalysis selection syntax.
-        node_setup : bool
-            Whether to add the node tree for the atomgroup. Default: True
-        """
-        if isinstance(atoms, mda.Universe):
-            atoms = atoms.select_atoms(selection)
-
-        universe = atoms.universe
-
-        mol_object = self._process_atomgroup(
-            ag=atoms,
-            name=name,
-            style=style,
-            node_setup=False,
-            return_object=True,
-        )
-
-        for sel_name, sel in custom_selections.items():
-            obj.set_attribute(
-                object=mol_object,
-                name=sel_name,
-                data=AtomGroupInBlender.bool_selection(atoms, sel),
-                type="BOOLEAN",
-                domain="POINT",
-            )
-
-        coll_frames = coll.frames(name)
-
-        # TODO: refractor it as a general feature
-        add_occupancy = True
-        for ts in universe.trajectory:
-            frame = obj.create_object(
-                name=name + "_frame_" + str(ts.frame),
-                collection=coll_frames,
-                vertices=atoms.positions * self.world_scale,
-            )
-            # adds occupancy data to each frame if it exists
-            # This is mostly for people who want to store frame-specific information in the
-            # b_factor but currently neither biotite nor MDAnalysis give access to frame-specific
-            # b_factor information. MDAnalysis gives frame-specific access to the `occupancy`
-            # so currently this is the only method to get frame-specific data into MN
-            # for more details: https://github.com/BradyAJohnston/MolecularNodes/issues/128
-            if add_occupancy:
-                try:
-                    obj.set_attribute(frame, "occupancy", ts.data["occupancy"])
-                except:
-                    add_occupancy = False
-
-        # disable the frames collection from the viewer
-        bpy.context.view_layer.layer_collection.children[coll.mn().name].children[
-            coll_frames.name
-        ].exclude = True
-
-        if node_setup:
-            nodes.create_starting_node_tree(
-                object=mol_object,
-                coll_frames=coll_frames,
-                style=style,
-            )
-
-        bpy.context.view_layer.objects.active = mol_object
-
-        return mol_object
-
-    def transfer_to_memory(
-        self, start=None, stop=None, step=None, verbose=False, **kwargs
-    ):
-        """
-        Transfer the trajectories in the session to memory.
-        This is an alternative way to make sure the blender session is
-        independent of the original trajectory file.
-
-        Parameters:
-        ----------
-        start : int, optional
-            The first frame to transfer (default: None).
-            If None, then the first frame of the trajectory is used.
-        stop : int, optional
-            The last frame to transfer (default: None).
-            If None, then the last frame of the trajectory is used.
-        step : int, optional
-            The step between frames (default: None).
-            If None, then the step is 1.
-        verbose : bool, optional
-            Whether to print the progress (default: False).
-        """
-        log = start_logging(logfile_name="mda")
-        warnings.warn(
-            "The trajectories in this session \n"
-            "is transferred to memory. \n"
-            "It is different from the in_memory loading \n"
-            "because it uses the MemoryReader in MDAnalysis. \n"
-            "instead of loading all the frames as individual objects. \n"
-            "in Blender. \n"
-        )
-
-        for rep_name in self.rep_names:
-            universe = self.universe_reps[rep_name]["universe"]
-            universe.transfer_to_memory(
-                start=start, stop=stop, step=step, verbose=verbose, **kwargs
-            )
-        log.info("The trajectories in this session is transferred to memory.")
-
-    def _process_atomgroup(
-        self,
-        ag,
-        frame_mapping=None,
-        subframes=0,
-        name="atoms",
-        style="vdw",
-        node_setup=True,
-        return_object=False,
-    ):
-        """
-        process the atomgroup in the Blender scene.
-
-        Parameters:
-        ----------
-        ag : MDAnalysis.AtomGroup
-            The atomgroup to add in the scene.
-        frame_mapping : np.ndarray
-            The frame mapping for the trajectory in Blender frame indices. Default: None
-        subframes : int
-            The number of subframes to interpolate between each frame.
-        name : str
-            The name of the atomgroup. Default: 'atoms'
-        style : str
-            The style of the atoms. Default: 'vdw'
-        node_setup : bool
-            Whether to add the node tree for the atomgroup. Default: True
-        return_object : bool
-            Whether to return the blender object or not. Default: False
-        """
-        ag_blender = AtomGroupInBlender(
-            ag=ag,
-            style=style,
-            world_scale=self.world_scale
-        )
-        # create the initial model
-        mol_object = obj.create_object(
-            name=name,
-            collection=coll.mn(),
-            vertices=ag_blender.positions,
-            edges=ag_blender.bonds,
-        )
-
-        # add the attributes for the model in blender
-        for att_name, att in ag_blender._attributes_2_blender.items():
-            obj.set_attribute(
-                mol_object, att_name, att["value"], att["type"], att["domain"]
-            )
-        mol_object['chain_ids'] = ag_blender.chain_ids
-        mol_object['atom_type_unique'] = ag_blender.atom_type_unique
-        mol_object.mn['subframes'] = subframes
-        mol_object.mn['molecule_type'] = 'md'
-
-        # add the atomgroup to the session
-        # the name of the atomgroup may be different from
-        # the input name because of the uniqueness requirement
-        # of the blender object name.
-        # instead, the name generated by blender is used.
-        if mol_object.name != name:
-            warnings.warn(
-                "The name of the object is changed to {} because {} is already used.".format(
-                    mol_object.name, name
-                )
-            )
-
-        self.atom_reps[mol_object.name] = ag_blender
-        self.universe_reps[mol_object.name] = {
-            "universe": ag.universe,
-            "frame_mapping": frame_mapping,
-        }
-        self.rep_names.append(mol_object.name)
-
-        # for old import, the node tree is added all at once
-        # in the end of in_memory
-        if node_setup:
-            nodes.create_starting_node_tree(
-                object=mol_object,
-                style=style,
-            )
-
-        if return_object:
-            return mol_object
-
-    @persistent
-    def _update_trajectory(self, frame):
-        """
-        The function that will be called when the frame changes.
-        It will update the positions and selections of the atoms in the scene.
-        """
-        for rep_name in self.rep_names:
-            universe = self.universe_reps[rep_name]["universe"]
-            frame_mapping = self.universe_reps[rep_name]["frame_mapping"]
-            subframes = bpy.data.objects[rep_name].mn['subframes']
-
-            if frame < 0:
-                continue
-
-            if frame_mapping:
-                # add the subframes to the frame mapping
-                frame_map = np.repeat(frame_mapping, subframes + 1)
-                # get the current and next frames
-                frame_a = frame_map[frame]
-                frame_b = frame_map[frame + 1]
-
-            else:
-                # get the initial frame
-                if subframes == 0:
-                    frame_a = frame
-                else:
-                    frame_a = int(frame / (subframes + 1))
-
-                # get the next frame
-                frame_b = frame_a + 1
-
-            if frame_a >= universe.trajectory.n_frames:
-                continue
-
-            ag_rep = self.atom_reps[rep_name]
-            mol_object = bpy.data.objects[rep_name]
-
-            # set the trajectory at frame_a
-            universe.trajectory[frame_a]
-
-            if subframes > 0:
-                fraction = frame % (subframes + 1) / (subframes + 1)
-
-                # get the positions for the next frame
-                locations_a = ag_rep.positions
-
-                if frame_b < universe.trajectory.n_frames:
-                    universe.trajectory[frame_b]
-                locations_b = ag_rep.positions
-
-                # interpolate between the two sets of positions
-                locations = lerp(locations_a, locations_b, t=fraction)
-            else:
-                locations = ag_rep.positions
-
-            # if the class of AtomGroup is UpdatingAtomGroup
-            # then update as a new mol_object
-            if isinstance(ag_rep.ag, mda.core.groups.UpdatingAtomGroup):
-                mol_object.data.clear_geometry()
-                mol_object.data.from_pydata(
-                    ag_rep.positions,
-                    ag_rep.bonds,
-                    faces=[])
-                for att_name, att in ag_rep._attributes_2_blender.items():
-                    obj.set_attribute(
-                        mol_object, att_name, att["value"], att["type"], att["domain"]
-                    )
-                mol_object['chain_id'] = ag_rep.chain_ids
-                mol_object['atom_type_unique'] = ag_rep.atom_type_unique
-                mol_object.mn['subframes'] = subframes
-            else:
-                # update the positions of the underlying vertices
-                obj.set_attribute(mol_object, 'position', locations)
-
-    @persistent
-    def _update_trajectory_handler_wrapper(self):
-        """
-        A wrapper for the update_trajectory function because Blender
-        requires the function to be taking one argument.
-        """
-        def update_trajectory_handler(scene):
-            frame = scene.frame_current
-            self._update_trajectory(frame)
-
-        return update_trajectory_handler
-
-    @persistent
-    def _update_style_handler_wrapper(self):
-        """
-        A wrapper for the update_style function because Blender
-        requires the function to be taking one argument.
-        """
-        def update_style_handler(scene):
-            self._remove_deleted_mol_objects()
-            # TODO: check for topology changes
-            # TODO: update for style changes
-
-        return update_style_handler
-
-    @persistent
-    def _remove_deleted_mol_objects(self):
-        """
-        Remove the deleted mol objects (e.g. due to operations inside Blender)
-        from the session.
-        """
-        for rep_name in self.rep_names:
-            if rep_name not in bpy.data.objects:
-                self.rep_names.remove(rep_name)
-                del self.atom_reps[rep_name]
-                del self.universe_reps[rep_name]
-
-    def _dump(self, blender_save_loc):
-        """
-        Dump the session as a pickle file 
-        """
-        log = start_logging(logfile_name="mda")
-        # get blender_save_loc
-        blender_save_loc = blender_save_loc.split(".blend")[0]
-        with open(f"{blender_save_loc}.mda_session", "wb") as f:
-            pickle.dump(self, f)
-        log.info("MDAnalysis session is dumped to {}".
-                 format(blender_save_loc))
-
-    @classmethod
-    def _rejuvenate(cls, mol_objects):
-        """
-        Rejuvenate the session from a pickle file in the default location
-        (`~/.blender_mda_session/`).
-        """
-        log = start_logging(logfile_name="mda")
-
-        # get session name from mol_objects dictionary
-        blend_file_name = bpy.data.filepath.split(".blend")[0]
-        try:
-            with open(f"{blend_file_name}.mda_session", "rb") as f:
-                cls = pickle.load(f)
-        except FileNotFoundError:
-            return None
-        bpy.app.handlers.frame_change_post.append(
-            cls._update_trajectory_handler_wrapper()
-        )
-        bpy.app.handlers.depsgraph_update_pre.append(
-            cls._update_style_handler_wrapper()
-        )
-        log.info("MDAnalysis session is loaded from {}".
-                 format(blend_file_name))
-        return cls
 
 
 @persistent

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -13,7 +13,7 @@ from ... import utils, data, color
 
 
 AtomList = TypeVar('AtomList', struc.AtomArrayStack, mda.AtomGroup)
-"""biotite.structure.AtomArrayStac oder MDAnalysis.AtomGroup"""
+"""biotite.structure.AtomArray oder MDAnalysis.AtomGroup"""
 
 
 class AtomAttribute:
@@ -44,7 +44,6 @@ class AtomAttribute:
         setattr(instance._atoms, self.prop_name, value)
         
     def __get__(self, instance, owner_class):
-            print(f"{self.prop_name=}")
             return getattr(instance._atoms, self.prop_name)
 
 class Molecule(ABC):
@@ -92,7 +91,8 @@ class Molecule(ABC):
         return f"<Molecule object: {self.name} with {len(self)} atoms>"
 
     def __getitem__(self, index: Union[int, list, slice]) -> "Molecule":
-        return self.__class__(name=self.name, atoms=self._atoms[:,index], **self.__dict__)
+        # just written for one dimensional slicing, so atomarrrays not atomarraystacks
+        return self.__class__(name=self.name, atoms=self._atoms[index], **self.__dict__)
     
     #TODO: __setattr__
 
@@ -149,7 +149,7 @@ class MoleculeAtomArray(Molecule):
     
     @property
     def bonds(self) -> np.ndarray:
-        return self._atoms.bonds.as_array()
+        return self._atoms.bonds.as_array()[:, [0, 1]]
 
     @classmethod
     @abstractmethod

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -33,14 +33,18 @@ class AtomAttribute:
                 self._atoms = atoms # name of the AtomList
 
         """
+    def __init__(self, prop_name: Optional[str] = None):
+        self.prop_name = prop_name
 
     def __set_name__(self, owner_class, prop_name):
-        self.prop_name = prop_name
+        if not self.prop_name:
+            self.prop_name = prop_name
         
     def __set__(self, instance, value):
         setattr(instance._atoms, self.prop_name, value)
         
     def __get__(self, instance, owner_class):
+            print(f"{self.prop_name=}")
             return getattr(instance._atoms, self.prop_name)
 
 class Molecule(ABC):
@@ -85,22 +89,8 @@ class Molecule(ABC):
         return self._n_atoms
     
     def __repr__(self) -> str:
-        return f"<Molecule object: {self.name}>"
-    
-    def _getattr__(self, name: str):
-        """
-        Get the attribute from the AtomArray if the attribute is not found in the Molecule instance.
+        return f"<Molecule object: {self.name} with {len(self)} atoms>"
 
-        Raises
-        ------
-        AttributeError
-            If the attribute is not found in the AtomArray.
-        """
-        try:
-            return getattr(self._atoms, name)
-        except AttributeError:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
-    
     def __getitem__(self, index: Union[int, list, slice]) -> "Molecule":
         return self.__class__(name=self.name, atoms=self._atoms[:,index], **self.__dict__)
     
@@ -147,7 +137,6 @@ class MoleculeAtomArray(Molecule):
     """
 
     coord = AtomAttribute() # attributes in the AtomArray._annot
-    bonds = AtomAttribute() # ...
     box = AtomAttribute()   # ...
     
     def __init__(self, **kwargs):
@@ -156,7 +145,11 @@ class MoleculeAtomArray(Molecule):
         # set every attribute in the AtomArray._annot as a descriptor
         # -> the data container has to have the name _atoms
         for attr in self._atoms._annot.keys():
-            setattr(self.__class__, attr, AtomAttribute())
+            setattr(self.__class__, attr, AtomAttribute(prop_name=attr))
+    
+    @property
+    def bonds(self) -> np.ndarray:
+        return self._atoms.bonds.as_array()
 
     @classmethod
     @abstractmethod

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -23,11 +23,9 @@ class AtomAttribute:
         self.prop_name = prop_name
         
     def __set__(self, instance, value):
-        print(f"Setting {self.prop_name} to {value}")
         setattr(instance._atoms, self.prop_name, value)
         
     def __get__(self, instance, owner_class):
-            print(f"{instance=}, {owner_class=}")
             return getattr(instance._atoms, self.prop_name)
 
    
@@ -60,19 +58,19 @@ class Molecule(ABC):
 
     """
 
+    coord = AtomAttribute()
+    chain_id = AtomAttribute()
+    res_name = AtomAttribute()
+    hetero = AtomAttribute()
+    atom_name = AtomAttribute()
+
+
     # TODO write custom method to apply filters like vstack and filter, sort, apply, ... to all attributes
     def __init__(self, name: str, atoms: struc.AtomArray):
         self._name = name
         self._n_atoms = len(atoms)
         self._atoms = atoms
-
-        #TODO: more intuitive way to interact with attributes, alternatively use instance._atoms.field_name
-        #self.coord = AtomAttribute()
-        #self.chain_id = AtomAttribute()
-        #self.res_name = AtomAttribute()
-        #self.hetero = AtomAttribute()
-        #self.atom_name = AtomAttribute()
-        #self.entity_id : Optional[np.ndarray]
+        self.entity_id: Optional[np.ndarray] = None
     
     @property
     def name(self) -> str:

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -83,8 +83,6 @@ class Molecule(ABC):
     
     @property
     def n_atoms(self) -> int:
-        if not self._n_atoms:
-            self._n_atoms = len(self)
         return self._n_atoms
 
     @classmethod
@@ -169,7 +167,7 @@ class Molecule(ABC):
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
     
     def __getitem__(self, index: Union[int, list, slice]) -> "Molecule":
-        return self.__class__(name=self.name, atoms=self._atoms[:,index])
+        return self.__class__(name=self.name, atoms=self._atoms[:,index], **self.__dict__)
 
     def __add__(self, other):
         self.coord = self.coord + other

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -12,7 +12,7 @@ from ... import blender as bl
 from ... import utils, data, color
 
 
-AtomList = TypeVar('AtomList', List)
+AtomList = TypeVar('AtomList', struc.AtomArrayStack, mda.AtomGroup)
 """biotite.structure.AtomArrayStac oder MDAnalysis.AtomGroup"""
 
 

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -1,23 +1,33 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Any, Union, List, Tuple, Dict
+from typing import Optional, Any, Union, List, Tuple, Dict, TypeVar, Generic, Sequence
 import warnings
 import time
 import numpy as np
 import bpy
 import biotite.structure as struc
 
+import MDAnalysis as mda
+
 from ... import blender as bl
 from ... import utils, data, color
 
 class AtomAttribute:
     """
-    Provides setter and getter for the atom attributes [biotite.structure.AtomArray (np.ndarray)](https://github.com/biotite-dev/biotite/blob/master/src/biotite/structure/atoms.py). 
-    The AtomArray is a np.ndarray with a structured dtype. 
+        Provides setter and getter for the atom attributes, in a fashion, that the attributes
+        are stored in the data-container of the class, but can be accessed directly from the class,
+        so that there is no dubplicated data and it simplifies the interaction with the user.
 
-    The setter:
+        Example usage:
 
-    The getter:
-    """
+        class MDA:
+            
+            postions = AtomGroupAttribute() # attribute of the AtomGroup
+            bonds = AtomGroupAttribute()    # ...
+
+            def __init__(self, ag: struc.AtomGroup):
+                self._atoms = atoms
+
+        """
 
     def __set_name__(self, owner_class, prop_name):
         self.prop_name = prop_name
@@ -28,54 +38,38 @@ class AtomAttribute:
     def __get__(self, instance, owner_class):
             return getattr(instance._atoms, self.prop_name)
 
-   
+T = TypeVar('T', struc.AtomArray, struc.AtomArrayStack, mda.Universe, mda.AtomGroup)
 
 class Molecule(ABC):
+
     """
-    Represents a molecule.
+    Every Molecule has the atrributes name, n_atoms, _atoms and entity_id.
 
     Attributes:
     ----
-    name (str): Name of the molecule.
-    n_atoms (int): Number of atoms in the molecule
-    _atoms (biotite.structure.AtomArrayStack): Contains the atom information of the molecule.
-    entity_id (np.ndarray): The entity ID of the atoms in the molecule.
 
-    Descriptors:
-    ----
-    coord (np.ndarray): The coordinates of the atoms in the molecule.
-    bonds (np.ndarray): The bonds between the atoms in the molecule.
-    box (np.ndarray): The box of the molecule.
-
-    every attribute in the AtomArray._annot is also a descriptor.
+    - `name (str):` Name of the molecule.
+    - `n_atoms (int):` Number of atoms in the molecule
+    - `_atoms (Sequence[T]):` Data container which contains the atom information of the molecule.
+        The Attributes are dynamically set as AtomAttribute descriptors in the child class.
+    - `entity_id (np.ndarray):` The entity ID of the atoms in the molecule.
 
     Methods:
     ----
-    __init__(self, name: str, atoms: struc.AtomArray): Initialize the molecule.
-    _get_structure(self): Get the structure of the molecule.
-    assemblies(self, as_array=False): Get the biological assemblies of the molecule.
-    __repr__(self): Return the string representation of the molecule.
-    __len__(self): Return the number of atoms in the molecule.
 
-    Arithmetic Operators - delegate to numpy
-
+    - `__init__(self, name: str, atoms: List[T]):` Initialize the molecule.
+    - `__len__(self) -> int:` Return the number of atoms in the molecule. Has to be defined in the child class.
+    - `__repr__(self) -> str:` Return the string representation of the molecule.
+    - `__getattr__(self, name: str):` Get the attribute from the AtomArray if the attribute is not found in the Molecule instance.
+    - `__getitem__(self, index: Union[int, list, slice]) -> "Molecule":` Return a new Molecule instance with the sliced atoms.
 
     """
 
-    coord = AtomAttribute()
-    bonds = AtomAttribute()
-    box = AtomAttribute()
-
-    def __init__(self, name: str, atoms: struc.AtomArray):
-        self._name = name
-        self._n_atoms = len(atoms)
-        self._atoms = atoms
-
-        # set every attribute in the AtomArray._annot as a descriptor
-        for attr in self._atoms._annot.keys():
-            setattr(self.__class__, attr, AtomAttribute())
-
-        self.entity_id: Optional[np.ndarray] = None
+    def __init__(self, name : str, atoms : List[T]):
+        self._name : str = name
+        self._atoms : List[T ]= atoms
+        self._n_atoms : int | None = None
+        self.entity_id: np.ndarray | None = None
     
     @property
     def name(self) -> str:
@@ -83,11 +77,87 @@ class Molecule(ABC):
     
     @property
     def n_atoms(self) -> int:
+        if not self._n_atoms:
+            self._n_atoms = len(self)
         return self._n_atoms
+    
+    def __repr__(self) -> str:
+        return f"<Molecule object: {self.name}>"
+    
+    def _getattr__(self, name: str):
+        """
+        Get the attribute from the AtomArray if the attribute is not found in the Molecule instance.
+
+        Raises
+        ------
+        AttributeError
+            If the attribute is not found in the AtomArray.
+        """
+        try:
+            return getattr(self._atoms, name)
+        except AttributeError:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+    
+    def __getitem__(self, index: Union[int, list, slice]) -> "Molecule":
+        return self.__class__(name=self.name, atoms=self._atoms[:,index], **self.__dict__)
+    
+    #TODO: __setattr__
+
+    @abstractmethod
+    def __len__(self) -> int:
+        ...
+
+class MoleculeAtomArray(Molecule):
+    """
+    Represents a molecule with an AtomArrayStruct as data container.
+
+    Descriptors:
+    ----
+    - `coord (np.ndarray):` The coordinates of the atoms in the molecule.
+    - `bonds (np.ndarray):` The bonds between the atoms in the molecule.
+    - `box (np.ndarray):` The box of the molecule.
+
+    - `every attribute` in the AtomArray._annot is also a descriptor.
+
+    Methods:
+    ----
+
+    - `_get_structure(self):` Get the structure of the molecule.
+    - `_assemblies(self, as_array=False):` Get the biological assemblies of the molecule.
+    - `assemblies(self, as_array=False):` Get the biological assemblies of the molecule.
+
+
+    Example usage:
+
+    ```python
+    class PDB(MoleculeAtomArray):
+        def __init__(self, atoms: struc.AtomArrayStack, fpath:str, **kwargs):
+
+            super().__init__(name="from-local-pdb-file", atoms=atoms)
+            self.fpath = fpath
+
+        @classmethod
+        def _get_structure(cls, fpath: str) -> "PDB":
+        ...
+    
+        mol = PDB._get_structure("path/to/file.pdb")
+    """
+
+    coord = AtomAttribute() # attributes in the AtomArray._annot
+    bonds = AtomAttribute() # ...
+    box = AtomAttribute()   # ...
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # set every attribute in the AtomArray._annot as a descriptor
+        # -> the data container has to have the name _atoms
+        for attr in self._atoms._annot.keys():
+            setattr(self.__class__, attr, AtomAttribute())
 
     @classmethod
     @abstractmethod
-    def _get_structure(cls, fpath: str):
+    def _get_structure(cls, fpath: str) -> "MoleculeAtomArray":
         """
         Get the structural information of the molecule with biotite.structure.io.
 
@@ -145,48 +215,6 @@ class Molecule(ABC):
             return utils.array_quaternions_from_dict(assemblies_info)
 
         return assemblies_info
-
-    def __repr__(self) -> str:
-        return f"<Molecule object: {self.name}>"
     
     def __len__(self) -> int:
         return self._atoms.array_length()
-
-    def __getattr__(self, name: str):
-        """
-        Get the attribute from the AtomArray if the attribute is not found in the Molecule instance.
-
-        Raises
-        ------
-        AttributeError
-            If the attribute is not found in the AtomArray.
-        """
-        if name in self._atoms._annot.keys():
-            return getattr(self._atoms, name)
-        else:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
-    
-    def __getitem__(self, index: Union[int, list, slice]) -> "Molecule":
-        return self.__class__(name=self.name, atoms=self._atoms[:,index], **self.__dict__)
-
-    def __add__(self, other):
-        self.coord = self.coord + other
-
-    def __sub__(self, other):
-        self.coord = self.coord - other
-
-    def __mul__(self, other):
-        pass
-
-    def __truediv__(self, other):
-        pass
-
-    def __iadd__(self, other):
-        pass
-
-    def __isub__(self, other):
-        pass
-
-    def __imul__(self, other):
-        pass    
-

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -11,10 +11,15 @@ import MDAnalysis as mda
 from ... import blender as bl
 from ... import utils, data, color
 
+
+AtomList = TypeVar('AtomList', List)
+"""biotite.structure.AtomArrayStac oder MDAnalysis.AtomGroup"""
+
+
 class AtomAttribute:
     """
         Provides setter and getter for the atom attributes, in a fashion, that the attributes
-        are stored in the data-container of the class, but can be accessed directly from the class,
+        are stored in the data-container(AtomList) of the class, but can be accessed directly from the class,
         so that there is no dubplicated data and it simplifies the interaction with the user.
 
         Example usage:
@@ -25,7 +30,7 @@ class AtomAttribute:
             bonds = AtomGroupAttribute()    # ...
 
             def __init__(self, ag: struc.AtomGroup):
-                self._atoms = atoms
+                self._atoms = atoms # name of the AtomList
 
         """
 
@@ -37,8 +42,6 @@ class AtomAttribute:
         
     def __get__(self, instance, owner_class):
             return getattr(instance._atoms, self.prop_name)
-
-T = TypeVar('T', struc.AtomArray, struc.AtomArrayStack, mda.Universe, mda.AtomGroup)
 
 class Molecule(ABC):
 
@@ -57,7 +60,7 @@ class Molecule(ABC):
     Methods:
     ----
 
-    - `__init__(self, name: str, atoms: List[T]):` Initialize the molecule.
+    - `__init__(self, name: str, atoms: AtomList):` Initialize the molecule.
     - `__len__(self) -> int:` Return the number of atoms in the molecule. Has to be defined in the child class.
     - `__repr__(self) -> str:` Return the string representation of the molecule.
     - `__getattr__(self, name: str):` Get the attribute from the AtomArray if the attribute is not found in the Molecule instance.
@@ -65,9 +68,9 @@ class Molecule(ABC):
 
     """
 
-    def __init__(self, name : str, atoms : List[T]):
+    def __init__(self, name : str, atoms : AtomList):
         self._name : str = name
-        self._atoms : List[T ]= atoms
+        self._atoms : AtomList= atoms
         self._n_atoms : int | None = None
         self.entity_id: np.ndarray | None = None
     

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -1,265 +1,122 @@
-from abc import ABCMeta
-from typing import Optional, Any
+from abc import ABC, abstractmethod
+from typing import Optional, Any, Union, List, Tuple, Dict
 import warnings
 import time
 import numpy as np
 import bpy
+import biotite.structure as struc
 
 from ... import blender as bl
 from ... import utils, data, color
 
-
-class Molecule(metaclass=ABCMeta):
+class AtomAttribute:
     """
-    Abstract base class for representing a molecule.
+    Provides setter and getter for the atom attributes [biotite.structure.AtomArray (np.ndarray)](https://github.com/biotite-dev/biotite/blob/master/src/biotite/structure/atoms.py). 
+    The AtomArray is a np.ndarray with a structured dtype. 
 
-    It associates the atomic data (the array) with the created 3D model inside of Blender
-    (the object). If multiple conformations are imported, then a `frames` collection
-    is also instantiated.
+    The setter:
 
-    The `get_attribute()` and `set_attribute()` methods access and set attributes on 
-    `object` that is in the Blender scene.
-
-    Attributes
-    ----------
-    file_path : str
-        The file path to the file which stores the atomic coordinates.
-    file : Any
-        The opened file.
-    object : bpy.types.Object
-        The Blender object representing the molecule.
-    frames : bpy.types.Collection
-        The Blender collection which holds the objects making up the frames to animate.
-    array: np.ndarray:
-        The numpy array which stores the atomic coordindates and associated attributes.
-    entity_ids : np.ndarray
-        The entity IDs of the molecule.
-    chain_ids : np.ndarray
-        The chain IDs of the molecule.
-
-    Methods
-    -------
-    set_attribute(data, name='NewAttribute', type=None, domain='POINT', overwrite=True)
-        Set an attribute on the object for the molecule.
-    get_attribute(name='position')
-        Get the value of an attribute on the object for the molecule.
-    create_model(name='NewMolecule', style='spheres', selection=None, build_assembly=False, centre=False, del_solvent=True, collection=None, verbose=False)
-        Create a 3D model for the molecule, based on the values from self.array.
-    assemblies(as_array=False)
-        Get the biological assemblies of the molecule.
+    The getter:
     """
 
-    def __init__(self):
-        self.file_path: str = None
-        self.file: Any = None
-        self.object: Optional[bpy.types.Object] = None
-        self.frames: Optional[bpy.types.Collection] = None
-        self.array: Optional[np.ndarray] = None
-        self.entity_ids: Optional[np.ndarray] = None
-        self.chain_ids: Optional[np.ndarray] = None
+    def __set_name__(self, owner_class, prop_name):
+        self.prop_name = prop_name
+        
+    def __set__(self, instance, value):
+        print(f"Setting {self.prop_name} to {value}")
+        setattr(instance._atoms, self.prop_name, value)
+        
+    def __get__(self, instance, owner_class):
+            print(f"{instance=}, {owner_class=}")
+            return getattr(instance._atoms, self.prop_name)
 
+   
+
+class Molecule(ABC):
+    """
+    Represents a molecule.
+
+    Attributes:
+    ----
+    name (str): Name of the molecule.
+    coord (AtomField): Coordinates of the atoms.
+    chain_id (AtomField): Chain IDs of the atoms.
+    res_name (AtomField): Residue names of the atoms.
+    entity_id (AtomField): Entity IDs of the atoms.
+    hetero (AtomField): Hetero flags of the atoms.
+    atom_name (AtomField): Atom names of the atoms.
+    n_atoms (int): Number of atoms in the molecule.
+
+    Methods:
+    ----
+    __init__(self, name: str, atoms: struc.AtomArray): Initialize the molecule.
+    _get_structure(self): Get the structure of the molecule.
+    assemblies(self, as_array=False): Get the biological assemblies of the molecule.
+    __repr__(self): Return the string representation of the molecule.
+    __len__(self): Return the number of atoms in the molecule.
+
+    Arithmetic Operators - delegate to numpy
+
+
+    """
+
+    # TODO write custom method to apply filters like vstack and filter, sort, apply, ... to all attributes
+    def __init__(self, name: str, atoms: struc.AtomArray):
+        self._name = name
+        self._n_atoms = len(atoms)
+        self._atoms = atoms
+
+        #TODO: more intuitive way to interact with attributes, alternatively use instance._atoms.field_name
+        #self.coord = AtomAttribute()
+        #self.chain_id = AtomAttribute()
+        #self.res_name = AtomAttribute()
+        #self.hetero = AtomAttribute()
+        #self.atom_name = AtomAttribute()
+        #self.entity_id : Optional[np.ndarray]
+    
     @property
-    def name(self) -> Optional[str]:
-        if self.object is not None:
-            return self.object.name
-        else:
-            return None
+    def name(self) -> str:
+        return self._name
+    
+    @property
+    def n_atoms(self) -> int:
+        if not self._n_atoms:
+            self._n_atoms = len(self)
+        return self._n_atoms
 
-    def set_attribute(
-        self,
-        data: np.ndarray,
-        name='NewAttribute',
-        type=None,
-        domain='POINT',
-        overwrite=True
-    ):
+    @classmethod
+    @abstractmethod
+    def _get_structure(cls, fpath: str):
         """
-        Set an attribute for the molecule.
-
-        Parameters
-        ----------
-        data : np.ndarray
-            The data to be set as the attribute. Must be of length equal to the length
-            of the domain.
-        name : str, optional
-            The name of the new attribute. Default is 'NewAttribute'.
-        type : str, optional
-            If value is None (Default), the data type is inferred. The data type of the 
-            attribute. Possbible values are ('FLOAT_VECTOR', 'FLOAT_COLOR", 'QUATERNION', 
-            'FLOAT', 'INT', 'BOOLEAN').
-        domain : str, optional
-            The domain of the attribute. Default is 'POINT'. Possible values are 
-            currently ['POINT', 'EDGE', 'FACE', 'SPLINE']
-        overwrite : bool, optional
-            Whether to overwrite an existing attribute with the same name, or create a 
-            new attribute with always a unique name. Default is True.
-        """
-        if not self.object:
-            warnings.warn(
-                f'No object yet created. Use `create_model()` to create a corresponding object.'
-            )
-            return None
-        bl.obj.set_attribute(
-            self.object,
-            name=name,
-            data=data,
-            domain=domain,
-            overwrite=overwrite
-        )
-
-    def get_attribute(self, name='position', evaluate=False) -> np.ndarray | None:
-        """
-        Get the value of an attribute for the associated object.
-
-        Parameters
-        ----------
-        name : str, optional
-            The name of the attribute. Default is 'position'.
-        evaluate : bool, optional
-            Whether to first evaluate all node trees before getting the requsted attribute. 
-            False (default) will sample the underlying atomic geometry, while True will 
-            sample the geometry that is created through the Geometry Nodes tree.
+        Get the structural information of the molecule with biotite.structure.io.
 
         Returns
         -------
-        np.ndarray
-            The value of the attribute.
-        """
-        if not self.object:
-            warnings.warn(
-                'No object yet created. Use `create_model()` to create a corresponding object.'
-            )
-            return None
-        return bl.obj.get_attribute(self.object, name=name, evaluate=evaluate)
 
-    def list_attributes(self, evaluate=False) -> list | None:
+        molecule : Molecule
+
         """
-        Returns a list of attribute names for the object.
+        ...
+
+    @abstractmethod
+    def _assemblies(self, as_array=False):
+        """
+        Get the biological assemblies of the molecule.
 
         Parameters
         ----------
-        evaluate : bool, optional
-            Whether to first evaluate the modifiers on the object before listing the 
-            available attributes.
+        as_array : bool, optional
+            Whether to return the assemblies as an array of quaternions.
+            Default is False.
 
         Returns
         -------
-        list[str] | None
-            A list of attribute names if the molecule object exists, None otherwise.
+        dict or None
+            The biological assemblies of the molecule, as a dictionary of
+            transformation matrices, or None if no assemblies are available.
         """
-        if not self.object:
-            warnings.warn("No object created")
-            return None
-        if evaluate:
-            return list(bl.obj.evaluated(self.object).data.attributes.keys())
-
-        return list(self.object.data.attributes.keys())
-
-    def _chain_ids(self, as_int=False):
-        """
-        Get the unique chain IDs of the molecule.
-
-        Parameters
-        ----------
-        as_int : bool, optional
-            Whether to return the chain IDs as integers. Default is False.
-
-        Returns
-        -------
-        ndarray
-            The unique chain IDs of the molecule.
-        """
-        if as_int:
-            return np.unique(self.array.chain_id, return_inverse=True)[1]
-        return np.unique(self.array.chain_id)
-
-    def create_model(
-        self,
-        name: str = 'NewMolecule',
-        style: str = 'spheres',
-        selection: np.ndarray = None,
-        build_assembly=False,
-        centre: bool = False,
-        del_solvent: bool = True,
-        collection=None,
-        verbose: bool = False,
-    ) -> bpy.types.Object:
-        """
-        Create a 3D model of the molecule inside of Blender. 
-
-        Creates a 3D model with one vertex per atom, and one edge per bond. Each vertex
-        is given attributes which correspond to the atomic data such as `atomic_number` for
-        the element and `res_name` for the residue name that the atom is associated with.
-
-        If multiple conformations of the structure are detected, the collection attribute
-        is also created which will store an object for each conformation, so that the 
-        object can interpolate between those conformations.
-
-        Parameters
-        ----------
-        name : str, optional
-            The name of the model. Default is 'NewMolecule'.
-        style : str, optional
-            The style of the model. Default is 'spheres'.
-        selection : np.ndarray, optional
-            The selection of atoms to include in the model. Default is None.
-        build_assembly : bool, optional
-            Whether to build the biological assembly. Default is False.
-        centre : bool, optional
-            Whether to center the model in the scene. Default is False.
-        del_solvent : bool, optional
-            Whether to delete solvent molecules. Default is True.
-        collection : str, optional
-            The collection to add the model to. Default is None.
-        verbose : bool, optional
-            Whether to print verbose output. Default is False.
-
-        Returns
-        -------
-        bpy.types.Object
-            The created 3D model, as an object in the 3D scene.
-        """
-        from biotite import InvalidFileError
-
-        if selection:
-            array = self.array[selection]
-        else:
-            array = self.array
-
-        model, frames = _create_model(
-            array=array,
-            name=name,
-            centre=centre,
-            del_solvent=del_solvent,
-            style=style,
-            collection=collection,
-            verbose=verbose,
-        )
-
-        if style:
-            bl.nodes.create_starting_node_tree(
-                object=model,
-                coll_frames=frames,
-                style=style,
-            )
-
-        try:
-            model['entity_ids'] = self.entity_ids
-        except AttributeError:
-            model['entity_ids'] = None
-
-        try:
-            model['biological_assemblies'] = self.assemblies()
-        except InvalidFileError:
-            pass
-
-        if build_assembly and style:
-            bl.nodes.assembly_insert(model)
-
-        self.object = model
-        self.frames = frames
-
-        return model
+        
+        ...
 
     def assemblies(self, as_array=False):
         """
@@ -290,290 +147,35 @@ class Molecule(metaclass=ABCMeta):
 
     def __repr__(self) -> str:
         return f"<Molecule object: {self.name}>"
+    
+    def __len__(self) -> int:
+        return self._atoms.shape[1]
+    
+    def __getitem__(self, index: Union[int, list, slice]) -> "Molecule":
+        return self.__class__(name=self.name, atoms=self._atoms[:,index])
+        
+    
+    def __eq__(self, __value: object):
+        pass
 
-def _create_model(array,
-                  name=None,
-                  centre=False,
-                  del_solvent=False,
-                  style='spherers',
-                  collection=None,
-                  world_scale=0.01,
-                  verbose=False
-                  ) -> (bpy.types.Object, bpy.types.Collection):
-    import biotite.structure as struc
-    frames = None
+    def __add__(self, other):
+        self.coord = self.coord + other
 
-    if isinstance(array, struc.AtomArrayStack):
-        if array.stack_depth() > 1:
-            frames = array
-        array = array[0]
+    def __sub__(self, other):
+        self.coor = self.coord - other
 
-    # remove the solvent from the structure if requested
-    if del_solvent:
-        array = array[np.invert(struc.filter_solvent(array))]
+    def __mul__(self, other):
+        pass
 
-    locations = array.coord * world_scale
+    def __truediv__(self, other):
+        pass
 
-    centroid = np.array([0, 0, 0])
-    if centre:
-        centroid = struc.centroid(array) * world_scale
+    def __iadd__(self, other):
+        pass
 
-    # subtract the centroid from all of the positions to localise the molecule on the world origin
-    if centre:
-        locations = locations - centroid
+    def __isub__(self, other):
+        pass
 
-    if not collection:
-        collection = bl.coll.mn()
+    def __imul__(self, other):
+        pass    
 
-    bonds_array = []
-    bond_idx = []
-
-    if array.bonds:
-        bonds_array = array.bonds.as_array()
-        bond_idx = bonds_array[:, [0, 1]]
-        # the .copy(order = 'C') is to fix a weird ordering issue with the resulting array
-        bond_types = bonds_array[:, 2].copy(order='C')
-
-    mol = bl.obj.create_object(name=name, collection=collection,
-                               vertices=locations, edges=bond_idx)
-
-    # Add information about the bond types to the model on the edge domain
-    # Bond types: 'ANY' = 0, 'SINGLE' = 1, 'DOUBLE' = 2, 'TRIPLE' = 3, 'QUADRUPLE' = 4
-    # 'AROMATIC_SINGLE' = 5, 'AROMATIC_DOUBLE' = 6, 'AROMATIC_TRIPLE' = 7
-    # https://www.biotite-python.org/apidoc/biotite.structure.BondType.html#biotite.structure.BondType
-    if array.bonds:
-        bl.obj.set_attribute(mol, name='bond_type', data=bond_types,
-                             type="INT", domain="EDGE")
-
-    # The attributes for the model are initially defined as single-use functions. This allows
-    # for a loop that attempts to add each attibute by calling the function. Only during this
-    # loop will the call fail if the attribute isn't accessible, and the warning is reported
-    # there rather than setting up a try: except: for each individual attribute which makes
-    # some really messy code.
-
-    # I still don't like this as an implementation, and welcome any cleaner approaches that
-    # anybody might have.
-
-    def att_atomic_number():
-        atomic_number = np.array([
-            data.elements.get(x, {'atomic_number': -1}).get("atomic_number")
-            for x in np.char.title(array.element)
-        ])
-        return atomic_number
-
-    def att_atom_id():
-        return array.atom_id
-
-    def att_res_id():
-        return array.res_id
-
-    def att_res_name():
-        other_res = []
-        counter = 0
-        id_counter = -1
-        res_names = array.res_name
-        res_ids = array.res_id
-        res_nums = []
-
-        for name in res_names:
-            res_num = data.residues.get(
-                name, {'res_name_num': -1}).get('res_name_num')
-
-            if res_num == 9999:
-                if res_names[counter - 1] != name or res_ids[counter] != res_ids[counter - 1]:
-                    id_counter += 1
-
-                unique_res_name = str(id_counter + 100) + "_" + str(name)
-                other_res.append(unique_res_name)
-
-                num = np.where(np.isin(np.unique(other_res), unique_res_name))[
-                    0][0] + 100
-                res_nums.append(num)
-            else:
-                res_nums.append(res_num)
-            counter += 1
-
-        mol['ligands'] = np.unique(other_res)
-        return np.array(res_nums)
-
-    def att_chain_id():
-        return np.unique(array.chain_id, return_inverse=True)[1]
-
-    def att_entity_id():
-        return array.entity_id
-
-    def att_b_factor():
-        return array.b_factor
-
-    def att_occupancy():
-        return array.occupancy
-
-    def att_vdw_radii():
-        vdw_radii = np.array(list(map(
-            # divide by 100 to convert from picometres to angstroms which is what all of coordinates are in
-            lambda x: data.elements.get(
-                x, {'vdw_radii': 100}).get('vdw_radii', 100) / 100,
-            np.char.title(array.element)
-        )))
-        return vdw_radii * world_scale
-
-    def att_atom_name():
-        atom_name = np.array(list(map(
-            lambda x: data.atom_names.get(x, -1),
-            array.atom_name
-        )))
-
-        return atom_name
-
-    def att_lipophobicity():
-        lipo = np.array(list(map(
-            lambda x, y: data.lipophobicity.get(x, {"0": 0}).get(y, 0),
-            array.res_name, array.atom_name
-        )))
-
-        return lipo
-
-    def att_charge():
-        charge = np.array(list(map(
-            lambda x, y: data.atom_charge.get(x, {"0": 0}).get(y, 0),
-            array.res_name, array.atom_name
-        )))
-        return charge
-
-    def att_color():
-        return color.color_chains(att_atomic_number(), att_chain_id())
-
-    def att_is_alpha():
-        return np.isin(array.atom_name, 'CA')
-
-    def att_is_solvent():
-        return struc.filter_solvent(array)
-
-    def att_is_backbone():
-        """
-        Get the atoms that appear in peptide backbone or nucleic acid phosphate backbones.
-        Filter differs from the Biotite's `struc.filter_peptide_backbone()` in that this
-        includes the peptide backbone oxygen atom, which biotite excludes. Additionally 
-        this selection also includes all of the atoms from the ribose in nucleic acids, 
-        and the other phosphate oxygens.
-        """
-        backbone_atom_names = [
-            'N', 'C', 'CA', 'O',                    # peptide backbone atoms
-            "P", "O5'", "C5'", "C4'", "C3'", "O3'",  # 'continuous' nucleic backbone atoms
-            "O1P", "OP1", "O2P", "OP2",             # alternative names for phosphate O's
-            "O4'", "C1'", "C2'", "O2'"              # remaining ribose atoms
-        ]
-
-        is_backbone = np.logical_and(
-            np.isin(array.atom_name, backbone_atom_names),
-            np.logical_not(struc.filter_solvent(array))
-        )
-        return is_backbone
-
-    def att_is_nucleic():
-        return struc.filter_nucleotides(array)
-
-    def att_is_peptide():
-        aa = struc.filter_amino_acids(array)
-        con_aa = struc.filter_canonical_amino_acids(array)
-
-        return aa | con_aa
-
-    def att_is_hetero():
-        return array.hetero
-
-    def att_is_carb():
-        return struc.filter_carbohydrates(array)
-
-    def att_sec_struct():
-        return array.sec_struct
-
-    # these are all of the attributes that will be added to the structure
-    # TODO add capcity for selection of particular attributes to include / not include to potentially
-    # boost performance, unsure if actually a good idea of not. Need to do some testing.
-    attributes = (
-        {'name': 'res_id',          'value': att_res_id,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'res_name',        'value': att_res_name,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'atomic_number',   'value': att_atomic_number,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'b_factor',        'value': att_b_factor,
-            'type': 'FLOAT',   'domain': 'POINT'},
-        {'name': 'occupancy',       'value': att_occupancy,
-            'type': 'FLOAT',   'domain': 'POINT'},
-        {'name': 'vdw_radii',       'value': att_vdw_radii,
-            'type': 'FLOAT',   'domain': 'POINT'},
-        {'name': 'chain_id',        'value': att_chain_id,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'entity_id',       'value': att_entity_id,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'atom_id',         'value': att_atom_id,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'atom_name',       'value': att_atom_name,
-            'type': 'INT',     'domain': 'POINT'},
-        {'name': 'lipophobicity',   'value': att_lipophobicity,
-            'type': 'FLOAT',   'domain': 'POINT'},
-        {'name': 'charge',          'value': att_charge,
-            'type': 'FLOAT',   'domain': 'POINT'},
-        {'name': 'Color',           'value': att_color,
-            'type': 'FLOAT_COLOR',   'domain': 'POINT'},
-
-        {'name': 'is_backbone',     'value': att_is_backbone,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'is_alpha_carbon', 'value': att_is_alpha,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'is_solvent',      'value': att_is_solvent,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'is_nucleic',      'value': att_is_nucleic,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'is_peptide',      'value': att_is_peptide,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'is_hetero',       'value': att_is_hetero,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'is_carb',         'value': att_is_carb,
-            'type': 'BOOLEAN', 'domain': 'POINT'},
-        {'name': 'sec_struct',      'value': att_sec_struct,
-            'type': 'INT',     'domain': 'POINT'}
-    )
-
-    # assign the attributes to the object
-    for att in attributes:
-        if verbose:
-            start = time.process_time()
-        try:
-            bl.obj.set_attribute(mol, name=att['name'], data=att['value'](
-            ), type=att['type'], domain=att['domain'])
-            if verbose:
-                print(
-                    f'Added {att["name"]} after {time.process_time() - start} s')
-        except:
-            if verbose:
-                warnings.warn(f"Unable to add attribute: {att['name']}")
-                print(
-                    f'Failed adding {att["name"]} after {time.process_time() - start} s')
-
-    coll_frames = None
-    if frames:
-
-        coll_frames = bl.coll.frames(mol.name, parent=bl.coll.data())
-        for i, frame in enumerate(frames):
-            frame = bl.obj.create_object(
-                name=mol.name + '_frame_' + str(i),
-                collection=coll_frames,
-                vertices=frame.coord * world_scale - centroid
-            )
-            # TODO if update_attribute
-            # bl.obj.set_attribute(attribute)
-
-    mol.mn['molcule_type'] = 'pdb'
-
-    # add custom properties to the actual blender object, such as number of chains, biological assemblies etc
-    # currently biological assemblies can be problematic to holding off on doing that
-    try:
-        mol['chain_ids'] = list(np.unique(array.chain_id))
-    except AttributeError:
-        mol['chain_ids'] = None
-        warnings.warn('No chain information detected.')
-
-    return mol, coll_frames

--- a/molecularnodes/io/parse/pdb.py
+++ b/molecularnodes/io/parse/pdb.py
@@ -29,6 +29,7 @@ class PDB(Molecule):
         except BadStructureError:
             sec_struct = _comp_secondary_structure(array.coords)
 
+        # because sec_struct is a annotation, it will be set as a descriptor in the class, without dublicated code
         array.set_annotation(
             'sec_struct', sec_struct
         )

--- a/molecularnodes/io/parse/pdb.py
+++ b/molecularnodes/io/parse/pdb.py
@@ -12,7 +12,7 @@ class PDB(Molecule):
     def __init__(self, atoms: struc, fpath:str, **kwargs):
 
         super().__init__(name="from-local-pdb-file", atoms=atoms)
-        self._path = fpath
+        self.fpath = fpath
 
     @classmethod
     def _get_structure(cls, fpath: str) -> "PDB":
@@ -37,7 +37,7 @@ class PDB(Molecule):
         return cls(atoms = array, fpath=fpath)
 
     def _assemblies(self):
-        file = pdb.PDBFile.read(self._path)
+        file = pdb.PDBFile.read(self.fpath)
         return PDBAssemblyParser(file).get_assemblies()
 
 

--- a/molecularnodes/io/parse/pdb.py
+++ b/molecularnodes/io/parse/pdb.py
@@ -18,6 +18,8 @@ class PDB(MoleculeAtomArray):
     def _get_structure(cls, fpath: str) -> "PDB":
 
         # TODO: implement entity ID, sec_struct for PDB files
+        # array is a atomarraystruc,
+        # and at the moment we just want the first one
         array = pdb.get_structure(
             pdb_file=pdb.PDBFile.read(fpath),
             extra_fields=['b_factor', 'occupancy', 'charge', 'atom_id'],
@@ -33,8 +35,9 @@ class PDB(MoleculeAtomArray):
         array.set_annotation(
             'sec_struct', sec_struct
         )
-
-        return cls(atoms = array, fpath=fpath)
+        # array is a atomarraystruc,
+        # and at the moment we just want the first one
+        return cls(atoms = array[0], fpath=fpath)
 
     def _assemblies(self):
         file = pdb.PDBFile.read(self.fpath)

--- a/molecularnodes/io/parse/pdb.py
+++ b/molecularnodes/io/parse/pdb.py
@@ -9,7 +9,7 @@ from biotite.structure import BadStructureError
 
 
 class PDB(Molecule):
-    def __init__(self, atoms: struc, fpath:str, **kwargs):
+    def __init__(self, atoms: struc.AtomArrayStack, fpath:str, **kwargs):
 
         super().__init__(name="from-local-pdb-file", atoms=atoms)
         self.fpath = fpath

--- a/molecularnodes/io/parse/pdb.py
+++ b/molecularnodes/io/parse/pdb.py
@@ -12,8 +12,6 @@ class PDB(Molecule):
     def __init__(self, atoms: struc, fpath:str, **kwargs):
 
         super().__init__(name="from-local-pdb-file", atoms=atoms)
-
-        self.sec_struct = AtomAttribute()
         self._path = fpath
 
     @classmethod

--- a/molecularnodes/io/parse/pdb.py
+++ b/molecularnodes/io/parse/pdb.py
@@ -1,14 +1,14 @@
 import numpy as np
 
 from .assembly import AssemblyParser
-from .molecule import Molecule, AtomAttribute
+from .molecule import MoleculeAtomArray, AtomAttribute
 
 from biotite.structure.io import pdb
 import biotite.structure as struc
 from biotite.structure import BadStructureError
 
 
-class PDB(Molecule):
+class PDB(MoleculeAtomArray):
     def __init__(self, atoms: struc.AtomArrayStack, fpath:str, **kwargs):
 
         super().__init__(name="from-local-pdb-file", atoms=atoms)


### PR DESCRIPTION
Proposal for Issue #464

Changes:
- abc for molecules
- molecule classes that want to inherit from it require two methods: 

```python
@classmethod
@abstractmethod
 def _get_structure(cls, fpath: str):
      ...
 @abstractmethod
  def _assemblies
```

- Every annotation in the AtomArrayStack is dynamically set as an attribute to the molecule class. E.g. PDB(Molecule) has the extra field `sec_struc`.
- the handling of the molecule object remains the same, but the annotations, which are set as class attributes, can be used to easily create masks that can be applied to the blender object.

- MoleculeInBleder class
  -  [ ] simplified setting of attributes (every attribute of the molecule class can be set as attribute in the MIB class.)