### PR TITLE
Selection Refactor

### DIFF
--- a/molecularnodes/entities/trajectory/selections.py
+++ b/molecularnodes/entities/trajectory/selections.py
@@ -1,48 +1,110 @@
 import MDAnalysis as mda
 import numpy.typing as npt
 import numpy as np
-
+from uuid import uuid1
 
 class Selection:
     def __init__(
-        self, universe: mda.Universe, selection_str, name, updating=True, periodic=True
-    ):
-        self.selection_str: str = selection_str
-        self.periodic: bool = periodic
-        self.updating: bool = updating
-        self.universe: mda.Universe = universe
-        self.message: str = ""
-        self.name: str = name
-        self.cleanup: bool = True
-        self.ag = universe.select_atoms(
-            selection_str, updating=updating, periodic=periodic
-        )
-        self.mask_array = self._ag_to_mask()
-
-    def _ag_to_mask(self) -> npt.NDArray[np.bool_]:
-        "Return a 1D boolean mask for the Universe atoms that are in the Selection's AtomGroup."
-        return np.isin(self.universe.atoms.ix, self.ag.ix).astype(bool)
-
-    def change_selection(
-        self,
-        selection_str: str,
-        name: str,
-        updating: bool = True,
-        periodic: bool = True,
-    ) -> None:
-        "Change the current AtomGroup, using the parent universe and creating a new selection with the given `selectrion_str`"
-        self.name = name
-        self.periodic = periodic
+        self, trajectory, name: str = "selection_1", selection_str: str = "all",  updating=True, periodic=True
+    ):  
+        self._ag: mda.AtomGroup | None = None
+        self._uuid: str = str(uuid1())
+        self._name = name
+        self._current_selection_str: str = ""
+        self.trajectory = trajectory
+        self.trajectory.object.mn_trajectory_selections.add()
+        self.trajectory.object.mn_trajectory_selections[-1].name = self.name
+        self.trajectory.object.mn_trajectory_selections[-1].uuid = self._uuid
         self.updating = updating
+        self.periodic = periodic
+        self.set_atom_group(selection_str)
         self.selection_str = selection_str
+        self.mask_array = self._ag_to_mask()
+    
+    @property
+    def name(self):
+        return self._name
+    
+    @name.setter
+    def name(self, name):
+        self.ui_item.name = name
+        self._name = name
+    
+    @property
+    def ui_item(self):
+        return self.trajectory.object.mn_trajectory_selections[self.name]
+    
+    @property
+    def selection_str(self) -> str:
+        return self.ui_item.selection_str
+    
+    @selection_str.setter
+    def selection_str(self, selection_str: str) -> None:
+        self.ui_item.selection_str = selection_str
         try:
-            self.ag = self.universe.select_atoms(
-                selection_str, updating=updating, periodic=periodic
-            )
+            self.set_atom_group(selection_str)
+            self.set_selection()
             self.message = ""
         except Exception as e:
             self.message = str(e)
             print(e)
+        
+    @property
+    def periodic(self) -> bool:
+        return self.ui_item.periodic
+
+    @periodic.setter
+    def periodic(self, periodic: bool) -> None:
+        if self.ui_item.periodic == periodic:
+            return
+        self.ui_item.periodic = periodic
+    
+    @property
+    def updating(self) -> bool:
+        return self.ui_item.updating
+    
+    @updating.setter
+    def updating(self, updating: bool) -> None:
+        if self.ui_item.updating == updating:
+            return
+        self.ui_item.updating = updating
+
+    @property
+    def message(self) -> str:
+        return self.ui_item.message
+    
+    @message.setter
+    def message(self, message: str) -> None:
+        self.ui_item.message = message
+
+    @property
+    def immutable(self) -> bool:
+        return self.ui_item.immutable
+    
+    @immutable.setter
+    def immutable(self, immutable: bool) -> None:
+        self.ui_item.immutable = immutable
+    
+    def set_atom_group(self, selection_str: str) -> None:
+        if self._current_selection_str == selection_str:
+            return
+        self._ag = self.trajectory.universe.select_atoms(
+            selection_str,
+            updating=self.updating,
+            periodic=self.periodic
+        )
+        self.mask_array = self._ag_to_mask()
+        self._current_selection_str = selection_str
+    
+    def _ag_to_mask(self) -> npt.NDArray[np.bool_]:
+        "Return a 1D boolean mask for the Universe atoms that are in the Selection's AtomGroup."
+        return np.isin(self.trajectory.universe.atoms.ix, self._ag.ix).astype(bool)
+    
+    def set_selection(self) -> None:
+        "Sets the selection in the trajectory"
+        if not self.updating:
+            return
+        self.trajectory.set_boolean(self.to_mask(), name=self.name)
 
     def to_mask(self) -> npt.NDArray[np.bool_]:
         "Returns the selection as a 1D numpy boolean mask. If updating=True, recomputes selection."
