### PR TITLE
Drop older Blender from tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [4.2, 4.3]
+        version: [4.4]
     env:
       ADDON_NAME: molecularnodes
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
     push:
       branches: ["main"]
     pull_request:
-      branches: ["main", "4.2", "4.3"]
+      branches: ["main", "4.4"]
     
 jobs:
     build:
@@ -13,7 +13,7 @@ jobs:
             max-parallel: 4
             fail-fast: false
             matrix:
-              version: ["4.2", "4.3", "4.4", "daily"]
+              version: ["4.4", "daily"]
               os: [ubuntu-latest, macos-14, windows-latest]
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Targeting only 4.4+ with future releases so dropping older versions from testing GHA.
