### PR TITLE
check first for cached file before attempting download

### DIFF
--- a/molecularnodes/io/retrieve.py
+++ b/molecularnodes/io/retrieve.py
@@ -60,6 +60,10 @@ def download(code, format="cif", cache=None, database="rcsb"):
     else:
         file = None
 
+    if file:
+        if os.path.exists(file):
+            return file
+
     # get the contents of the url
     try:
         r = requests.get(_url(code, format, database))


### PR DESCRIPTION
Returns the file path if already exists and using a cache, before attempting any network connections. Speed up if exists and able to be used without a network connection if cache exists.