@@ -51,9 +113,8 @@ class Selection:
         return self.mask_array
 
     @classmethod
-    def from_atomgroup(cls, atomgroup: mda.AtomGroup, name: str = ""):
+    def from_atomgroup(cls, trajectory, atomgroup: mda.AtomGroup, name: str = ""):
         "Create a Selection object from an AtomGroup"
-
         # set default value
         selection_str = f"sel_{atomgroup.n_atoms}_atoms"
         updating = False
@@ -74,7 +135,7 @@ class Selection:
 
         if name == "":
             name = selection_str
-        selection = cls(atomgroup.universe, "all", name, updating, periodic)
+        selection = cls(trajectory, atomgroup.universe, "all", name, updating, periodic)
 
         selection.selection_str = selection_str
         selection.ag = atomgroup

--- a/molecularnodes/entities/trajectory/selections.py
+++ b/molecularnodes/entities/trajectory/selections.py
@@ -5,7 +5,7 @@ from uuid import uuid1
 
 class Selection:
     def __init__(
-        self, trajectory, name: str = "selection_1", selection_str: str = "all",  updating=True, periodic=True
+        self, trajectory, name: str = "selection_0", selection_str: str = "all",  updating=True, periodic=True
     ):  
         self._ag: mda.AtomGroup | None = None
         self._uuid: str = str(uuid1())
@@ -22,13 +22,8 @@ class Selection:
         self.mask_array = self._ag_to_mask()
     
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
-    
-    @name.setter
-    def name(self, name):
-        self.ui_item.name = name
-        self._name = name
     
     @property
     def ui_item(self):

--- a/molecularnodes/entities/trajectory/selections.py
+++ b/molecularnodes/entities/trajectory/selections.py
@@ -83,13 +83,18 @@ class Selection:
     def set_atom_group(self, selection_str: str) -> None:
         if self._current_selection_str == selection_str:
             return
-        self._ag = self.trajectory.universe.select_atoms(
-            selection_str,
-            updating=self.updating,
-            periodic=self.periodic
-        )
-        self.mask_array = self._ag_to_mask()
-        self._current_selection_str = selection_str
+        try:
+            self._ag = self.trajectory.universe.select_atoms(
+                selection_str,
+                updating=self.updating,
+                periodic=self.periodic
+            )
+            self.mask_array = self._ag_to_mask()
+            self._current_selection_str = selection_str
+            self.message = ""
+        except Exception as e:
+            self.message = str(e)
+            print(str(e) + f" in selection: `{self.name}` on object: `{self.trajectory.object.name}`" )
     
     def _ag_to_mask(self) -> npt.NDArray[np.bool_]:
         "Return a 1D boolean mask for the Universe atoms that are in the Selection's AtomGroup."

--- a/molecularnodes/entities/trajectory/trajectory.py
+++ b/molecularnodes/entities/trajectory/trajectory.py
@@ -485,13 +485,9 @@ class Trajectory(MolecularEntity):
     def _update_selections(self):
         
         for sel in self.object.mn_trajectory_selections:
