### PR TITLE
Correction for interpolation when crossing periodic boundaries

### DIFF
--- a/molecularnodes/io/universe/handlers.py
+++ b/molecularnodes/io/universe/handlers.py
@@ -23,10 +23,8 @@ def _update_universes(self, context: bpy.types.Context) -> None:
 def update_universes(scene):
     "Updatins all positions and selections for each universe."
     for universe in scene.MNSession.universes.values():
-        universe._update_trajectory(scene.frame_current)
-        universe._update_selections()
-        # try:
-        #     universe._update_trajectory(scene.frame_current)
-        #     universe._update_selections()
-        # except Exception as e:
-        #     print(f"Error updating {universe}: {e}")
+        try:
+            universe._update_trajectory(scene.frame_current)
+            universe._update_selections()
+        except Exception as e:
+            print(f"Error updating {universe}: {e}")

--- a/molecularnodes/io/universe/handlers.py
+++ b/molecularnodes/io/universe/handlers.py
@@ -23,8 +23,10 @@ def _update_universes(self, context: bpy.types.Context) -> None:
 def update_universes(scene):
     "Updatins all positions and selections for each universe."
     for universe in scene.MNSession.universes.values():
-        try:
-            universe._update_trajectory(scene.frame_current)
-            universe._update_selections()
-        except Exception as e:
-            print(f"Error updating {universe}: {e}")
+        universe._update_trajectory(scene.frame_current)
+        universe._update_selections()
+        # try:
+        #     universe._update_trajectory(scene.frame_current)
+        #     universe._update_selections()
+        # except Exception as e:
+        #     print(f"Error updating {universe}: {e}")

--- a/molecularnodes/io/universe/universe.py
+++ b/molecularnodes/io/universe/universe.py
@@ -9,7 +9,7 @@ from bpy.app.handlers import persistent
 from ... import data
 from ...types import MNDataObject, ObjectMissingError
 from ...blender import coll, nodes, obj
-from ...utils import lerp
+from ...utils import lerp, correct_periodic_positions
 from .selections import Selection, TrajectorySelectionItem
 
 
@@ -475,6 +475,13 @@ class MNUniverse(MNDataObject):
             if frame_b < universe.trajectory.n_frames:
                 universe.trajectory[frame_b]
             locations_b = self.positions
+
+            if bob.mn.correct_periodic:
+                locations_b = correct_periodic_positions(
+                    locations_a,
+                    locations_b,
+                    dimensions=universe.dimensions[:3] * self.world_scale,
+                )
 
             # interpolate between the two sets of positions
             locations = lerp(locations_a, locations_b, t=fraction)

--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -82,3 +82,9 @@ class MolecularNodesObjectProperties(bpy.types.PropertyGroup):
         default=True,
         update=_update_universes,
     )
+    correct_periodic: BoolProperty(  # type: ignore
+        name="Correct",
+        description="Correct for periodic boundary crossing when using interpolation. Assumes cubic dimensions.",
+        default=True,
+        update=_update_universes,
+    )

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -143,6 +143,7 @@ def panel_md_properties(layout, context):
     # row.alignment = "LEFT"
     row.prop(bob.mn, "subframes")
     row.prop(bob.mn, "interpolate")
+    row.prop(bob.mn, "correct_periodic")
     layout.label(text="Selections", icon="RESTRICT_SELECT_OFF")
     row = layout.row()
     row = row.split(factor=0.9)

--- a/molecularnodes/utils.py
+++ b/molecularnodes/utils.py
@@ -5,10 +5,29 @@ from pathlib import Path
 
 import bpy
 import numpy as np
+import numpy.typing as npt
+from typing import List
 from bpy.app.translations import pgettext_tip as tip_
 from mathutils import Matrix
 
 ADDON_DIR = Path(__file__).resolve().parent
+
+
+def correct_periodic_1d(value1, value2, boundary):
+    diff = value2 - value1
+    half = boundary / 2
+    value2[diff > half] -= boundary
+    value2[diff < -half] += boundary
+    return value2
+
+
+def correct_periodic_positions(positions_1, positions_2, dimensions):
+    final_positions = positions_2.copy()
+    for i in range(3):
+        final_positions[:, i] = correct_periodic_1d(
+            positions_1[:, i], positions_2[:, i], dimensions[i]
+        )
+    return final_positions
 
 
 def lerp(a: np.ndarray, b: np.ndarray, t: float = 0.5) -> np.ndarray:

--- a/tests/__snapshots__/test_mda.ambr
+++ b/tests/__snapshots__/test_mda.ambr
@@ -1,4 +1,13 @@
 # serializer version: 1
+# name: TestMDA.test_correct_periodic
+  [[1.5 1.1 1.0]
+   [1.4 1.1 1.0]
+   [1.4 1.1 1.0]
+   ...
+   [1.3 1.4 0.6]
+   [0.0 0.9 1.2]
+   [2.6 2.3 0.4]]
+# ---
 # name: TestMDA.test_save_persistance
   [[0.4 0.3 0.5]
    [0.4 0.3 0.5]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import molecularnodes as mn
+import bpy
+import numpy as np
+
+mn._test_register()
+
+
+def test_correct_1d():
+    assert np.allclose(
+        mn.utils.correct_periodic_1d(np.array((0.9, 0.1)), np.array((0.1, 0.9)), 1.0),
+        np.array((1.1, -0.1)),
+    )


### PR DESCRIPTION
Adds an option to correct for periodic boundary crossing when using interpolation for trajectory playback.

https://github.com/BradyAJohnston/MolecularNodes/assets/36021261/c6c51c0a-b4c8-4633-8bda-e7a9b705b6e1

