### PR TITLE
Fix relative filepaths

### DIFF
--- a/molecularnodes/bpyd/object.py
+++ b/molecularnodes/bpyd/object.py
@@ -95,7 +95,7 @@ class BlenderObject:
         """
         if not isinstance(obj, Object):
             raise ValueError(f"{obj} must be a Blender object of type Object")
-        self._object = obj
+        self._object_name = obj.name
 
     @property
     def object(self) -> Object | None:
@@ -107,30 +107,8 @@ class BlenderObject:
         Object | None
             The Blender object, or None if not found.
         """
-        # If we don't have connection to an object, attempt to re-stablish to a new
-        # object in the scene with the same UUID. This helps if duplicating / deleting
-        # objects in the scene, but sometimes Blender just loses reference to the object
-        # we are working with because we are manually setting the data on the mesh,
-        # which can wreak havoc on the object database. To protect against this,
-        # if we have a broken link we just attempt to find a new suitable object for it
-        try:
-            # if the connection is broken then trying to the name will raise a connection
-            # error. If we are loading from a saved session then the object_ref will be
-            # None and get an AttributeError
-            self._object.name
-            return self._object
-        except (ReferenceError, AttributeError):
-            for obj in bpy.data.objects:
-                if obj.mn.uuid == self.uuid:
-                    print(
-                        Warning(
-                            f"Lost connection to object: {self._object}, now connected to {obj}"
-                        )
-                    )
-                    self._object = obj
-                    return obj
 
-            return None
+        return bpy.data.objects.get(self._object_name)
 
     @object.setter
     def object(self, value: Object) -> None:
@@ -142,7 +120,7 @@ class BlenderObject:
         value : Object
             The Blender object to set.
         """
-        self._object = value
+        self._object_name = value.name
 
     def store_named_attribute(
         self,

--- a/molecularnodes/entities/__init__.py
+++ b/molecularnodes/entities/__init__.py
@@ -1,14 +1,19 @@
-from . import molecule, trajectory
+from .molecule import CLASSES as MOL_CLASSES
+from .trajectory import CLASSES as TRAJ_CLASSES
 from .density import MN_OT_Import_Map
 from .trajectory.dna import MN_OT_Import_OxDNA_Trajectory
+from .ensemble.ui import MN_OT_Import_Cell_Pack, MN_OT_Import_Star_File
+
 from .ensemble.cellpack import CellPack
 from .ensemble.star import StarFile
-from .ensemble.ui import MN_OT_Import_Cell_Pack, MN_OT_Import_Star_File
 from .molecule.pdb import PDB
 from .molecule.pdbx import BCIF, CIF
 from .molecule.sdf import SDF
 from .molecule.ui import fetch, load_local
-from .trajectory.trajectory import Trajectory
+from .trajectory import Trajectory
+from .molecule import Molecule
+from .ensemble import Ensemble
+
 
 CLASSES = (
     [
@@ -17,6 +22,6 @@ CLASSES = (
         MN_OT_Import_OxDNA_Trajectory,
         MN_OT_Import_Star_File,
     ]
-    + trajectory.CLASSES
-    + molecule.CLASSES
+    + TRAJ_CLASSES
+    + MOL_CLASSES
 )

--- a/molecularnodes/entities/ensemble/__init__.py
+++ b/molecularnodes/entities/ensemble/__init__.py
@@ -1,1 +1,2 @@
 from .ui import load_starfile, load_cellpack
+from .ensemble import Ensemble

--- a/molecularnodes/entities/ensemble/ensemble.py
+++ b/molecularnodes/entities/ensemble/ensemble.py
@@ -18,11 +18,9 @@ class Ensemble(MolecularEntity, metaclass=ABCMeta):
 
         """
         super().__init__()
-        self.type: str = "ensemble"
         self.file_path: Path = bl.path_resolve(file_path)
         self.instances: bpy.types.Collection = None
         self.frames: bpy.types.Collection = None
