### PR TITLE
Refactor centre code

### DIFF
--- a/molecularnodes/blender/obj.py
+++ b/molecularnodes/blender/obj.py
@@ -30,6 +30,14 @@ class AttributeMismatchError(Exception):
         super().__init__(self.message)
 
 
+def centre(array: np.array):
+    return np.mean(array, axis=0)
+
+
+def centre_weighted(array: np.ndarray, weight: np.ndarray):
+    return np.sum(array * weight.reshape((len(array), 1)), axis=0) / np.sum(weight)
+
+
 class ObjectTracker:
     """
     A context manager for tracking new objects in Blender.

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -178,24 +178,24 @@ class Molecule(metaclass=ABCMeta):
 
         return list(self.object.data.attributes.keys())
 
-    def centre(self, centre_type: str = 'centroid', evaluate=False) -> np.ndarray:
+    def centre(self, centre_type: str = 'centroid') -> np.ndarray:
         """
         Calculate the centre of mass/geometry of the Molecule object
 
         :return: np.ndarray of shape (3,) user-defined centroid of all atoms in
                  the Molecule object
         """
-        positions = self.get_attribute(name='position',
-                                       evaluate=evaluate)
-        if centre_type.lower() == 'centroid':
-            return np.mean(positions, axis=0)
-        elif centre_type.lower() == 'mass':
-            masses = self.get_attribute(name='mass',
-                                        evaluate=evaluate)
-            return np.sum(masses[:, None] * positions, axis=0) / np.sum(masses)
+        positions = self.get_attribute(name='position')
+
+        if centre_type == 'centroid':
+            return bl.obj.centre(positions)
+        elif centre_type == 'mass':
+            mass = self.get_attribute(name='mass')
+            return bl.obj.centre_weighted(positions, mass)
         else:
-            print('given `centre_type` value is unexpected. returning zeroes')
-            return np.array([0, 0, 0])
+            raise ValueError(
+                f"`{centre_type}` not a supported selection of ['centroid', 'mass']"
+            )
 
     def create_model(
         self,
@@ -289,35 +289,6 @@ class Molecule(metaclass=ABCMeta):
         # same with the collection of bpy Objects for frames
         self.frames = frames
 
-        # deal with removing centres:
-        # first, remove centroid (whether CoM or CoG) from the Molecule
-        if centre in ['mass', 'centroid']:
-            centroid = self.centre(centre_type=centre)
-            positions = self.get_attribute(name='position')
-            positions -= centroid
-            self.set_attribute(data=positions,
-                               name='position',
-                               type='FLOAT_VECTOR',
-                               overwrite=True)
-        # second, if a frames collection was made, remove each frame's centroid
-        # from the frame's positions; unfortunately each instance in
-        # self.frame.objects is a bpy.Object rather than a Molecule. so use the
-        # bl.obj.get_attribute() and bl.obj.set_attribute() functions instead.
-        if self.frames and centre:
-            for frame in self.frames.objects:
-                positions = bl.obj.get_attribute(frame, name='position')
-                if centre == 'centroid':
-                    positions -= np.mean(positions, axis=0)
-                elif centre == 'mass':
-                    masses = bl.obj.get_attribute(frame, name='mass')
-                    positions -= np.sum(masses[:, None]
-                                        * positions, axis=0) / np.sum(masses)
-                bl.obj.set_attribute(frame,
-                                     name='position',
-                                     data=positions,
-                                     type='FLOAT_VECTOR',
-                                     overwrite=True)
-
         return model
 
     def assemblies(self, as_array=False):
@@ -362,17 +333,41 @@ def _create_model(array,
                   ) -> (bpy.types.Object, bpy.types.Collection):
     import biotite.structure as struc
     frames = None
+    is_stack = isinstance(array, struc.AtomArrayStack)
+
+    # remove the solvent from the structure if requested
+    if del_solvent:
+        array = array[:, np.invert(struc.filter_solvent(array))]
+
+    try:
+        mass = np.array([
+            data.elements.get(x, {}).get('standard_mass', 0.)
+            for x in np.char.title(array.element)
+        ])
+        array.set_annotation('mass', mass)
+    except AttributeError:
+        pass
+
+    def centre_array(atom_array, centre):
+        if centre == 'centroid':
+            atom_array.coord -= bl.obj.centre(atom_array.coord)
+        elif centre == 'mass':
+            atom_array.coord -= bl.obj.centre_weighted(
+                array=atom_array.coord,
+                weight=atom_array.mass
+            )
+
+    if centre in ['mass', 'centroid']:
+        if is_stack:
+            for atom_array in array:
+                centre_array(atom_array, centre)
+        else:
+            centre_array(atom_array, centre)
 
     if isinstance(array, struc.AtomArrayStack):
         if array.stack_depth() > 1:
             frames = array
         array = array[0]
-
-    # remove the solvent from the structure if requested
-    if del_solvent:
-        array = array[np.invert(struc.filter_solvent(array))]
-
-    locations = array.coord * world_scale
 
     if not collection:
         collection = bl.coll.mn()
@@ -387,8 +382,12 @@ def _create_model(array,
         bond_types = bonds_array[:, 2].copy(order='C')
 
     # creating the blender object and meshes and everything
-    mol = bl.obj.create_object(name=name, collection=collection,
-                               vertices=locations, edges=bond_idx)
+    mol = bl.obj.create_object(
+        name=name,
+        collection=collection,
+        vertices=array.coord * world_scale,
+        edges=bond_idx
+    )
 
     # Add information about the bond types to the model on the edge domain
     # Bond types: 'ANY' = 0, 'SINGLE' = 1, 'DOUBLE' = 2, 'TRIPLE' = 3, 'QUADRUPLE' = 4
@@ -472,13 +471,7 @@ def _create_model(array,
         return vdw_radii * world_scale
 
     def att_mass():
-        # units: daltons
-        mass = np.array(list(map(
-            lambda x: data.elements.get(
-                x, {}).get('standard_mass', 0.),
-            np.char.title(array.element)
-        )))
-        return mass
+        return array.mass
 
     def att_atom_name():
         atom_name = np.array(list(map(

--- a/molecularnodes/io/parse/molecule.py
+++ b/molecularnodes/io/parse/molecule.py
@@ -337,7 +337,11 @@ def _create_model(array,
 
     # remove the solvent from the structure if requested
     if del_solvent:
-        array = array[:, np.invert(struc.filter_solvent(array))]
+        mask = np.invert(struc.filter_solvent(array))
+        if is_stack:
+            array = array[:, mask]
+        else:
+            array = array[mask]
 
     try:
         mass = np.array([
@@ -364,7 +368,7 @@ def _create_model(array,
         else:
             centre_array(atom_array, centre)
 
-    if isinstance(array, struc.AtomArrayStack):
+    if is_stack:
         if array.stack_depth() > 1:
             frames = array
         array = array[0]

--- a/tests/__snapshots__/test_load.ambr
+++ b/tests/__snapshots__/test_load.ambr
@@ -7,14 +7,14 @@
 # ---
 # name: test_centring[1BNA-centroid]
   list([
-    '[-0. -0.  0.]',
+    '[-0. -0. -0.]',
     '[-0.0001 -0.      0.0001]',
   ])
 # ---
 # name: test_centring[1BNA-mass]
   list([
     '[ 0.0001  0.     -0.0001]',
-    '[-0. -0.  0.]',
+    '[ 0.  0. -0.]',
   ])
 # ---
 # name: test_centring[4ozs-]
@@ -25,14 +25,14 @@
 # ---
 # name: test_centring[4ozs-centroid]
   list([
-    '[ 0. -0.  0.]',
+    '[-0. -0.  0.]',
     '[-0.      0.0001 -0.0001]',
   ])
 # ---
 # name: test_centring[4ozs-mass]
   list([
     '[ 0.     -0.0001  0.0001]',
-    '[-0. -0. -0.]',
+    '[ 0. -0. -0.]',
   ])
 # ---
 # name: test_centring[8H1B-]
@@ -43,14 +43,14 @@
 # ---
 # name: test_centring[8H1B-centroid]
   list([
-    '[ 0. -0. -0.]',
+    '[-0.  0.  0.]',
     '[-0.0008 -0.0005  0.0005]',
   ])
 # ---
 # name: test_centring[8H1B-mass]
   list([
     '[ 0.0008  0.0005 -0.0005]',
-    '[-0. -0.  0.]',
+    '[-0.  0.  0.]',
   ])
 # ---
 # name: test_centring[8U8W-]
@@ -61,14 +61,14 @@
 # ---
 # name: test_centring[8U8W-centroid]
   list([
-    '[-0.  0. -0.]',
+    '[ 0. -0. -0.]',
     '[ 0.0003 -0.0003  0.0007]',
   ])
 # ---
 # name: test_centring[8U8W-mass]
   list([
     '[-0.0003  0.0003 -0.0007]',
-    '[-0.  0. -0.]',
+    '[ 0. -0.  0.]',
   ])
 # ---
 # name: test_load_small_mol

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -83,12 +83,14 @@ def test_centring(snapshot_custom: NumpySnapshotExtension, code, centre_method):
     centre_method. Check the CoG and CoM values against the snapshot file.
     """
     mol = mn.io.fetch(code, centre=centre_method, cache_dir=data_dir)
-    CoG = mol.centre(centre_type='centroid')
+    CoG = mol.centre()
     CoM = mol.centre(centre_type='mass')
+
     if centre_method == 'centroid':
         assert np.linalg.norm(CoG) < 1e-06
     elif centre_method == 'mass':
         assert np.linalg.norm(CoM) < 1e-06
+
     CoG = np.array_str(CoG, precision=4, suppress_small=True)
     CoM = np.array_str(CoM, precision=4, suppress_small=True)
     assert snapshot_custom == [CoG, CoM]


### PR DESCRIPTION
Refactors the code so that the centre is applied before the object is created, rather than after.

Fixes #496 by applying the centre before the object is created, rather than after. The bug is ultimately created by what is discussed in #439 which is a Blender bug, so this now avoids it.