### PR TITLE
generalise update handler

### DIFF
--- a/molecularnodes/addon.py
+++ b/molecularnodes/addon.py
@@ -14,7 +14,7 @@
 import bpy
 from bpy.app.handlers import frame_change_pre, load_post, save_post
 from bpy.props import PointerProperty, CollectionProperty
-from .handlers import update_trajectories
+from .handlers import update_entities
 from . import entities, operators, props, session, ui
 from .utils import add_current_module_to_path
 from .ui import pref
@@ -58,7 +58,7 @@ def register():
 
     save_post.append(session._pickle)
     load_post.append(session._load)
-    frame_change_pre.append(update_trajectories)
+    frame_change_pre.append(update_entities)
 
     bpy.types.Scene.MNSession = session.MNSession()  # type: ignore
     bpy.types.Object.uuid = props.uuid_property  # type: ignore
@@ -83,7 +83,7 @@ def unregister():
 
     save_post.remove(session._pickle)
     load_post.remove(session._load)
-    frame_change_pre.remove(update_trajectories)
+    frame_change_pre.remove(update_entities)
     del bpy.types.Scene.MNSession  # type: ignore
     del bpy.types.Scene.mn  # type: ignore
     del bpy.types.Object.mn  # type: ignore

--- a/molecularnodes/entities/trajectory/dna.py
+++ b/molecularnodes/entities/trajectory/dna.py
@@ -56,7 +56,7 @@ class OXDNA(Trajectory):
 
         return self.object
 
-    def _update_positions(self, frame: int) -> None:
+    def set_frame(self, frame: int) -> None:
         super()._update_positions(frame)
         self._update_timestep_values()
 

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -45,9 +45,9 @@ def update_entities(scene):
             else:
                 frame_to_set = entity.frame
             
-            # do the entity setting
+            # do the entity setting, if the method isn't implemented, just pass
             try:
-                entity.set_frame(scene.frame_current)
+                entity.set_frame(frame_to_set)
             except NotImplementedError:
                 pass
 

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -1,28 +1,25 @@
 import bpy
 from bpy.app.handlers import persistent
-# from .session import update_trajectories
-
-# from .session import MNSession
 
 
 # this update function requires a self and context input, as funcitons with these inputs
 # have ot be passed to the `update` arguments of UI properties. When the UI is updated,
 # the function is called with the UI element being `self` and the current context being
 # passed into the function
-def _update_trajectories(self, context: bpy.types.Context) -> None:
+def _udpate_entities(self, context: bpy.types.Context) -> None:
     """
     Function for being called at various points in the updating of the UI, to ensure
     positions and selections of the trajectories are udpated with the new inputs
     """
-    update_trajectories(context.scene)
+    update_entities(context.scene)
 
 
-def _update_trajectories_on_frame_change(self, context: bpy.types.Context) -> None:
+def _update_entities_on_frame_change(self, context: bpy.types.Context) -> None:
     """
     Function for being called at various points in the updating of the UI, to ensure
     positions and selections of the trajectories are udpated with the new inputs
     """
-    update_trajectories(context.scene)
+    update_entities(context.scene)
 
 
 def _selection_update_trajectories(self, context: bpy.types.Context) -> None:
@@ -34,7 +31,7 @@ def _selection_update_trajectories(self, context: bpy.types.Context) -> None:
     if self.immutable:
         return
     else:
-        update_trajectories(context.scene)
+        update_entities(context.scene)
 
 
 # this is the 'perisisent' function which can be appended onto the
@@ -43,25 +40,28 @@ def _selection_update_trajectories(self, context: bpy.types.Context) -> None:
 # use the `frame_change_pre` handler as we want the frame to change first, then we update
 # the universe based on the current frame value
 @persistent
-def update_trajectories(scene):
-    "Call the set_frame method of all trajectories in the current session"
+def update_entities(scene):
+    "Call the `set_frame()` method of all trajectories in the current session"
     session = scene.MNSession
-    for traj in session.trajectories.values():
+    for entity in session.entities:
         # use the updated method if it exists but otherwise fallback on the old method
         # of updating the trajectories
-        if hasattr(traj, "update_with_scene"):
-            if traj.update_with_scene:
-                traj.set_frame(scene.frame_current)
+        
+        if hasattr(entity, "update_with_scene"):
+            if entity.update_with_scene:
+                frame_to_set = scene.frame_current
             else:
-                traj.set_frame(traj.frame)
+                frame_to_set = entity.frame
+            
+            # do the entity setting
+            try:
+                entity.set_frame(scene.frame_current)
+            except NotImplementedError:
+                pass
 
         else:
