### PR TITLE
Bump to `setup-blender@v3` in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [4.2.5, 4.3.2]
+        version: [4.2, 4.3]
     env:
       ADDON_NAME: molecularnodes
     steps:
@@ -22,7 +22,7 @@ jobs:
         with:
           file: '${{ env.ADDON_NAME }}/blender_manifest.toml'
           field: 'version'
-      - uses: BradyAJohnston/setup-blender@v2.1
+      - uses: BradyAJohnston/setup-blender@v3
         with:
           version: ${{ matrix.version }}
       - name: Build extension

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -3,6 +3,7 @@ name: Test Daily Build
 on:
   schedule:
     - cron: '0 0 * * *'
+
 jobs:
     build:
         runs-on: ${{ matrix.os }}
@@ -14,7 +15,7 @@ jobs:
               os: [ubuntu-latest, macos-14, windows-latest]
         steps:
             - uses: actions/checkout@v4
-            - uses: BradyAJohnston/setup-blender@v2.1
+            - uses: BradyAJohnston/setup-blender@v3
               with:
                 version: ${{ matrix.version }}
             - name: Install in Blender

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
             max-parallel: 4
             fail-fast: false
             matrix:
-              version: ["4.2.5", "4.3.2", "daily"]
+              version: ["4.2", "4.3", "4.4", "daily"]
               os: [ubuntu-latest, macos-14, windows-latest]
         steps:
             - uses: actions/checkout@v4
-            - uses: BradyAJohnston/setup-blender@v2.1
+            - uses: BradyAJohnston/setup-blender@v3
               with:
                 version: ${{ matrix.version }}
             - name: Install in Blender


### PR DESCRIPTION
Bumps to the latest [`setup-blender`](https://github.com/BradyAJohnston/setup-blender) version and adjusts the versions of Blender we are testing against to ensure the 4.4 beta (and eventual release) is being tested.