-            try:
-                selection = self.selections[sel.name]
-                selection.set_atom_group(sel.selection_str)
-                selection.set_selection()
-            except Exception as e:
-                print(e)
-                return None
+            selection = self.selections[sel.name]
+            selection.set_atom_group(sel.selection_str)
+            selection.set_selection()
 
     @property
     def _frame(self) -> int:

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -6,7 +6,7 @@ from bpy.app.handlers import persistent
 # have ot be passed to the `update` arguments of UI properties. When the UI is updated,
 # the function is called with the UI element being `self` and the current context being
 # passed into the function
-def _udpate_entities(self, context: bpy.types.Context) -> None:
+def _update_entities(self, context: bpy.types.Context) -> None:
     """
     Function for being called at various points in the updating of the UI, to ensure
     positions and selections of the trajectories are udpated with the new inputs

--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -1,9 +1,9 @@
 import bpy
 from bpy.types import PropertyGroup
 from bpy.props import IntProperty, BoolProperty, EnumProperty, StringProperty
-from .handlers import _selection_update_trajectories, _udpate_entities
+from .handlers import _update_entities
 from .style import STYLE_ITEMS
-
+from .session import get_session
 
 uuid_property = StringProperty(  # type: ignore
     name="UUID",
@@ -13,6 +13,12 @@ uuid_property = StringProperty(  # type: ignore
 
 
 class MolecularNodesSceneProperties(PropertyGroup):
+    is_updating: BoolProperty(  # type: ignore
+        name="Updating",
+        description="Currently updating data in the scene, don't trigger more updates",
+        default=False,
+    )
+    
     import_centre: BoolProperty(  # type: ignore
         name="Centre Structure",
         description="Move the imported Molecule on the World Origin",
@@ -117,39 +123,40 @@ class MolecularNodesObjectProperties(PropertyGroup):
         name="Frame",
         description="Frame of the loaded trajectory",
         default=0,
-        update=_udpate_entities,
+        update=_update_entities,
         min=0,
     )
     update_with_scene: BoolProperty(  # type: ignore
         name="Update with Scene",
         description="Update the trajectory with the scene frame",
         default=True,
-        update=_udpate_entities,
+        update=_update_entities,
     )
     subframes: IntProperty(  # type: ignore
         name="Subframes",
         description="Number of subframes to insert between frames of the loaded trajectory",
         default=0,
-        update=_udpate_entities,
+        update=_update_entities,
         min=0,
     )
     offset: IntProperty(  # type: ignore
         name="Offset",
         description="Offset the starting playback for the trajectory on the timeine. Positive starts the playback later than frame 0, negative starts it earlier than frame 0",
         default=0,
-        update=_udpate_entities,
+        update=_update_entities,
     )
+    
     interpolate: BoolProperty(  # type: ignore
         name="Interpolate",
         description="Whether to interpolate when using subframes",
         default=True,
-        update=_udpate_entities,
+        update=_update_entities,
     )
     average: IntProperty(  # type: ignore
         name="Average",
         description="Average the position this number of frames either side of the current frame",
         default=0,
-        update=_udpate_entities,
+        update=_update_entities,
         min=0,
         soft_max=5,
     )
@@ -157,7 +164,7 @@ class MolecularNodesObjectProperties(PropertyGroup):
         name="Correct",
         description="Correct for periodic boundary crossing when using interpolation or averaging. Assumes cubic dimensions and only works if the unit cell is orthorhombic",
         default=False,
-        update=_udpate_entities,
+        update=_update_entities,
     )
     filepath_trajectory: StringProperty(  # type: ignore
         name="Trajectory",
@@ -176,32 +183,38 @@ class MolecularNodesObjectProperties(PropertyGroup):
 class TrajectorySelectionItem(bpy.types.PropertyGroup):
     """Group of properties for custom selections for MDAnalysis import."""
 
+    uuid: StringProperty(  # type: ignore
+        name="UUID",
+        description="Unique ID for matching selection in UI to selection on python object",
+        default=""
+    )
+    
     name: StringProperty(  # type: ignore
         name="Name",
         description="Name of the attribute on the mesh",
         default="custom_selection",
-        update=_selection_update_trajectories,
+        update=_update_entities,
     )
 
     selection_str: StringProperty(  # type: ignore
         name="Selection",
         description="Selection to be applied, written in the MDAnalysis selection language",
         default="name CA",
-        update=_selection_update_trajectories,
+        update=_update_entities,
     )
 
     updating: BoolProperty(  # type: ignore
         name="Updating",
         description="Recalculate the selection on scene frame change",
         default=True,
-        update=_selection_update_trajectories,
+        # update=_selection_update_trajectories,
     )
 
     periodic: BoolProperty(  # type: ignore
         name="Periodic",
         description="For geometric selections, whether to account for atoms in different periodic images when searching",
         default=True,
-        update=_selection_update_trajectories,
+        # update=_selection_update_trajectories,
     )
 
     message: StringProperty(  # type: ignore
@@ -261,11 +274,10 @@ class MN_OT_Universe_Selection_Add(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        obj.mn_trajectory_selections.add()
+        traj = get_session(context).match(obj)
         i = int(len(obj.mn_trajectory_selections) - 1)
-        obj.mn_trajectory_selections[i].name = f"selection_{i + 1}"
+        traj.add_selection(name=f"selection_{i + 1}", selection_str=f"protein")
         obj.mn["list_index"] = i
-        _udpate_entities(self, context)
 
         return {"FINISHED"}
 
@@ -282,12 +294,11 @@ class MN_OT_Universe_Selection_Delete(bpy.types.Operator):
     def execute(self, context):
         obj = context.active_object
         index = obj.mn.trajectory_selection_index
-
-        sel_list = obj.mn_trajectory_selections
-        sel_list.remove(index)
-        obj.mn.trajectory_selection_index = len(sel_list) - 1
-        _udpate_entities(self, context)
-
+        traj  = get_session(context).match(obj)
+        names = [s.name for s in obj.mn_trajectory_selections]
+        traj.remove_selection(names[index])
+        obj.mn.trajectory_selection_index = int(max(min(index, len(obj.mn_trajectory_selections) - 1), 0))
+        
         return {"FINISHED"}
 
 

--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -278,7 +278,16 @@ class MN_OT_Universe_Selection_Add(bpy.types.Operator):
         obj = context.active_object
         traj = get_session(context).match(obj)
         i = int(len(obj.mn_trajectory_selections) - 1)
-        traj.add_selection(name=f"selection_{i + 1}", selection_str=f"protein")
+        name = "selection_0"
+        while True:
+            if len(obj.mn_trajectory_selections) == 0:
+                break
+            if name in obj.mn_trajectory_selections:
+                i += 1
+                name = f"selection_{i}"
+            else:
+                break
+        traj.add_selection(name=name, selection_str="all")
         obj.mn["list_index"] = i
 
         return {"FINISHED"}

--- a/molecularnodes/props.py
+++ b/molecularnodes/props.py
@@ -254,7 +254,9 @@ class MN_UL_TrajectorySelectionListUI(bpy.types.UIList):
                 custom_icon = "ERROR"
                 row.alert = True
 
-            row.prop(item, "name", text="", emboss=False)
+            col = row.column()
+            col.prop(item, "name", text="", emboss=False)
+            col.enabled = False
             row.prop(item, "updating", icon_only=True, icon="FILE_REFRESH")
             row.prop(item, "periodic", icon_only=True, icon="CUBE")
             if item.immutable:


### PR DESCRIPTION
This pull request introduces a comprehensive refactor of the selection logic within the codebase. Key changes include:

- Refactored the selection mechanism for trajectories, they now reference the `UIListItem` items for their properties rather than trying to maintain data between two locations
- Removed the dynamic naming feature for selections, simplifying the naming process. Was a hassle to get working and couldn't sync when changing
- Enhanced error handling in the `set_atom_group` method, ensuring robust exception management and improved logging.
- Updated the selection naming logic in the `MN_OT_Universe_Selection_Add` operator to guarantee unique names are generated dynamically.
