### PR TITLE
Remove Object Context Menu Swap Style

### DIFF
--- a/molecularnodes/__init__.py
+++ b/molecularnodes/__init__.py
@@ -17,7 +17,7 @@ from bpy.app.handlers import frame_change_post, load_post, save_post
 from . import entities, operators, props, session, ui
 from .ui import pref
 from .ui.node_menu import MN_add_node_menu
-from .ui.panel import MN_PT_panel, change_style_menu, change_style_node_menu
+from .ui.panel import MN_PT_Scene, pt_object_context, change_style_node_menu
 
 all_classes = (
     ui.CLASSES
@@ -25,7 +25,7 @@ all_classes = (
     + entities.CLASSES
     + [
         props.MolecularNodesObjectProperties,
-        MN_PT_panel,
+        MN_PT_Scene,
     ]
     + pref.CLASSES
     + session.CLASSES
@@ -50,7 +50,7 @@ def register():
             pass
 
     bpy.types.NODE_MT_add.append(MN_add_node_menu)
-    bpy.types.VIEW3D_MT_object_context_menu.prepend(change_style_menu)
+    bpy.types.VIEW3D_MT_object_context_menu.prepend(pt_object_context)
     bpy.types.NODE_MT_context_menu.prepend(change_style_node_menu)
 
     save_post.append(session._pickle)
@@ -75,7 +75,7 @@ def unregister():
             pass
 
     bpy.types.NODE_MT_add.remove(MN_add_node_menu)
-    bpy.types.VIEW3D_MT_object_context_menu.remove(change_style_menu)
+    bpy.types.VIEW3D_MT_object_context_menu.remove(pt_object_context)
     bpy.types.NODE_MT_context_menu.remove(change_style_node_menu)
 
     save_post.remove(session._pickle)

--- a/molecularnodes/operators/node_add_buttons.py
+++ b/molecularnodes/operators/node_add_buttons.py
@@ -259,45 +259,11 @@ class MN_OT_Change_Color(Operator):
         return {"FINISHED"}
 
 
-class MN_OT_Change_Style(Operator):
-    bl_idname = "mn.style_change"
-    bl_label = "Style"
-
-    style: EnumProperty(name="Style", items=STYLE_ITEMS)  # type: ignore
-
-    def execute(self, context):
-        object = context.active_object
-        nodes.change_style_node(object, self.style)
-        return {"FINISHED"}
-
-
-class MN_OT_Swap_Style_Node(bpy.types.Operator):
-    bl_idname = "mn.style_change_node"
-    bl_label = "Style"
-
-    style: bpy.props.EnumProperty(name="Style", items=STYLE_ITEMS)  # type: ignore
-
-    @classmethod
-    def poll(self, context):
-        node = context.space_data.edit_tree.nodes.active
-        return node.name.startswith("Style")
-
-    def execute(self, context):
-        nodes.swap_style_node(
-            tree=context.space_data.node_tree,
-            node_style=context.space_data.edit_tree.nodes.active,
-            style=self.style,
-        )
-        return {"FINISHED"}
-
-
 CLASSES = [
     MN_OT_Add_Custom_Node_Group,
     MN_OT_Residues_Selection_Custom,
-    MN_OT_Change_Style,
     MN_OT_Assembly_Bio,
     MN_OT_iswitch_custom,
-    MN_OT_Swap_Style_Node,
     MN_OT_Change_Color,
     MN_OT_Node_Swap,
 ]

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -76,14 +76,9 @@ packages = {
 }
 
 
-def change_style_menu(self, context):
+def pt_object_context(self, context):
     layout = self.layout
-    # obj = context.active_object
-    layout.label(text="Molecular Nodes")
-
-    # current_style = nodes.get_style_node(obj).replace("Style ", "")
-    layout.operator_menu_enum("mn.style_change", "style", text="Style")
-    layout.separator()
+    return None
 
 
 def is_style_node(context):
@@ -93,29 +88,15 @@ def is_style_node(context):
 
 def change_style_node_menu(self, context):
     layout = self.layout
-    layout.label(text="Molecular Nodes", icon="MOD_PARTICLES")
     node = context.active_node
     prefix = node.node_tree.name.split(" ")[0].lower()
     if prefix not in ["color", "select", "is", "style", "topology", "animate"]:
         return None
+    layout.label(text="Molecular Nodes", icon="MOD_PARTICLES")
 
     row = layout.row()
     op = row.operator_menu_enum("mn.node_swap", "node_items", text="Change Node")
     op.node_description = "The topology nodes"
-    # if is_style_node(context):
-    #     row = layout.row()
-    #     row.operator_menu_enum("mn.style_change_node", "style", text="Change Style")
-
-    # if node.name.startswith("Color"):
-    #     row = layout.row()
-    #     row.operator_menu_enum("mn.change_color", "color", text="Change Color")
-    #     row = layout.row()
-    #     op = row.operator_menu_enum("mn.node_swap", "node_items", text="Change Node")
-    #     op.node_description = "testing"
-
-    # layout.row().column().prop(
-    #     context.space_data.edit_tree.nodes.active.node_tree, "color_tag"
-    # )
 
     layout.separator()
 
@@ -305,7 +286,7 @@ def panel_scene(layout, context):
     focus.prop(cam.dof, "aperture_fstop")
 
 
-class MN_PT_panel(bpy.types.Panel):
+class MN_PT_Scene(bpy.types.Panel):
     bl_label = "Molecular Nodes"
     bl_idname = "MN_PT_panel"
     bl_space_type = "PROPERTIES"


### PR DESCRIPTION
After some user feedback, people don't like the right-click to change the style. The menu was also showing up for all objects which is annoying.

It would also be better to not obfuscate the node graph, and still require users to go into the node graph. 

They can right click on the style nodes in there to change them.
