### PR TITLE
Handle IPython not being installed in add-on release

### DIFF
--- a/docs/citations/citations.yml
+++ b/docs/citations/citations.yml
@@ -1,3 +1,8 @@
+- title: "Nanoplasmonics for Enhanced Fluorescence Detection of Nucleic Acids: From Fundamentals to Boosting Cancer Management"
+  image: https://advanced.onlinelibrary.wiley.com/cms/asset/7810a557-fd0f-4cbe-a4c3-002ff7926356/anbr202400088-fig-0003-m.jpg
+  path: https://advanced.onlinelibrary.wiley.com/doi/full/10.1002/anbr.202400088
+  doi: https://doi.org/10.1002/anbr.202400088
+
 - title: Modeling membranes in situ
   image: https://ars.els-cdn.com/content/image/1-s2.0-S0959440X24000642-gr1.jpg
   path: https://www.sciencedirect.com/science/article/pii/S0959440X24000642?via%3Dihub

--- a/molecularnodes/scene/base.py
+++ b/molecularnodes/scene/base.py
@@ -1,9 +1,13 @@
 import bpy
 from ..entities import Molecule
 import tempfile
-from IPython.display import Image, display
 from pathlib import Path
 
+try:
+    from IPython.display import Image, display
+except ImportError:
+    Image = None
+    display = None
 IS_EEVEE_NEXT = bpy.app.version[0] == 4 and bpy.app.version[1] >= 2
 
 
@@ -247,4 +251,11 @@ class Canvas:
             tmp_path = Path(tmpdir) / "snapshot.png"
             bpy.context.scene.render.filepath = str(tmp_path)
             bpy.ops.render.render(write_still=True, animation=False)
-            display(Image(tmp_path))
+            if display and Image:
+                display(Image(tmp_path))
+            else:
+                # Alternative handling like saving to disk
+                if path:
+                    import shutil
+
+                    shutil.copy(tmp_path, path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ Documentation = "https://bradyajohnston.github.io/MolecularNodes"
 
 [project.optional-dependencies]
 bpy = ["bpy>=4.2"]
+jupyter = ["jupyter", "IPython"]
 dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython"]
 test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython"]
 docs = ["quartodoc", "tomlkit", "nodepad", "jupyter", "IPython"]


### PR DESCRIPTION
For initial notebook rendering Canvas has been added which uses IPython for notebook display. This better handles if IPython insn't installed because it is the add-on release.

- **handle IPython not being installed for add-on**
- **add jupyter install group**