-        bpy.context.scene.MNSession.ensembles[self.uuid] = self
 
     @classmethod
     def create_object(

--- a/molecularnodes/entities/ensemble/star.py
+++ b/molecularnodes/entities/ensemble/star.py
@@ -15,7 +15,6 @@ from .ensemble import Ensemble
 class StarFile(Ensemble):
     def __init__(self, file_path):
         super().__init__(file_path)
-        self.type = "starfile"
 
     @classmethod
     def from_starfile(cls, file_path):

--- a/molecularnodes/entities/entity.py
+++ b/molecularnodes/entities/entity.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta
 import bpy
 from uuid import uuid1
+from bpy.types import Object
 from ..bpyd import (
     BlenderObject,
 )
@@ -13,8 +14,27 @@ class MolecularEntity(
     def __init__(self) -> None:
         self.uuid: str = str(uuid1())
         self.type: str = ""
-        self._object: bpy.types.Object | None
 
     @property
     def bob(self) -> BlenderObject:
         return BlenderObject(self.object)
+
+    @property
+    def object(self) -> Object:
+        try:
+            return bpy.data.objects[self._object_name]
+        except KeyError:
+            # if we can't find a refernce to the object via a name, then we look via the
+            # unique uuids that were assigned to the object and the entity to match up
+            for obj in bpy.data.objects:
+                if obj.mn.uuid == self.uuid:
+                    self._object_name = obj.name
+                    return obj
+
+    @object.setter
+    def object(self, value) -> None:
+        if not isinstance(value, Object):
+            raise ValueError(
+                f"Can only set object to be of type bpy.types.Object, not {type(value)=}"
+            )
+        self._object_name = value.name

--- a/molecularnodes/entities/entity.py
+++ b/molecularnodes/entities/entity.py
@@ -13,7 +13,7 @@ class MolecularEntity(
 ):
     def __init__(self) -> None:
         self.uuid: str = str(uuid1())
-        self.type: str = ""
+        bpy.context.scene.MNSession.entities[self.uuid] = self
 
     @property
     def bob(self) -> BlenderObject:

--- a/molecularnodes/entities/molecule/molecule.py
+++ b/molecularnodes/entities/molecule/molecule.py
@@ -74,8 +74,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         self.array: np.ndarray
         self._frames_collection_name: str = ""
 
-        bpy.context.scene.MNSession.molecules[self.uuid] = self
-
     @property
     def frames(self) -> Collection:
         return bpy.data.collections.get(self._frames_collection_name)

--- a/molecularnodes/entities/molecule/molecule.py
+++ b/molecularnodes/entities/molecule/molecule.py
@@ -4,6 +4,7 @@ import warnings
 from abc import ABCMeta
 from pathlib import Path
 from typing import Optional, Tuple, Union
+from bpy.types import Collection
 
 import biotite.structure as struc
 import bpy
@@ -71,10 +72,20 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         self._parse_filepath(file_path=file_path)
         self.file: str
         self.array: np.ndarray
-        self.frames: bpy.types.Collection | None = None
-        self.frames_name: str = ""
+        self._frames_collection_name: str = ""
 
         bpy.context.scene.MNSession.molecules[self.uuid] = self
+
+    @property
+    def frames(self) -> Collection:
+        return bpy.data.collections.get(self._frames_collection_name)
+
+    @frames.setter
+    def frames(self, value) -> None:
+        if value is None:
+            self._frames_collection_name = None
+        else:
+            self._frames_collection_name = value.name
 
     @classmethod
     def _read(self, file_path: Union[Path, io.BytesIO]):

--- a/molecularnodes/entities/trajectory/trajectory.py
+++ b/molecularnodes/entities/trajectory/trajectory.py
@@ -21,7 +21,7 @@ class Trajectory(MolecularEntity):
         self.calculations: Dict[str, Callable] = {}
         self.world_scale = world_scale
         self.frame_mapping: npt.NDArray[np.in64] | None = None
-        bpy.context.scene.MNSession.trajectories[self.uuid] = self
+        bpy.context.scene.MNSession.entities[self.uuid] = self
 
     def selection_from_ui(self, ui_item: TrajectorySelectionItem) -> Selection:
         self.selections[ui_item.name] = Selection(

--- a/molecularnodes/entities/trajectory/trajectory.py
+++ b/molecularnodes/entities/trajectory/trajectory.py
@@ -21,7 +21,6 @@ class Trajectory(MolecularEntity):
         self.calculations: Dict[str, Callable] = {}
         self.world_scale = world_scale
         self.frame_mapping: npt.NDArray[np.in64] | None = None
-        bpy.context.scene.MNSession.entities[self.uuid] = self
 
     def selection_from_ui(self, ui_item: TrajectorySelectionItem) -> Selection:
         self.selections[ui_item.name] = Selection(

--- a/molecularnodes/entities/trajectory/ui.py
+++ b/molecularnodes/entities/trajectory/ui.py
@@ -9,7 +9,6 @@ import bpy
 import MDAnalysis as mda
 
 from ... import blender as bl
-from ...session import get_session
 from .trajectory import Trajectory
 from bpy.props import StringProperty
 
@@ -63,7 +62,7 @@ class MN_OT_Reload_Trajectory(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        traj = get_session(context).trajectories.get(obj.mn.uuid)
+        traj = context.scene.MNSession.trajectories.get(obj.mn.uuid)
         return not traj
 
     def execute(self, context):

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -6,22 +6,23 @@ import bpy
 from pathlib import Path
 from bpy.app.handlers import persistent
 from bpy.props import StringProperty
-from bpy.types import Context
+from bpy.types import Context, Operator
 
-from .entities.ensemble.ensemble import Ensemble
-from .entities.molecule.molecule import Molecule
-from .entities.trajectory.trajectory import Trajectory
+from .entities import Ensemble, Molecule, Trajectory
 
 
 def path_relative_to_blend_wd(filepath: str | Path) -> Path:
     "Get the path of something, relative to the working directory of the current .blend file"
-    blend_working_directory = bpy.path.abspath("//")
+    blend_working_directory = Path(bpy.data.filepath).parent
     if blend_working_directory == "":
         raise ValueError(
             "Unable to get current working directly, .blend file not saved"
         )
-
-    return Path(filepath).relative_to(Path(blend_working_directory))
+    try:
+        return Path(filepath).relative_to(Path(blend_working_directory))
+    except ValueError as e:
+        print(Warning("Unable to make "))
+        return Path(filepath)
 
 
 def make_paths_relative(trajectories: Dict[str, Trajectory]) -> None:
@@ -160,29 +161,6 @@ def _pickle(filepath) -> None:
 
 @persistent
 def _load(filepath: str, printing: str = "quiet") -> None:
-    """
-    Load a session from the specified file path.
-
-    This function attempts to load a session from the given file path using the
-    `get_session().load(filepath)` method. If the file path is empty, the function
-    returns immediately without attempting to load anything. If the file is not found,
-    it handles the `FileNotFoundError` exception and optionally prints a message
-    based on the `printing` parameter.
-
-    Args:
-        filepath (str): The path to the file from which to load the session. If this
-            is an empty string, the function will return without doing anything.
-        printing (str, optional): Controls the verbosity of the function. If set to
-            "verbose", a message will be printed when the file is not found. Defaults
-            to "quiet".
-
-    Returns:
-        None: This function does not return any value.
-
-    Raises:
-        FileNotFoundError: If the file specified by `filepath` does not exist and
-            `printing` is set to "verbose", a message will be printed.
-    """
     # the file hasn't been saved or we are opening a fresh file, so don't
     # attempt to load anything
     if filepath == "":
@@ -197,7 +175,7 @@ def _load(filepath: str, printing: str = "quiet") -> None:
             pass
 
 
-class MN_OT_Session_Remove_Item(bpy.types.Operator):
+class MN_OT_Session_Remove_Item(Operator):
     bl_idname = "mn.session_remove_item"
     bl_label = "Remove"
     bl_description = "Remove this item from the internal Molecular Nodes session"
@@ -221,7 +199,7 @@ class MN_OT_Session_Remove_Item(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class MN_OT_Session_Create_Object(bpy.types.Operator):
+class MN_OT_Session_Create_Object(Operator):
     bl_idname = "mn.session_create_object"
     bl_label = "Create Object"
     bl_description = "Create a new object linked to this item"

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -237,8 +237,6 @@ def item_ui(layout, item):
 
 def panel_session(layout, context):
     session = get_session(context)
-    # if session.n_items > 0:
-    #     return None
     row = layout.row()
     row.label(text="Loaded items in the session")
     # row.operator("mn.session_reload")

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -200,7 +200,8 @@ class TestTrajectory:
         assert os.path.exists(session.stashpath(filepath))
         bpy.ops.wm.open_mainfile(filepath=filepath)
 
-        traj = mn.session.get_session().trajectories[uuid]
+        traj = mn.session.get_session().get(uuid)
+        assert traj is not None
         verts_frame_0 = traj.named_attribute("position")
         bpy.context.scene.frame_set(4)
         verts_frame_4 = traj.named_attribute("position")


### PR DESCRIPTION
If we import a molecular dynamics trajectory before first saving the `.blend` file, then the file paths will be absolute for the topology and trajectory. This means the `.blend` is no longer portable. 

This is fine if we remain on the same machine, but breaks if we try to move a folder onto another machine for rendering. 

To fix this, part of the saving / serialisation process has to be turning absolute file paths into relative. This was previously quite janky (#662 ), so needs to be improved and streamlined.