### PR TITLE
Add operator to switch the style node

### DIFF
--- a/molecularnodes/__init__.py
+++ b/molecularnodes/__init__.py
@@ -14,9 +14,10 @@
 from .utils import template_install
 from . import auto_load
 from .props import MolecularNodesObjectProperties
-from .ui.node_menu import MN_add_node_menu
+from .ui.node_menu import MN_add_node_menu, draw_node_menus
 from .io.parse.mda import _rejuvenate_universe, _sync_universe
 from .io.parse.star import _rehydrate_ensembles
+from .ui.panel import change_style_menu, change_style_node_menu
 import bpy
 
 bl_info = {
@@ -29,7 +30,7 @@ bl_info = {
     "warning": "",
     "doc_url": "https://bradyajohnston.github.io/MolecularNodes/",
     "tracker_url": "https://github.com/BradyAJohnston/MolecularNodes/issues",
-    "category": "Import"
+    "category": "Import",
 }
 
 auto_load.init()
@@ -40,8 +41,9 @@ universe_funcs = [_sync_universe, _rejuvenate_universe]
 def register():
     auto_load.register()
     bpy.types.NODE_MT_add.append(MN_add_node_menu)
-    bpy.types.Object.mn = bpy.props.PointerProperty(
-        type=MolecularNodesObjectProperties)
+    bpy.types.VIEW3D_MT_object_context_menu.prepend(change_style_menu)
+    bpy.types.NODE_MT_context_menu.prepend(change_style_node_menu)
+    bpy.types.Object.mn = bpy.props.PointerProperty(type=MolecularNodesObjectProperties)
     for func in universe_funcs:
         try:
             bpy.app.handlers.load_post.append(func)
@@ -53,6 +55,9 @@ def register():
 def unregister():
     try:
         bpy.types.NODE_MT_add.remove(MN_add_node_menu)
+        bpy.types.VIEW3D_MT_object_context_menu.remove(change_style_menu)
+        bpy.types.NODE_MT_context_menu.remove(change_style_node_menu)
+
         auto_load.unregister()
         del bpy.types.Object.mn
         for func in universe_funcs:

--- a/molecularnodes/ui/node_menu.py
+++ b/molecularnodes/ui/node_menu.py
@@ -5,106 +5,122 @@ from .func import build_menu
 
 
 class MN_MT_Node_Color(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_COLOR'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_COLOR"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
-        build_menu(layout, menu_items['color'])
+        build_menu(layout, menu_items["color"])
 
 
 class MN_MT_Node_Bonds(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_BONDS'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_BONDS"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
-        build_menu(layout, menu_items['bonds'])
+        build_menu(layout, menu_items["bonds"])
 
 
 class MN_MT_Node_Style(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_STYLE'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_STYLE"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
         layout.operator_context = "INVOKE_DEFAULT"
-        build_menu(layout, menu_items['style'])
+        build_menu(layout, menu_items["style"])
 
 
 class MN_MT_Node_Select(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_SELECT'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_SELECT"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
         layout.operator_context = "INVOKE_DEFAULT"
-        build_menu(layout, menu_items['select'])
+        build_menu(layout, menu_items["select"])
 
 
 class MN_MT_Node_Assembly(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_ASSEMBLY'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_ASSEMBLY"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
         layout.operator_context = "INVOKE_DEFAULT"
-        build_menu(layout, menu_items['assembly'])
+        build_menu(layout, menu_items["assembly"])
 
 
 class MN_MT_Node_DNA(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_DNA'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_DNA"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
-        build_menu(layout, menu_items['DNA'])
+        build_menu(layout, menu_items["DNA"])
 
 
 class MN_MT_Node_Animate(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_ANIMATE'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_ANIMATE"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
-        build_menu(layout, menu_items['animate'])
+        build_menu(layout, menu_items["animate"])
 
 
 class MN_MT_Node_Utils(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_UTILS'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_UTILS"
+    bl_label = ""
 
     def draw(self, context):
-        build_menu(self.layout, menu_items['utils'])
+        build_menu(self.layout, menu_items["utils"])
 
 
 class MN_MT_Node_CellPack(bpy.types.Menu):
     bl_idname = "MN_MT_NODE_CELLPACK"
-    bl_label = ''
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
-        build_menu(layout, menu_items['cellpack'])
+        build_menu(layout, menu_items["cellpack"])
 
 
 class MN_MT_Node_Density(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_DENSITY'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_DENSITY"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
         layout.operator_context = "INVOKE_DEFAULT"
-        build_menu(layout, menu_items['density'])
+        build_menu(layout, menu_items["density"])
 
 
 class MN_MT_Node_Topology(bpy.types.Menu):
-    bl_idname = 'MN_MT_NODE_TOPOLOGY'
-    bl_label = ''
+    bl_idname = "MN_MT_NODE_TOPOLOGY"
+    bl_label = ""
 
     def draw(self, context):
         layout = self.layout
         layout.operator_context = "INVOKE_DEFAULT"
-        build_menu(layout, menu_items['topology'])
+        build_menu(layout, menu_items["topology"])
+
+
+def draw_node_menus(self, context):
+    layout = self.layout
+    layout.separator()
+    layout.label(text="Molecular Nodes", icon="MOD_PARTICLES")
+    layout.menu("MN_MT_NODE_STYLE", text="Style", icon_value=77)
+    layout.menu("MN_MT_NODE_SELECT", text="Selection", icon_value=256)
+    layout.menu("MN_MT_NODE_COLOR", text="Color", icon="COLORSET_07_VEC")
+    layout.menu("MN_MT_NODE_ANIMATE", text="Animation", icon_value=409)
+    layout.menu("MN_MT_NODE_TOPOLOGY", text="Topology", icon="ORIENTATION_CURSOR")
+    layout.menu("MN_MT_NODE_ASSEMBLY", text="Assemblies", icon="GROUP_VERTEX")
+    layout.menu("MN_MT_NODE_CELLPACK", text="CellPack", icon="PARTICLE_POINT")
+    layout.menu("MN_MT_NODE_DENSITY", text="Density", icon="VOLUME_DATA")
+    layout.menu("MN_MT_NODE_DNA", text="DNA", icon="GP_SELECT_BETWEEN_STROKES")
+    layout.menu("MN_MT_NODE_UTILS", text="Utilities", icon_value=92)
 
 
 class MN_MT_Node(bpy.types.Menu):
@@ -112,26 +128,10 @@ class MN_MT_Node(bpy.types.Menu):
     bl_label = "Menu for Adding Nodes in GN Tree"
 
     def draw(self, context):
-        layout = self.layout.column_flow(columns=1)
-        layout.operator_context = "INVOKE_DEFAULT"
-
-        layout.menu('MN_MT_NODE_STYLE', text='Style', icon_value=77)
-        layout.menu('MN_MT_NODE_SELECT', text='Selection', icon_value=256)
-        layout.menu('MN_MT_NODE_COLOR', text='Color', icon='COLORSET_07_VEC')
-        layout.menu('MN_MT_NODE_ANIMATE', text='Animation', icon_value=409)
-        layout.menu('MN_MT_NODE_TOPOLOGY', text='Topology',
-                    icon='ORIENTATION_CURSOR')
-        layout.menu('MN_MT_NODE_ASSEMBLY',
-                    text='Assemblies', icon='GROUP_VERTEX')
-        layout.menu('MN_MT_NODE_CELLPACK',
-                    text='CellPack', icon='PARTICLE_POINT')
-        layout.menu('MN_MT_NODE_DENSITY', text='Density', icon="VOLUME_DATA")
-        layout.menu('MN_MT_NODE_DNA', text='DNA',
-                    icon='GP_SELECT_BETWEEN_STROKES')
-        layout.menu('MN_MT_NODE_UTILS', text='Utilities', icon_value=92)
+        draw_node_menus(self, context)
 
 
 def MN_add_node_menu(self, context):
-    if ('GeometryNodeTree' == bpy.context.area.spaces[0].tree_type):
+    if "GeometryNodeTree" == bpy.context.area.spaces[0].tree_type:
         layout = self.layout
-        layout.menu('MN_MT_NODE', text='Molecular Nodes', icon_value=88)
+        layout.menu("MN_MT_NODE", text="Molecular Nodes", icon_value=88)

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -1,68 +1,114 @@
 import bpy
 from .. import pkg
 from ..blender import nodes
-from ..io import (
-    wwpdb, local, star, cellpack, md, density, dna
-)
+from ..io import wwpdb, local, star, cellpack, md, density, dna
 
 bpy.types.Scene.MN_panel = bpy.props.EnumProperty(
     name="Panel Selection",
     items=(
-        ('import', "Import", "Import macromolecules", 0),
-        ('object', "Object", "Adjust settings affecting the selected object", 1),
-        ('scene',  "Scene", "Change settings for the world and rendering", 2)
-    )
+        ("import", "Import", "Import macromolecules", 0),
+        ("object", "Object", "Adjust settings affecting the selected object", 1),
+        ("scene", "Scene", "Change settings for the world and rendering", 2),
+    ),
 )
 
 bpy.types.Scene.MN_panel_import = bpy.props.EnumProperty(
     name="Method",
     items=(
-        ('pdb', "PDB", "Download from the PDB", 0),
-        ('local', "Local", "Open a local file", 1),
-        ('md', "MD", "Import a molecular dynamics trajectory", 2),
-        ('density', "Density", "Import an EM Density Map", 3),
-        ('star', 'Starfile', "Import a .starfile mapback file", 4),
-        ('cellpack', 'CellPack', "Import a CellPack .cif/.bcif file", 5),
-        ('dna', 'oxDNA', 'Import an oxDNA file', 6)
-    )
+        ("pdb", "PDB", "Download from the PDB", 0),
+        ("local", "Local", "Open a local file", 1),
+        ("md", "MD", "Import a molecular dynamics trajectory", 2),
+        ("density", "Density", "Import an EM Density Map", 3),
+        ("star", "Starfile", "Import a .starfile mapback file", 4),
+        ("cellpack", "CellPack", "Import a CellPack .cif/.bcif file", 5),
+        ("dna", "oxDNA", "Import an oxDNA file", 6),
+    ),
 )
 
 chosen_panel = {
-    'pdb': wwpdb,
-    'local': local,
-    'star': star,
-    'md': md,
-    'density': density,
-    'cellpack': cellpack,
-    'dna': dna
-
+    "pdb": wwpdb,
+    "local": local,
+    "star": star,
+    "md": md,
+    "density": density,
+    "cellpack": cellpack,
+    "dna": dna,
 }
 
 packages = {
-    'pdb': ['biotite'],
-    'star': ['starfile','mrcfile','pillow'],
-    'local': ['biotite'],
-    'cellpack': ['biotite', 'msgpack'],
-    'md': ['MDAnalysis'],
-    'density': ['mrcfile'],
-    'dna': []
+    "pdb": ["biotite"],
+    "star": ["starfile", "mrcfile", "pillow"],
+    "local": ["biotite"],
+    "cellpack": ["biotite", "msgpack"],
+    "md": ["MDAnalysis"],
+    "density": ["mrcfile"],
+    "dna": [],
 }
 
 
-class MN_OT_Change_Style(bpy.types.Operator):
-    bl_idname = 'mn.style_change'
-    bl_label = 'Style'
+class MN_OT_Swap_Style_Node(bpy.types.Operator):
+    bl_idname = "mn.style_change_node"
+    bl_label = "Style"
 
-    style: bpy.props.EnumProperty(
-        name="Style",
-        items=nodes.STYLE_ITEMS
-    )
+    style: bpy.props.EnumProperty(name="Style", items=nodes.STYLE_ITEMS)  # type: ignore
+
+    @classmethod
+    def poll(self, context):
+        node = context.space_data.edit_tree.nodes.active
+        return node.name.startswith("MN_style")
+
+    def execute(self, context):
+        nodes.swap_style_node(
+            tree=context.space_data.node_tree,
+            node_style=context.space_data.edit_tree.nodes.active,
+            style=self.style,
+        )
+        return {"FINISHED"}
+
+
+def change_style_menu(self, context):
+    layout = self.layout
+    bob = context.active_object
+    layout.label(text="Molecular Nodes")
+
+    current_style = nodes.format_node_name(
+        nodes.get_style_node(bob).node_tree.name
+    ).replace("Style ", "")
+    layout.operator_menu_enum("mn.style_change", "style", text="Style")
+    # ui_from_node(layout.row(), nodes.get_style_node(bob))
+    layout.separator()
+
+
+def is_style_node(context):
+    node = context.space_data.edit_tree.nodes.active
+    return node.name.startswith("MN_style")
+
+
+def change_style_node_menu(self, context):
+    layout = self.layout
+    layout.label(text="Molecular Nodes", icon="MOD_PARTICLES")
+    row = layout.row()
+    if is_style_node(context):
+        node = context.active_node
+        row.operator_menu_enum("mn.style_change_node", "style", text="Change Style")
+    else:
+        pass
+        # layout.label(text="test")
+
+    layout.separator()
+
+
+class MN_OT_Change_Style(bpy.types.Operator):
+    bl_idname = "mn.style_change"
+    bl_label = "Style"
+
+    style: bpy.props.EnumProperty(name="Style", items=nodes.STYLE_ITEMS)
 
     def execute(self, context):
         object = context.active_object
         nodes.change_style_node(object, self.style)
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 def check_installs(selection):
@@ -76,15 +122,14 @@ def check_installs(selection):
 def panel_import(layout, context):
     scene = context.scene
     selection = scene.MN_panel_import
-    layout.prop(scene, 'MN_panel_import')
+    layout.prop(scene, "MN_panel_import")
     install_required = not check_installs(selection)
     buttons = layout.column(align=True)
 
     if install_required:
-        buttons.label(text='Please install the requried packages.')
+        buttons.label(text="Please install the requried packages.")
         for package in packages[selection]:
-            pkg.button_install_pkg(buttons, package, pkg.get_pkgs()[
-                                   package]['version'])
+            pkg.button_install_pkg(buttons, package, pkg.get_pkgs()[package]["version"])
 
     col = layout.column()
     col.enabled = not install_required
@@ -97,7 +142,7 @@ def ui_from_node(layout, node):
     for user control in a panel, rather than through the node editor.
     """
     col = layout.column(align=True)
-    ntree = bpy.context.active_object.modifiers['MolecularNodes'].node_group
+    ntree = bpy.context.active_object.modifiers["MolecularNodes"].node_group
 
     tree = node.node_tree.interface.items_tree
 
@@ -124,7 +169,7 @@ def panel_object(layout, context):
     if mol_type == "pdb":
         layout.label(text=f"PDB: {object.mn.pdb_code.upper()}")
     if mol_type == "md":
-        layout.prop(object.mn, 'subframes')
+        layout.prop(object.mn, "subframes")
     if mol_type == "star":
         layout.label(text=f"Ensemble")
         box = layout.box()
@@ -134,13 +179,14 @@ def panel_object(layout, context):
     row = layout.row(align=True)
     row.label(text="Style")
     current_style = nodes.format_node_name(
-        nodes.get_style_node(object).node_tree.name).replace("Style ", "")
-    row.operator_menu_enum('mn.style_change', 'style', text=current_style)
+        nodes.get_style_node(object).node_tree.name
+    ).replace("Style ", "")
+    row.operator_menu_enum("mn.style_change", "style", text=current_style)
     box = layout.box()
     ui_from_node(box, nodes.get_style_node(object))
     row = layout.row()
     row.label(text="Experimental", icon_value=2)
-    row.operator('mn.add_armature')
+    row.operator("mn.add_armature")
 
 
 def panel_scene(layout, context):
@@ -158,10 +204,10 @@ def panel_scene(layout, context):
     else:
         world.prop(bpy.data.scenes["Scene"].eevee, "taa_render_samples")
     world.label(text="Background")
-    world.prop(world_shader.inputs[1], 'default_value', text='HDRI Strength')
+    world.prop(world_shader.inputs[1], "default_value", text="HDRI Strength")
     row = world.row()
-    row.prop(scene.render, 'film_transparent')
-    row.prop(world_shader.inputs[2], 'default_value', text="Background")
+    row.prop(scene.render, "film_transparent")
+    row.prop(world_shader.inputs[2], "default_value", text="Background")
 
     col = grid.column()
     col.label(text="Camera Settings")
@@ -172,39 +218,39 @@ def panel_scene(layout, context):
     row.prop(bpy.data.scenes["Scene"].render, "resolution_x", text="X")
     row.prop(bpy.data.scenes["Scene"].render, "resolution_y", text="Y")
     row = camera.grid_flow()
-    row.prop(cam.dof, 'use_dof')
+    row.prop(cam.dof, "use_dof")
     row.prop(bpy.data.scenes["Scene"].render, "use_motion_blur")
     focus = camera.column()
     focus.enabled = cam.dof.use_dof
-    focus.prop(cam.dof, 'focus_object')
+    focus.prop(cam.dof, "focus_object")
     distance = focus.row()
-    distance.enabled = (cam.dof.focus_object is None)
-    distance.prop(cam.dof, 'focus_distance')
-    focus.prop(cam.dof, 'aperture_fstop')
+    distance.enabled = cam.dof.focus_object is None
+    distance.prop(cam.dof, "focus_distance")
+    focus.prop(cam.dof, "aperture_fstop")
 
 
 class MN_PT_panel(bpy.types.Panel):
-    bl_label = 'Molecular Nodes'
-    bl_idname = 'MN_PT_panel'
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = 'scene'
+    bl_label = "Molecular Nodes"
+    bl_idname = "MN_PT_panel"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "scene"
     bl_order = 0
-    bl_options = {'HEADER_LAYOUT_EXPAND'}
+    bl_options = {"HEADER_LAYOUT_EXPAND"}
     bl_ui_units_x = 0
 
     def draw(self, context):
         layout = self.layout
         scene = context.scene
         row = layout.row(align=True)
-        for p in ['import', 'object', 'scene']:
-            row.prop_enum(scene, 'MN_panel', p)
+        for p in ["import", "object", "scene"]:
+            row.prop_enum(scene, "MN_panel", p)
 
         # the possible panel functions to choose between
         which_panel = {
             "import": panel_import,
             "scene": panel_scene,
-            "object": panel_object
+            "object": panel_object,
         }
         # call the required panel function with the layout and context
         which_panel[scene.MN_panel](layout, context)


### PR DESCRIPTION
Adds operators for quickly changing the style node, from both the 3D viewport (changing the auto-detected style node) or in the GN editor, when right clicking on a style node.

https://github.com/BradyAJohnston/MolecularNodes/assets/36021261/fd77aad8-6815-497c-90f0-507c48928ab4

