### PR TITLE
add check for online access when drawing panels

### DIFF
--- a/molecularnodes/entities/molecule/ui.py
+++ b/molecularnodes/entities/molecule/ui.py
@@ -461,6 +461,21 @@ class MN_OT_Import_AlphaFold(bpy.types.Operator):
 
 
 def check_online_access_for_ui(layout: bpy.types.UILayout) -> bpy.types.UILayout:
+    """
+    Disable UI without Online Access
+
+    Checks for the online access permissions, and adds a warning and disables following
+    UI elements if it fails the check. Returns the UILayout that will have .enabled flag
+    set to False, disabling all subsequent uses of the layout.
+
+    Args:
+        layout (bpy.types.UILayout): The UILayout element to add the warning and potentially
+        disable.
+
+    Returns:
+        bpy.types.UILayout: The altered UILayout element, for use in downstream UI
+        components.
+    """
     if not bpy.app.online_access:
         layout.label(
             text="Online access disabled. Change in Blender's system preferences.",

--- a/molecularnodes/entities/molecule/ui.py
+++ b/molecularnodes/entities/molecule/ui.py
@@ -463,7 +463,7 @@ class MN_OT_Import_AlphaFold(bpy.types.Operator):
 def check_online_access_for_ui(layout: bpy.types.UILayout) -> bpy.types.UILayout:
     if not bpy.app.online_access:
         layout.label(
-            text="Online access disabled. Change in Blender's network preferences.",
+            text="Online access disabled. Change in Blender's system preferences.",
             icon="ERROR",
         )
         op = layout.operator("wm.url_open", text="Online Access Docs", icon="URL")

--- a/molecularnodes/entities/molecule/ui.py
+++ b/molecularnodes/entities/molecule/ui.py
@@ -460,9 +460,26 @@ class MN_OT_Import_AlphaFold(bpy.types.Operator):
 # the UI for the panel, which will display the operator and the properties
 
 
+def check_online_access_for_ui(layout: bpy.types.UILayout) -> bpy.types.UILayout:
+    if not bpy.app.online_access:
+        layout.label(
+            text="Online access disabled. Change in Blender's network preferences.",
+            icon="ERROR",
+        )
+        op = layout.operator("wm.url_open", text="Online Access Docs", icon="URL")
+        op.url = "https://docs.blender.org/manual/en/dev/editors/preferences/system.html#bpy-types-preferencessystem-use-online-access"
+        layout = layout.column()
+        layout.alert = True
+        layout.enabled = False
+
+    return layout
+
+
 def panel_wwpdb(layout, scene):
     layout.label(text="Download from PDB", icon="IMPORT")
     layout.separator()
+
+    layout = check_online_access_for_ui(layout)
 
     row_import = layout.row().split(factor=0.5)
     row_import.prop(scene, "MN_pdb_code")
@@ -503,6 +520,8 @@ def panel_wwpdb(layout, scene):
 def panel_alphafold(layout, scene):
     layout.label(text="Download from the AlphaFold DataBase", icon="IMPORT")
     layout.separator()
+
+    layout = check_online_access_for_ui(layout)
 
     row_import = layout.row().split(factor=0.5)
     row_import.prop(scene, "MN_alphafold_code")


### PR DESCRIPTION
Adds a check that disables the panel and displays a warning for the wwPDB and AlphaFold download panels if networking disabled.

![image](https://github.com/user-attachments/assets/ce628c70-6146-43b3-a393-0b0aab73df19)
