### PR TITLE
Fixes BradyAJohnston/MolecularNodes#698 - bug in custom residues selection operator

### DIFF
--- a/molecularnodes/operators/node_add_buttons.py
+++ b/molecularnodes/operators/node_add_buttons.py
@@ -187,7 +187,7 @@ class MN_OT_Residues_Selection_Custom(Operator):
     )
 
     def execute(self, context):
-        with nodes.DuplicatePrevention():
+        with databpy.nodes.DuplicatePrevention():
             node_residues = nodes.resid_multiple_selection(
                 node_name="MN_select_res_id_custom",
                 input_resid_string=self.input_resid_string,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -100,3 +100,19 @@ def test_op_api_mda(snapshot_custom: NumpySnapshotExtension):
 
     assert not np.allclose(pos_2, traj_op.position)
     assert not np.allclose(pos_2, traj_func.position)
+
+def test_op_residues_selection_custom():
+    topo = str(data_dir / "md_ppr/box.gro")
+    traj = str(data_dir / "md_ppr/first_5_frames.xtc")
+
+    bpy.context.scene.MN_import_md_topology = topo
+    bpy.context.scene.MN_import_md_trajectory = traj
+    bpy.context.scene.mn.import_style = "ribbon"
+
+    with ObjectTracker() as o:
+        bpy.ops.mn.import_trajectory()
+
+    area = bpy.context.screen.areas[-1]
+    area.ui_type = 'GeometryNodeTree'
+    with bpy.context.temp_override(area = area):
+        bpy.ops.mn.residues_selection_custom('EXEC_DEFAULT')


### PR DESCRIPTION
This issue only occurs through the Blender UI.  The API works fine and the test `test_custom_resid_selection` is already included in `tests/test_nodes.py`.  I have added the test case to check for any errors when the operator executes in `tests/test_ops.py`.