### PR TITLE
Add trajectory reloading

### DIFF
--- a/molecularnodes/__init__.py
+++ b/molecularnodes/__init__.py
@@ -45,8 +45,8 @@ def register():
     for op in all_classes:
         try:
             bpy.utils.register_class(op)
-        except Exception:
-            # print(e)
+        except Exception as e:
+            print(e)
             pass
 
     bpy.types.NODE_MT_add.append(MN_add_node_menu)

--- a/molecularnodes/blender/__init__.py
+++ b/molecularnodes/blender/__init__.py
@@ -10,3 +10,10 @@ def path_resolve(path: Union[str, Path]) -> Path:
         return Path(bpy.path.abspath(str(path)))
     else:
         raise ValueError(f"Unable to resolve path: {path}")
+
+
+def active_object(context: bpy.types.Context = None) -> bpy.types.Object:
+    if context is None:
+        return bpy.context.active_object
+
+    return context.active_object

--- a/molecularnodes/entities/__init__.py
+++ b/molecularnodes/entities/__init__.py
@@ -7,7 +7,7 @@ from .ensemble.ui import MN_OT_Import_Cell_Pack, MN_OT_Import_Star_File
 from .molecule.pdb import PDB
 from .molecule.pdbx import BCIF, CIF
 from .molecule.sdf import SDF
-from .molecule.ui import MN_OT_Import_wwPDB, fetch, load_local
+from .molecule.ui import fetch, load_local
 from .trajectory.trajectory import Trajectory
 
 CLASSES = (
@@ -16,7 +16,6 @@ CLASSES = (
         MN_OT_Import_Map,
         MN_OT_Import_OxDNA_Trajectory,
         MN_OT_Import_Star_File,
-        MN_OT_Import_wwPDB,
     ]
     + trajectory.CLASSES
     + molecule.CLASSES

--- a/molecularnodes/entities/trajectory/trajectory.py
+++ b/molecularnodes/entities/trajectory/trajectory.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 
 from ... import data
 from ..entity import MolecularEntity, ObjectMissingError
-from ...blender import coll, mesh, nodes
+from ...blender import coll, mesh, nodes, path_resolve
 from ...utils import lerp, correct_periodic_positions
 from .selections import Selection, TrajectorySelectionItem
 
@@ -416,6 +416,13 @@ class Trajectory(MolecularEntity):
             },
         }
 
+    def save_filepaths_on_object(self) -> None:
+        obj = self.object
+        obj.mn.filepath_topology = str(path_resolve(self.universe.filename))
+        obj.mn.filepath_trajectory = str(
+            path_resolve(self.universe.trajectory.filename)
+        )
+
     def create_object(
         self,
         style: str = "vdw",
@@ -447,6 +454,7 @@ class Trajectory(MolecularEntity):
         obj["atom_type_unique"] = self.atom_type_unique
         self.subframes = subframes
         obj.mn.molecule_type = "md"
+        self.save_filepaths_on_object()
 
         if style is not None:
             nodes.create_starting_node_tree(obj, style=style, name=f"MN_{obj.name}")

--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -94,3 +94,15 @@ class MolecularNodesObjectProperties(bpy.types.PropertyGroup):
         default=True,
         update=_update_trajectories,
     )
+    filepath_trajectory: StringProperty(  # type: ignore
+        name="Trajectory",
+        description="Filepath for the `trajectory` of the Object",
+        subtype="FILE_PATH",
+        default="",
+    )
+    filepath_topology: StringProperty(  # type: ignore
+        name="Topology",
+        description="Filepath for the Topology of the Object",
+        subtype="FILE_PATH",
+        default="",
+    )

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -21,9 +21,7 @@ def trim(dictionary: dict):
         if hasattr(item, "calculations"):
             item.calculations = {}
         try:
-            if isinstance(item.object, bpy.types.Object):
-                item.name = item.object.name
-                item.object = None
+            item.object = None
             if hasattr(item, "frames"):
                 if isinstance(item.frames, bpy.types.Collection):
                     item.frames_name = item.frames.name
@@ -131,11 +129,10 @@ class MNSession:
     def pickle(self, filepath) -> None:
         pickle_path = self.stashpath(filepath)
 
+        make_paths_relative(self.trajectories)
         self.molecules = trim(self.molecules)
         self.trajectories = trim(self.trajectories)
         self.ensembles = trim(self.ensembles)
-
-        make_paths_relative(self.trajectories)
 
         # don't save anything if there is nothing to save
         if self.n_items == 0:

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -45,6 +45,7 @@ def trim(dictionary: dict):
 def make_paths_relative(trajectories: Dict[str, Trajectory]) -> None:
     for key, traj in trajectories.items():
         traj.universe.load_new(make_path_relative(traj.universe.trajectory.filename))
+        traj.save_filepaths_on_object()
 
 
 def trim_root_folder(filename):
@@ -54,7 +55,10 @@ def trim_root_folder(filename):
 
 def make_path_relative(filepath):
     "Take a path and make it relative, in an actually usable way"
-    filepath = os.path.relpath(filepath)
+    try:
+        filepath = os.path.relpath(filepath)
+    except ValueError:
+        return filepath
 
     # count the number of "../../../" there are to remove
     n_to_remove = int(filepath.count("..") - 2)

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -137,6 +137,16 @@ def panel_md_properties(layout, context):
     obj = context.active_object
     session = get_session()
     universe = session.trajectories.get(obj.mn.uuid)
+    trajectory_is_linked = bool(universe)
+    col = layout.column()
+    col.enabled = False
+    if not trajectory_is_linked:
+        col.enabled = True
+        col.label(text="Object not linked to a trajectory, please reload one")
+        col.prop(obj.mn, "filepath_topology")
+        col.prop(obj.mn, "filepath_trajectory")
+        col.operator("mn.reload_trajectory")
+        return None
 
     layout.label(text="Trajectory Playback", icon="OPTIONS")
     row = layout.row()

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -84,7 +84,7 @@ def test_op_api_mda(snapshot_custom: NumpySnapshotExtension):
     bpy.context.scene.MN_import_style = "ribbon"
 
     with ObjectTracker() as o:
-        bpy.ops.mn.import_protein_md()
+        bpy.ops.mn.import_trajectory()
         obj_1 = o.latest()
 
     assert obj_1.name == name


### PR DESCRIPTION
Fixes #615 
Fixes #614 

Helps to fix errors where the trajectory loses it's connection to the underlying universe. Adds operator to more easily restore the trajectory when the connection is lost

https://github.com/user-attachments/assets/e3f176af-d11c-466d-8215-cd53a1883023

- **Operator to reload trajectory**
- **fixed problem with pickling while saving**
