### PR TITLE
Change to `named_attribute()`

### DIFF
--- a/molecularnodes/blender/bones.py
+++ b/molecularnodes/blender/bones.py
@@ -37,7 +37,7 @@ def add_bones(object, name="armature"):
 
 def get_bone_positions(object):
     positions, atom_name, chain_id, res_id, sec_struct = [
-        mesh.get_attribute(object, att)
+        mesh.named_attribute(object, att)
         for att in ["position", "atom_name", "chain_id", "res_id", "sec_struct"]
     ]
 

--- a/molecularnodes/blender/mesh.py
+++ b/molecularnodes/blender/mesh.py
@@ -163,7 +163,7 @@ class AttributeDataType(Enum):
     FLOAT4X4 = "FLOAT4X4"
 
 
-def set_attribute(
+def store_named_attribute(
     obj: bpy.types.Object,
     name: str,
     data: np.ndarray,
@@ -254,7 +254,7 @@ def set_attribute(
     return attribute
 
 
-def get_attribute(
+def named_attribute(
     object: bpy.types.Object, name="position", evaluate=False
 ) -> np.ndarray:
     """
@@ -404,6 +404,8 @@ def create_data_object(
         if np.issubdtype(data.dtype, str):
             data = np.unique(data, return_inverse=True)[1]
 
-        set_attribute(object, name=column, data=data, data_type=type, domain="POINT")
+        store_named_attribute(
+            object, name=column, data=data, data_type=type, domain="POINT"
+        )
 
     return object

--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -730,7 +730,7 @@ def create_assembly_node_tree(
             "name": "assembly_id",
             "type": "NodeSocketInt",
             "min": 1,
-            "max": max(mesh.get_attribute(data_object, "assembly_id")),
+            "max": max(mesh.named_attribute(data_object, "assembly_id")),
             "default": 1,
         },
     )

--- a/molecularnodes/entities/ensemble/cellpack.py
+++ b/molecularnodes/entities/ensemble/cellpack.py
@@ -68,7 +68,7 @@ class CellPack(Ensemble):
             )
 
             colors = np.tile(color.random_rgb(i), (len(chain_atoms), 1))
-            bl.mesh.set_attribute(
+            bl.mesh.store_named_attribute(
                 obj,
                 name="Color",
                 data=colors,

--- a/molecularnodes/entities/ensemble/star.py
+++ b/molecularnodes/entities/ensemble/star.py
@@ -222,7 +222,7 @@ class StarFile(Ensemble):
             col_type = self.data[col].dtype
             # If col_type is numeric directly add
             if np.issubdtype(col_type, np.number):
-                bl.mesh.set_attribute(
+                bl.mesh.store_named_attribute(
                     blender_object,
                     col,
                     self.data[col].to_numpy().reshape(-1),
@@ -235,7 +235,9 @@ class StarFile(Ensemble):
                 codes = (
                     self.data[col].astype("category").cat.codes.to_numpy().reshape(-1)
                 )
-                bl.mesh.set_attribute(blender_object, col, codes, "INT", "POINT")
+                bl.mesh.store_named_attribute(
+                    blender_object, col, codes, "INT", "POINT"
+                )
                 # Add the category names as a property to the blender object
                 blender_object[f"{col}_categories"] = list(
                     self.data[col].astype("category").cat.categories

--- a/molecularnodes/entities/entity.py
+++ b/molecularnodes/entities/entity.py
@@ -64,7 +64,7 @@ class MolecularEntity(metaclass=ABCMeta):
     def object(self, value):
         self.object_ref = value
 
-    def get_attribute(self, name="position", evaluate=False) -> np.ndarray | None:
+    def named_attribute(self, name="position", evaluate=False) -> np.ndarray | None:
         """
         Get the value of an object for the data molecule.
 
@@ -87,7 +87,7 @@ class MolecularEntity(metaclass=ABCMeta):
                 "No object yet created. Use `create_object()` to create a corresponding object."
             )
             return None
-        return bl.mesh.get_attribute(self.object, name=name, evaluate=evaluate)
+        return bl.mesh.named_attribute(self.object, name=name, evaluate=evaluate)
 
     def set_position(self, positions: np.ndarray) -> None:
         "A slightly optimised way to set the positions of the object's mesh"
@@ -110,9 +110,9 @@ class MolecularEntity(metaclass=ABCMeta):
             obj.data.update()  # type: ignore
 
     def set_boolean(self, boolean: np.ndarray, name="boolean") -> None:
-        self.set_attribute(boolean, name=name, data_type="BOOLEAN")
+        self.store_named_attribute(boolean, name=name, data_type="BOOLEAN")
 
-    def set_attribute(
+    def store_named_attribute(
         self,
         data: np.ndarray,
         name="NewAttribute",
@@ -146,7 +146,7 @@ class MolecularEntity(metaclass=ABCMeta):
                 "No object yet created. Use `create_object()` to create a corresponding object."
             )
             return None
-        bl.mesh.set_attribute(
+        bl.mesh.store_named_attribute(
             self.object,
             name=name,
             data=data,

--- a/molecularnodes/entities/molecule/molecule.py
+++ b/molecularnodes/entities/molecule/molecule.py
@@ -23,7 +23,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
     (the object). If multiple conformations are imported, then a `frames` collection
     is also instantiated.
 
-    The `get_attribute()` and `set_attribute()` methods access and set attributes on
+    The `named_attribute()` and `store_named_attribute()` methods access and set attributes on
     `object` that is in the Blender scene.
 
     Attributes
@@ -45,9 +45,9 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
 
     Methods
     -------
-    set_attribute(data, name='NewAttribute', type=None, domain='POINT', overwrite=True)
+    store_named_attribute(data, name='NewAttribute', type=None, domain='POINT', overwrite=True)
         Set an attribute on the object for the molecule.
-    get_attribute(name='position')
+    named_attribute(name='position')
         Get the value of an attribute on the object for the molecule.
     create_object(name='NewMolecule', style='spheres', selection=None, build_assembly=False, centre = '', del_solvent=True, collection=None, verbose=False)
         Create a 3D model for the molecule, based on the values from self.array.
@@ -111,12 +111,12 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         :return: np.ndarray of shape (3,) user-defined centroid of all atoms in
                  the Molecule object
         """
-        positions = self.get_attribute(name="position")
+        positions = self.named_attribute(name="position")
 
         if centre_type == "centroid":
             return bl.mesh.centre(positions)
         elif centre_type == "mass":
-            mass = self.get_attribute(name="mass")
+            mass = self.named_attribute(name="mass")
             return bl.mesh.centre_weighted(positions, mass)
         else:
             raise ValueError(
@@ -327,7 +327,7 @@ def _create_object(
     # 'AROMATIC_SINGLE' = 5, 'AROMATIC_DOUBLE' = 6, 'AROMATIC_TRIPLE' = 7
     # https://www.biotite-python.org/apidoc/biotite.structure.BondType.html#biotite.structure.BondType
     if array.bonds:
-        bl.mesh.set_attribute(
+        bl.mesh.store_named_attribute(
             obj, name="bond_type", data=bond_types, data_type="INT", domain="EDGE"
         )
 
@@ -600,7 +600,7 @@ def _create_object(
         if verbose:
             start = time.process_time()
         try:
-            bl.mesh.set_attribute(
+            bl.mesh.store_named_attribute(
                 obj,
                 name=att["name"],
                 data=att["value"](),
@@ -627,7 +627,7 @@ def _create_object(
                 # vertices=frame.coord * world_scale - centroid
             )
             # TODO if update_attribute
-            # bl.mesh.set_attribute(attribute)
+            # bl.mesh.store_named_attribute(attribute)
 
     # this has started to throw errors for me. I'm not sure why.
     # mol.mn['molcule_type'] = 'pdb'

--- a/molecularnodes/entities/trajectory/dna.py
+++ b/molecularnodes/entities/trajectory/dna.py
@@ -176,7 +176,7 @@ def read_trajectory(filepath):
     return np.stack(frames)
 
 
-def set_attributes_to_dna_mol(mol, frame, scale_dna=0.1):
+def store_named_attributes_to_dna_mol(mol, frame, scale_dna=0.1):
     attributes = ("base_vector", "base_normal", "velocity", "angular_velocity")
     for i, att in enumerate(attributes):
         col_idx = np.array([3, 4, 5]) + i * 3
@@ -190,7 +190,7 @@ def set_attributes_to_dna_mol(mol, frame, scale_dna=0.1):
         if att != "angular_velocity":
             data *= scale_dna
 
-        mesh.set_attribute(mol, att, data, data_type="FLOAT_VECTOR")
+        mesh.store_named_attribute(mol, att, data, data_type="FLOAT_VECTOR")
 
 
 def toplogy_to_bond_idx_pairs(topology: np.ndarray):
@@ -260,15 +260,15 @@ def load(top, traj, name="oxDNA", setup_nodes=True, world_scale=0.01):
     )
 
     # adding additional toplogy information from the topology and frames objects
-    mesh.set_attribute(obj, "res_name", topology[:, 1], "INT")
-    mesh.set_attribute(obj, "chain_id", topology[:, 0], "INT")
-    mesh.set_attribute(
+    mesh.store_named_attribute(obj, "res_name", topology[:, 1], "INT")
+    mesh.store_named_attribute(obj, "chain_id", topology[:, 0], "INT")
+    mesh.store_named_attribute(
         obj,
         "Color",
         data=color.color_chains_equidistant(topology[:, 0]),
         data_type="FLOAT_COLOR",
     )
-    set_attributes_to_dna_mol(obj, trajectory[0], scale_dna=scale_dna)
+    store_named_attributes_to_dna_mol(obj, trajectory[0], scale_dna=scale_dna)
 
     # if the 'frames' file only contained one timepoint, return the object without creating
     # any kind of collection for storing multiple frames from a trajectory, and a None
@@ -288,7 +288,7 @@ def load(top, traj, name="oxDNA", setup_nodes=True, world_scale=0.01):
         frame_obj = mesh.create_object(
             frame[:, 0:3] * scale_dna, name=frame_name, collection=collection
         )
-        set_attributes_to_dna_mol(frame_obj, frame, scale_dna)
+        store_named_attributes_to_dna_mol(frame_obj, frame, scale_dna)
 
     if setup_nodes:
         nodes.create_starting_node_tree(

--- a/molecularnodes/entities/trajectory/trajectory.py
+++ b/molecularnodes/entities/trajectory/trajectory.py
@@ -80,10 +80,6 @@ class Trajectory(MolecularEntity):
         "Set the boolean attribute for this selection on the mesh of the object"
         self.set_boolean(name=selection.name, boolean=selection.to_mask())
 
-    def named_attribute(self, name: str, evaluate=False) -> npt.NDArray:
-        "Get a named attribute from the corresponding object"
-        return self.named_attribute(name=name, evaluate=evaluate)
-
     @property
     def subframes(self):
         obj = self.object

--- a/molecularnodes/entities/trajectory/trajectory.py
+++ b/molecularnodes/entities/trajectory/trajectory.py
@@ -82,7 +82,7 @@ class Trajectory(MolecularEntity):
 
     def named_attribute(self, name: str, evaluate=False) -> npt.NDArray:
         "Get a named attribute from the corresponding object"
-        return self.get_attribute(name=name, evaluate=evaluate)
+        return self.named_attribute(name=name, evaluate=evaluate)
 
     @property
     def subframes(self):
@@ -423,7 +423,7 @@ class Trajectory(MolecularEntity):
 
         for att_name, att in self._attributes_2_blender.items():
             try:
-                mesh.set_attribute(
+                mesh.store_named_attribute(
                     obj, att_name, att["value"], att["type"], att["domain"]
                 )
             except Exception as e:
@@ -452,7 +452,7 @@ class Trajectory(MolecularEntity):
     def _update_calculations(self):
         for name, func in self.calculations.items():
             try:
-                self.set_attribute(name=name, data=func(self.universe))
+                self.store_named_attribute(name=name, data=func(self.universe))
             except Exception as e:
                 print(e)
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -20,10 +20,10 @@ def test_attribute(snapshot_custom, code, format):
         assert snapshot_custom == vals
 
 
-def test_set_attribute(snapshot_custom):
+def test_store_named_attribute(snapshot_custom):
     mol = mn.entities.fetch("8H1B", cache_dir=data_dir, style=None, format="bcif")
-    before = mol.get_attribute("position")
-    mol.set_attribute(mol.get_attribute("position") + 10, "position")
-    after = mol.get_attribute("position")
+    before = mol.named_attribute("position")
+    mol.store_named_attribute(mol.named_attribute("position") + 10, "position")
+    after = mol.named_attribute("position")
 
     assert not np.allclose(before, after)

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -29,7 +29,7 @@ def density_file():
 def test_density_load(density_file):
     obj = mn.entities.density.load(density_file).object
     evaluated = mn.blender.mesh.evaluate_using_mesh(obj)
-    pos = mn.blender.mesh.get_attribute(evaluated, "position")
+    pos = mn.blender.mesh.named_attribute(evaluated, "position")
 
     assert len(pos) > 1000
 
@@ -50,7 +50,7 @@ def test_density_centered(density_file):
     obj = mn.entities.density.load(density_file, center=True, overwrite=True).object
     evaluated = mn.blender.mesh.evaluate_using_mesh(obj)
 
-    pos = mn.blender.mesh.get_attribute(evaluated, "position")
+    pos = mn.blender.mesh.named_attribute(evaluated, "position")
 
     assert len(pos) > 1000
 
@@ -69,7 +69,7 @@ def test_density_invert(density_file):
     style_node.inputs["Threshold"].default_value = 0.01
     evaluated = mn.blender.mesh.evaluate_using_mesh(obj)
 
-    pos = mn.blender.mesh.get_attribute(evaluated, "position")
+    pos = mn.blender.mesh.named_attribute(evaluated, "position")
     # At this threshold after inverting we should have a cube the size of the volume
     assert pos[:, 0].max() > 2.0
     assert pos[:, 1].max() > 2.0

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -64,7 +64,7 @@ def test_download_format(code, format):
             mol2 = o
 
     def verts(object):
-        return mn.blender.mesh.get_attribute(object, "position")
+        return mn.blender.mesh.named_attribute(object, "position")
 
     assert np.isclose(verts(mol), verts(mol2)).all()
 
@@ -114,7 +114,7 @@ def test_centring_different(code):
             mol1.centre(centre_type="mass"), mol2.centre(centre_type="mass")
         )
         assert not np.allclose(
-            mol1.get_attribute("position"), mol2.get_attribute("position")
+            mol1.named_attribute("position"), mol2.named_attribute("position")
         )
 
 
@@ -143,9 +143,9 @@ def test_rcsb_nmr(snapshot_custom):
 
     assert snapshot_custom == sample_attribute(mol, "position", evaluate=True)
 
-    pos_1 = mol.get_attribute("position", evaluate=True)
+    pos_1 = mol.named_attribute("position", evaluate=True)
     bpy.context.scene.frame_set(100)
-    pos_2 = mol.get_attribute("position", evaluate=True)
+    pos_2 = mol.named_attribute("position", evaluate=True)
     assert (pos_1 != pos_2).all()
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -95,7 +95,7 @@ def test_color_custom(snapshot_custom: NumpySnapshotExtension, code, attribute):
     for i, input in enumerate(node_col.inputs):
         input.default_value = mn.color.random_rgb(i)
 
-    assert snapshot_custom == mol.get_attribute("Color")
+    assert snapshot_custom == mol.named_attribute("Color")
 
 
 def test_custom_resid_selection():
@@ -270,7 +270,7 @@ def test_node_topology(snapshot_custom: NumpySnapshotExtension, code, node_name)
 
         group.links.new(output, input)
 
-        assert snapshot_custom == mn.blender.mesh.get_attribute(
+        assert snapshot_custom == mn.blender.mesh.named_attribute(
             mol.object, "test_attribute", evaluate=True
         )
 
@@ -315,7 +315,7 @@ def test_compute_backbone(snapshot_custom: NumpySnapshotExtension):
 
             group.links.new(output, input)
 
-            assert snapshot_custom == mn.blender.mesh.get_attribute(
+            assert snapshot_custom == mn.blender.mesh.named_attribute(
                 mol, "test_attribute", evaluate=True
             )
 
@@ -329,7 +329,7 @@ def test_compute_backbone(snapshot_custom: NumpySnapshotExtension):
 
             group.links.new(output, input)
 
-            assert snapshot_custom == mn.blender.mesh.get_attribute(
+            assert snapshot_custom == mn.blender.mesh.named_attribute(
                 mol, "test_attribute", evaluate=True
             )
 

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -23,11 +23,13 @@ def test_creat_obj():
 def test_set_position():
     mol = mn.entities.fetch("8FAT", cache_dir=data_dir)
 
-    pos_a = mol.get_attribute("position")
+    pos_a = mol.named_attribute("position")
 
-    mol.set_attribute(data=mol.get_attribute("position") + 10, name="position")
+    mol.store_named_attribute(
+        data=mol.named_attribute("position") + 10, name="position"
+    )
 
-    pos_b = mol.get_attribute("position")
+    pos_b = mol.named_attribute("position")
     print(f"{pos_a=}")
     print(f"{pos_b=}")
 
@@ -48,11 +50,11 @@ def test_matrix_read_write():
     arr = np.array((5, 4, 4), float)
     arr = np.random.rand(5, 4, 4)
 
-    mesh.set_attribute(obj, "test_matrix", arr, "FLOAT4X4")
+    mesh.store_named_attribute(obj, "test_matrix", arr, "FLOAT4X4")
 
-    assert np.allclose(mesh.get_attribute(obj, "test_matrix"), arr)
+    assert np.allclose(mesh.named_attribute(obj, "test_matrix"), arr)
 
     arr2 = np.random.rand(5, 4, 4)
-    mesh.set_attribute(obj, "test_matrix2", arr2)
+    mesh.store_named_attribute(obj, "test_matrix2", arr2)
 
-    assert not np.allclose(mesh.get_attribute(obj, "test_matrix2"), arr)
+    assert not np.allclose(mesh.named_attribute(obj, "test_matrix2"), arr)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import molecularnodes as mn
 
-from molecularnodes.blender.mesh import ObjectTracker, get_attribute
+from molecularnodes.blender.mesh import ObjectTracker, named_attribute
 
 from .utils import sample_attribute, NumpySnapshotExtension
 from .constants import data_dir, codes, attributes
@@ -98,10 +98,10 @@ def test_op_api_mda(snapshot_custom: NumpySnapshotExtension):
 
     # capture positions, change the frame number and test that the positions have updated
     # and cahnged
-    pos_1, pos_2 = [get_attribute(x, "position") for x in [obj_1, obj_2]]
+    pos_1, pos_2 = [named_attribute(x, "position") for x in [obj_1, obj_2]]
     bpy.context.scene.frame_set(4)
 
-    assert not np.allclose(get_attribute(obj_1, "position"), pos_1)
+    assert not np.allclose(named_attribute(obj_1, "position"), pos_1)
     assert np.allclose(
-        get_attribute(obj_1, "position"), get_attribute(obj_2, "position")
+        named_attribute(obj_1, "position"), named_attribute(obj_2, "position")
     )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -29,7 +29,7 @@ custom_selections = [
 def test_select_multiple_residues(selection):
     n_atoms = 100
     object = mn.blender.mesh.create_object(np.zeros((n_atoms, 3)))
-    mn.blender.mesh.set_attribute(object, "res_id", np.arange(n_atoms) + 1)
+    mn.blender.mesh.store_named_attribute(object, "res_id", np.arange(n_atoms) + 1)
 
     mod = nodes.get_mod(object)
     group = nodes.new_group(fallback=False)
@@ -44,6 +44,6 @@ def test_select_multiple_residues(selection):
     vertices_count = len(mn.blender.mesh.evaluated(object).data.vertices)
     assert vertices_count == len(selection[1])
     assert (
-        mn.blender.mesh.get_attribute(mn.blender.mesh.evaluated(object), "res_id")
+        mn.blender.mesh.named_attribute(mn.blender.mesh.evaluated(object), "res_id")
         == selection[1]
     ).all()

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -32,7 +32,7 @@ def test_starfile_attributes(type):
     # Activate the rotation debug mode in the nodetreee and get the quaternion attribute
     debugnode = ensemble.star_node.node_tree.nodes["Switch.001"]
     debugnode.inputs["Switch"].default_value = True
-    quat_attribute = ensemble.get_attribute("MNDEBUGEuler", evaluate=True)
+    quat_attribute = ensemble.named_attribute("MNDEBUGEuler", evaluate=True)
 
     # Convert from blender to scipy conventions and then into Scipy rotation
     rot_from_geo_nodes = R.from_quat(quat_attribute[:, [1, 2, 3, 0]])

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -2,7 +2,7 @@ import bpy
 import os
 import pytest
 import molecularnodes as mn
-from molecularnodes.blender.mesh import get_attribute
+from molecularnodes.blender.mesh import named_attribute
 
 import MDAnalysis as mda
 import numpy as np

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,9 @@ def sample_attribute(
 
     random.seed(seed)
     if error:
-        attribute = mn.blender.mesh.get_attribute(object, attribute, evaluate=evaluate)
+        attribute = mn.blender.mesh.named_attribute(
+            object, attribute, evaluate=evaluate
+        )
         length = len(attribute)
 
         if n > length:
@@ -78,7 +80,7 @@ def sample_attribute(
         return attribute[idx, :]
     else:
         try:
-            attribute = mn.blender.mesh.get_attribute(
+            attribute = mn.blender.mesh.named_attribute(
                 object=object, name=attribute, evaluate=evaluate
             )
             length = len(attribute)


### PR DESCRIPTION
Changes the `set_attribute()` and `get_attribute()` to be `store_named_attribute()` and `named_attribute()`.

This aligns with the naming conventions of the nodes, to better signal they are working on the Blender Object rather than normal python objects.

- **change to named_attribute() / store_named_attribute9)**
- **fix trajectory attribute**
