### PR TITLE
str -> Optional[Str] in create_starting_node_tree

### DIFF
--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -360,7 +360,7 @@ def create_starting_node_tree(
     coll_frames: bpy.types.Collection | None = None,
     style: str = "spheres",
     name: str | None = None,
-    color: Optional[str]  = "common",
+    color: str | None  = "common",
     material: str = "MN Default",
     is_modifier: bool = True,
 ):

--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -360,7 +360,7 @@ def create_starting_node_tree(
     coll_frames: bpy.types.Collection | None = None,
     style: str = "spheres",
     name: str | None = None,
-    color: str = "common",
+    color: Optional[str]  = "common",
     material: str = "MN Default",
     is_modifier: bool = True,
 ):


### PR DESCRIPTION
`Molecule.create_object()` calls this function which has branch for `None` but a type that is only `str`

```python
def create_starting_node_tree(
    object: bpy.types.Object,
    coll_frames: bpy.types.Collection | None = None,
    style: str = "spheres",
    name: str | None = None,
    color: Optional[str]  = "common",
    material: str = "MN Default",
...
...
    # if requested, setup the nodes for generating colors in the node tree
    if color is not None:    <---- allowing this to be set
        if color == "common":
            node_color_set = add_custom(tree, "Set Color", [200, 0])
            node_color_common = add_custom(tree, "Color Common", [-50, -150])
            node_random_color = add_custom(tree, "Color Attribute Random", [-300, -150])
...
...
```