### PR TITLE
Fix long breaks in CA backbones

### DIFF
--- a/tests/test_nodes_geometry.py
+++ b/tests/test_nodes_geometry.py
@@ -5,6 +5,7 @@ from molecularnodes.blender import nodes
 from molecularnodes import bpyd
 
 from .constants import data_dir
+import pytest
 
 
 def test_centre_on_selection():
@@ -34,3 +35,29 @@ def test_centre_on_selection():
     assert np.allclose(
         new_centres, [np.array((0, 0, 0), dtype=float) for x in chain_ids], atol=1e-5
     )
+
+
+def test_atoms_to_ca_splines(snapshot):
+    """
+    This test is for if the chains are still connected as continuous, even though they are
+    separate by a larger distance
+    """
+    mol = mn.entities.fetch("1HQM", style=None)
+
+    group = nodes.get_mod(mol.object).node_group = nodes.new_tree()
+    link = group.links.new
+
+    node_atcas = nodes.add_custom(group, ".Atoms to CA Splines")
+    node_ctm = group.nodes.new("GeometryNodeCurveToMesh")
+
+    link(group.nodes["Group Input"].outputs[0], node_atcas.inputs[0])
+    link(node_atcas.outputs[0], node_ctm.inputs[0])
+    link(node_ctm.outputs[0], group.nodes["Group Output"].inputs[0])
+
+    pos_pre = mol.named_attribute("position", evaluate=True)
+
+    node_atcas.inputs["Threshold (A)"].default_value = 200
+
+    pos_post = mol.named_attribute("position", evaluate=True)
+
+    assert not np.allclose(pos_pre.shape, pos_post.shape)


### PR DESCRIPTION
Fixes problem introduce where long breaks in CA backbones in the same `chain_id` (unmodelled regions) were being filled in for the `Style Ribbon` node. Now the check is not assuming an edge like previously, instead assuming continuous CA.

| Before | After |
|--|--|
|![blender_RAeDrsv8XY](https://github.com/user-attachments/assets/c159f6a4-5320-47bf-8a91-b2e4a8583f4d)|![blender_81cRDffVtj](https://github.com/user-attachments/assets/9a1b9777-c814-4d0b-a98b-8a95b6806e85)|
|![blender_K9Vx3DI9rM](https://github.com/user-attachments/assets/118687eb-e10c-4bb2-996c-14eb802ed45f)|![blender_46w9wDPnTE](https://github.com/user-attachments/assets/db5c9137-2992-4e92-9575-dd3b03a6d1a9)|