-            traj._update_positions(scene.frame_current)
-            traj._update_selections()
-            traj._update_calculations()
-
-        # except NotImplementedError:
-        #     pass
-        # except Exception as e:
-        #     # print(f"Error updating {traj}: {e}")
-        #     raise e
+            # this is the old method of updating the trajectories and is maintained for
+            # backwards compatibility # TODO: takeout for later release
+            entity._update_positions(scene.frame_current)
+            entity._update_selections()
+            entity._update_calculations()

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -35,7 +35,7 @@ def _selection_update_trajectories(self, context: bpy.types.Context) -> None:
 def update_entities(scene):
     "Call the `set_frame()` method of all entities in the current session"
     session = scene.MNSession
-    for entity in session.entities:
+    for entity in session.entities.values():
         # use the updated method if it exists but otherwise fallback on the old method
         # of updating the trajectories
         

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -14,14 +14,6 @@ def _udpate_entities(self, context: bpy.types.Context) -> None:
     update_entities(context.scene)
 
 
-def _update_entities_on_frame_change(self, context: bpy.types.Context) -> None:
-    """
-    Function for being called at various points in the updating of the UI, to ensure
-    positions and selections of the trajectories are udpated with the new inputs
-    """
-    update_entities(context.scene)
-
-
 def _selection_update_trajectories(self, context: bpy.types.Context) -> None:
     """
     Function for selection changing. If the selection is immutable e.g.
@@ -41,7 +33,7 @@ def _selection_update_trajectories(self, context: bpy.types.Context) -> None:
 # the universe based on the current frame value
 @persistent
 def update_entities(scene):
-    "Call the `set_frame()` method of all trajectories in the current session"
+    "Call the `set_frame()` method of all entities in the current session"
     session = scene.MNSession
     for entity in session.entities:
         # use the updated method if it exists but otherwise fallback on the old method

--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.types import PropertyGroup
 from bpy.props import IntProperty, BoolProperty, EnumProperty, StringProperty
-from .handlers import _selection_update_trajectories, _update_trajectories
+from .handlers import _selection_update_trajectories, _udpate_entities
 from .style import STYLE_ITEMS
 
 
@@ -117,39 +117,39 @@ class MolecularNodesObjectProperties(PropertyGroup):
         name="Frame",
         description="Frame of the loaded trajectory",
         default=0,
-        update=_update_trajectories,
+        update=_udpate_entities,
         min=0,
     )
     update_with_scene: BoolProperty(  # type: ignore
         name="Update with Scene",
         description="Update the trajectory with the scene frame",
         default=True,
-        update=_update_trajectories,
+        update=_udpate_entities,
     )
     subframes: IntProperty(  # type: ignore
         name="Subframes",
         description="Number of subframes to insert between frames of the loaded trajectory",
         default=0,
-        update=_update_trajectories,
+        update=_udpate_entities,
         min=0,
     )
     offset: IntProperty(  # type: ignore
         name="Offset",
         description="Offset the starting playback for the trajectory on the timeine. Positive starts the playback later than frame 0, negative starts it earlier than frame 0",
         default=0,
-        update=_update_trajectories,
+        update=_udpate_entities,
     )
     interpolate: BoolProperty(  # type: ignore
         name="Interpolate",
         description="Whether to interpolate when using subframes",
         default=True,
-        update=_update_trajectories,
+        update=_udpate_entities,
     )
     average: IntProperty(  # type: ignore
         name="Average",
         description="Average the position this number of frames either side of the current frame",
         default=0,
-        update=_update_trajectories,
+        update=_udpate_entities,
         min=0,
         soft_max=5,
     )
@@ -157,7 +157,7 @@ class MolecularNodesObjectProperties(PropertyGroup):
         name="Correct",
         description="Correct for periodic boundary crossing when using interpolation or averaging. Assumes cubic dimensions and only works if the unit cell is orthorhombic",
         default=False,
-        update=_update_trajectories,
+        update=_udpate_entities,
     )
     filepath_trajectory: StringProperty(  # type: ignore
         name="Trajectory",
@@ -265,7 +265,7 @@ class MN_OT_Universe_Selection_Add(bpy.types.Operator):
         i = int(len(obj.mn_trajectory_selections) - 1)
         obj.mn_trajectory_selections[i].name = f"selection_{i + 1}"
         obj.mn["list_index"] = i
-        _update_trajectories(self, context)
+        _udpate_entities(self, context)
 
         return {"FINISHED"}
 
@@ -286,7 +286,7 @@ class MN_OT_Universe_Selection_Delete(bpy.types.Operator):
         sel_list = obj.mn_trajectory_selections
         sel_list.remove(index)
         obj.mn.trajectory_selection_index = len(sel_list) - 1
-        _update_trajectories(self, context)
+        _udpate_entities(self, context)
 
         return {"FINISHED"}
 


### PR DESCRIPTION
Changes the update handler to be more general, looping over all entities and calling the `set_frame()` method on them. Unblocks #719 
