### PR TITLE
Include assets/template directories in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include molecularnodes/assets/*
+recursive-include molecularnodes/assets/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include molecularnodes/assets/*
+recursive-include molecularnodes/assets *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ bpy =  ["bpy>=4.2"]
 test = ["pytest", "pytest-cov", "syrupy", "scipy"]
 docs = ["quartodoc", "tomlkit"]
 
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+molecularnodes = ["assets/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,4 @@ docs = ["quartodoc", "tomlkit"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-molecularnodes = ["assets/*"]
+molecularnodes = ["assets/*", "assets/template/*"]


### PR DESCRIPTION
This pull request resolves the issue where files in the `assets/template/` directories were not being included in the package when installing via `pip install git+https://github.com/BradyAJohnston/MolecularNodes.git@main`
