### PR TITLE
20250227 smallfix

### DIFF
--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -269,7 +269,10 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         """
         is_stack = isinstance(self.array, struc.AtomArrayStack)
 
-        array = self.array if selection is None else self.array[selection]
+        if isinstance(selection, np.ndarray):
+            array = self.array[selection]
+        else:
+            array = self.array
 
         # remove the solvent from the structure if requested
         if del_solvent:

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -269,10 +269,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         """
         is_stack = isinstance(self.array, struc.AtomArrayStack)
 
-        if selection:
-            array = self.array[selection]
-        else:
-            array = self.array
+        array = self.array if selection is None else self.array[selection]
 
         # remove the solvent from the structure if requested
         if del_solvent:


### PR DESCRIPTION
In the current code, passing a selection leads to the following error:


```
packages/molecularnodes/entities/molecule/base.py#line=269), in Molecule.create_object(self, name, style, selection, build_assembly, centre, del_solvent, del_hydrogen, collection, verbose, color)
    226 """
    227 Create a 3D model of the molecule inside of Blender.
    228 
   (...)
    266     The created 3D model, as an object in the 3D scene.
    267 """
    268 is_stack = isinstance(self.array, struc.AtomArrayStack)
--> 270 if selection:
    271     array = self.array[selection]
    272 else:

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```


This is an issue with truthiness of np.ndarray. This adds explicit type check.