### PR TITLE
add pytest-xdist to tests install suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Documentation = "https://bradyajohnston.github.io/MolecularNodes"
 bpy = ["bpy>=4.2"]
 jupyter = ["jupyter", "IPython"]
 dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython"]
-test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython"]
+test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython", "pytest-xdist"]
 docs = ["quartodoc", "tomlkit", "nodepad", "jupyter", "IPython"]
 
 [build-system]


### PR DESCRIPTION
not currently used in tests (fails inside of blender, segfaults with bpy module) but useful in future. Speeds up test running on local machine, reporting 100% success but ultimately segfault for reporting reasons in GHA.