### PR TITLE
Option to offset trajectory playback

### DIFF
--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -76,6 +76,12 @@ class MolecularNodesObjectProperties(bpy.types.PropertyGroup):
         default=0,
         update=_update_trajectories,
     )
+    offset: IntProperty(  # type: ignore
+        name="Offset",
+        description="Offset the starting playback for the trajectory on the timeine. Positive starts the playback later than frame 0, negative starts it earlier than frame 0",
+        default=0,
+        update=_update_trajectories,
+    )
     interpolate: BoolProperty(  # type: ignore
         name="Interpolate",
         description="Whether to interpolate when using subframes",
@@ -84,7 +90,7 @@ class MolecularNodesObjectProperties(bpy.types.PropertyGroup):
     )
     correct_periodic: BoolProperty(  # type: ignore
         name="Correct",
-        description="Correct for periodic boundary crossing when using interpolation. Assumes cubic dimensions.",
+        description="Correct for periodic boundary crossing when using interpolation. Assumes cubic dimensions",
         default=True,
         update=_update_trajectories,
     )

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -140,6 +140,7 @@ def panel_md_properties(layout, context):
 
     layout.label(text="Trajectory Playback", icon="OPTIONS")
     row = layout.row()
+    row.prop(obj.mn, "offset")
     row.prop(obj.mn, "subframes")
     row.prop(obj.mn, "interpolate")
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -97,7 +97,9 @@ class TestTrajectory:
         bpy.context.scene.frame_set(0)
         pos_0 = traj.named_attribute("position")
 
-        # if we change the offset, we should change the positions if negative
+        # if the offset is negative, the positions of the starting frame 0 will change.
+        # if the offset is positive, then all of the frames up till the offset frame
+        # will remain the same
         traj.offset = offset
         if offset < 0:
             assert not np.allclose(pos_0, traj.named_attribute("position"))

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -90,6 +90,27 @@ class TestTrajectory:
 
         assert not np.allclose(pos_a, pos_b)
 
+    @pytest.mark.parametrize("offset", [-2, 2])
+    def test_trajectory_offset(self, Trajectory, offset):
+        traj = Trajectory
+        traj.offset = 0
+        bpy.context.scene.frame_set(0)
+        pos_0 = traj.named_attribute("position")
+
+        # if we change the offset, we should change the positions if negative
+        traj.offset = offset
+        if offset < 0:
+            assert not np.allclose(pos_0, traj.named_attribute("position"))
+        else:
+            assert np.allclose(pos_0, traj.named_attribute("position"))
+            bpy.context.scene.frame_set(offset - 1)
+            assert np.allclose(pos_0, traj.named_attribute("position"))
+
+        # after resetting the offset to 0, it should be the same as the initial positions
+        bpy.context.scene.frame_set(0)
+        traj.offset = 0
+        assert np.allclose(pos_0, traj.named_attribute("position"))
+
     @pytest.mark.parametrize("interpolate", [True, False])
     def test_subframes(self, Trajectory, interpolate):
         traj = Trajectory


### PR DESCRIPTION
Adds the `Offset` property for Trajectories. Changing this value changes the starting frame for the trajectory during playback. `50` will start the playback of the trajectory at frame `50` inside of Blender. `-50` will start trajectory playback 50 frames before frame `0` inside of Blender. 


https://github.com/user-attachments/assets/ff572d8f-31f2-4d11-bf72-4c849e9a4b79

