### PR TITLE
Handle existing mda session being None

### DIFF
--- a/molecularnodes/io/parse/mda.py
+++ b/molecularnodes/io/parse/mda.py
@@ -431,7 +431,7 @@ class MDAnalysisSession:
             raise ImportError("MDAnalysis is not installed.")
 
         # if the session already exists, load the existing session
-        if hasattr(bpy.types.Scene, "mda_session"):
+        if hasattr(bpy.types.Scene, "mda_session") and bpy.types.Scene.mda_session is not None:
             warnings.warn("The existing mda session is loaded.")
             log.warning("The existing mda session is loaded.")
             existing_session = bpy.types.Scene.mda_session


### PR DESCRIPTION
When parsing a MD file for the first time with molecular nodes 4.1.0 as well as 4.1.0, I got an error that existing_session is None here: https://github.com/BradyAJohnston/MolecularNodes/blob/33a07854f471eebe8f131d260b3fcbc9416f69b0/molecularnodes/io/parse/mda.py#L438

Not sure where this is coming from but this fixes the issue