### PR TITLE
make types consistent for materials udring initial tree creation

### DIFF
--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -258,7 +258,7 @@ def new_tree(
     return group
 
 
-def assign_material(node, new_material="default") -> None:
+def assign_material(node, new_material: str | bpy.types.Material ="default") -> None:
     material.add_all_materials()
     material_socket = node.inputs.get("Material")
     if material_socket is None:
@@ -280,7 +280,7 @@ def add_custom(
     name,
     location=[0, 0],
     width=NODE_WIDTH,
-    material="default",
+    material: str | bpy.types.Material ="default",
     show_options=False,
     link=False,
 ):
@@ -361,7 +361,7 @@ def create_starting_node_tree(
     style: str = "spheres",
     name: str | None = None,
     color: str | None = "common",
-    material: str = "MN Default",
+    material: str | bpy.types.Material  = "MN Default",
     is_modifier: bool = True,
 ):
     """


### PR DESCRIPTION
`assign_material` allows for string or material but  the functions that call it restrict it to string. Fixing the signatures in the chain to allow `str | bpy.types.Material`


```python
def assign_material(node, new_material: str | bpy.types.Material ="default") -> None:
    material.add_all_materials()
    material_socket = node.inputs.get("Material")
    if material_socket is None:
        return None

    if isinstance(new_material, bpy.types.Material):
        material_socket.default_value = new_material
    elif new_material == "default":
        material_socket.default_value = material.default()
    else:
```