### PR TITLE
Changes testing to use the new `setup-blender` GHA

### DIFF
--- a/.github/workflows/test-addon.yml
+++ b/.github/workflows/test-addon.yml
@@ -2,9 +2,9 @@ name: Test in Blender
 
 on: 
     push:
-      branches: ["main", "4.2", "extensions-platform"]
+      branches: ["main"]
     pull_request:
-      branches: ["main", "4.2", "extensions-platform"]
+      branches: ["main", "4.2", "4.3"]
     
 jobs:
     build:
@@ -17,53 +17,15 @@ jobs:
               os: [ubuntu-latest, macos-14, windows-latest]
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
+            - uses: BradyAJohnston/setup-blender@v2
               with:
-                python-version: 3.11.7
-              
-            - name: Cache Blender Linux
-              if: matrix.os == 'ubuntu-latest'
-              uses: actions/cache@v2
-              with:
-                path: ~/blender.tar.xz
-                key: ${{ runner.os }}-blender-${{ hashFiles('**/test-addon.yml') }}
-            
-            - name: Test in Blender Linux
-              if: matrix.os == 'ubuntu-latest'
+                version: ${{ matrix.version }}
+            - name: Run tests in Blender
               run: |
-                if [[ ! -f ./blender.tar.xz ]]; then
-                  wget -nv https://download.blender.org/release/Blender${{ matrix.version }}/blender-${{ matrix.version }}.0-linux-x64.tar.xz -O ./blender.tar.xz
-                fi
-                mkdir -p ./blender
-                ls -lrta
-                tar -xf ./blender.tar.xz -C ./blender --strip-components=1
-                ls -lrta
-                blender/blender --version
-                blender/blender -b --python tests/install.py
-                blender/blender -b --python tests/run.py -- -v tests/ --cov=molecularnodes --cov-report=xml:coverage.xml --ignore=molecularnodes/ui/panel.py            
-
-            - name: Test in Blender MacOS ARM
-              if: matrix.os == 'macos-14'
-              run: |
-                curl -L -o blender.dmg https://download.blender.org/release/Blender${{ matrix.version }}/blender-${{ matrix.version }}.0-macos-arm64.dmg
-                hdiutil attach blender.dmg
-                cp -R /Volumes/Blender/Blender.app /Applications/
-                hdiutil detach /Volumes/Blender
-                alias blender='/Applications/Blender.app/Contents/MacOS/Blender'
-                /Applications/Blender.app/Contents/MacOS/Blender --version
-                /Applications/Blender.app/Contents/MacOS/Blender -b -P tests/install.py
-                /Applications/Blender.app/Contents/MacOS/Blender -b -P tests/run.py -- -v tests/
-                        
-            - name: Test in Blender Windows
-              if: matrix.os == 'windows-latest'
-              shell: pwsh
-              run: |
-                Invoke-WebRequest -Uri "https://download.blender.org/release/Blender${{ matrix.version }}/blender-${{ matrix.version }}.0-windows-x64.zip" -OutFile "blender.zip"
-                Expand-Archive -Path "blender.zip" -DestinationPath "blender"
-                $blenderPath = Get-ChildItem -Path "blender" -Directory | Select-Object -First 1
-                .\blender\blender-${{ matrix.version }}.0-windows-x64\blender.exe --version
-                .\blender\blender-${{ matrix.version }}.0-windows-x64\blender.exe -b --python tests/install.py
-                .\blender\blender-${{ matrix.version }}.0-windows-x64\blender.exe -b --python tests/run.py -- -v tests/
+                blender -b -P tests/python.py -- -m pip install uv
+                blender -b -P tests/python.py -- -m uv pip install -r pyproject.toml --all-extras
+                blender -b -P tests/python.py -- -m uv pip install -e .
+                blender -b -P tests/python.py -- -m uv run --no-project --module pytest --cov --cov-report=xml
     
             - name: Expose coverage as a CI download 
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
Changes the test to use the new [`setup-blender`](https://github.com/BradyAJohnston/setup-blender) GHA that I created.

Doesn't do any fancy scraping of versions, just downloads and installs the specified version numbers, up to the user to provide.


Now a much smaller `.yml` file is required: 
```yml
name: Run Tests

on: 
    push:
      branches: ["main"]
    pull_request:
      branches: ["*"]
    
jobs:
    build:
        runs-on: ${{ matrix.os }}
        strategy:
            max-parallel: 4
            fail-fast: false
            matrix:
              version: ["4.2", "4.3"]
              os: [macos-14, "ubuntu-latest", "windows-latest"]
        steps:
            - uses: actions/checkout@v4
            - name: Install Blender
              uses: bradyajohnston/setup-blender@v1
              with:
                version: ${{ matrix.version }}
            - name: Run tests in Blender
              run: blender --version
```