### PR TITLE
Fix Doc Build

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -101,7 +101,7 @@ quartodoc:
       desc: Importing and manipulating different molecular entities
       contents:
         # - entities.MolecularEntity
-        - entities.Molecule
+        # - entities.Molecule
         - entities.Trajectory
         - entities.Ensemble
         - entities.OXDNA

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -36,23 +36,23 @@ website:
 
   sidebar:
 
-    - id: nodes            
+    - id: nodes
       title: Nodes
       contents: nodes/
-  
+
     - id: api
       title: Python API
       contents: api/
 
     - id: attributes
-      contents: 
+      contents:
         - attributes.qmd
         - data_table.qmd
         - api_introduction.qmd
 
     - id: tutorials
       align: left
-      contents: 
+      contents:
         - tutorials/index.qmd
         - tutorials/installation.qmd
         - tutorials/00_interface.md
@@ -70,10 +70,10 @@ website:
 format:
   html:
     page-layout: full
-    theme: 
+    theme:
       - darkly
       - style.scss
-      
+
     toc: true
     toc-depth: 2
     preview-colour:
@@ -90,12 +90,12 @@ quartodoc:
   # css: api/_styles-quartodoc.css
 
   sections:
-    - title: Importing
-      desc: Downloading and importing molecular data through the API.
-      contents:
-        - fetch
-        - parse
-        - download.download
+  #   - title: Importing
+  #     desc: Downloading and importing molecular data through the API.
+  #     contents:
+  #       - fetch
+  #       - parse
+  #       - download.download
 
     - title: Entity
       desc: Importing and manipulating different molecular entities
@@ -105,6 +105,6 @@ quartodoc:
         - entities.Trajectory
         - entities.Ensemble
         - entities.OXDNA
-    
+
     - title: Scene
         - scene.Canvas

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -100,7 +100,7 @@ quartodoc:
     - title: Entity
       desc: Importing and manipulating different molecular entities
       contents:
-        - entities.MolecularEntity
+        # - entities.MolecularEntity
         - entities.Molecule
         - entities.Trajectory
         - entities.Ensemble

--- a/docs/api_introduction.qmd
+++ b/docs/api_introduction.qmd
@@ -7,7 +7,7 @@ jupyter: python3
 ::: {.callout-warning}
 # The API is Unstable
 
-Molecular Nodes is designed and created first and foremost as an add-on for Blender, so the API can at times seem a bit quirky and for the time being is not to be considered stable. 
+Molecular Nodes is designed and created first and foremost as an add-on for Blender, so the API can at times seem a bit quirky and for the time being is not to be considered stable.
 
 Molecular Nodes is versioned to match Blender versions, so while we are currently up to "4.2.*", the  API should be not be consired to be that mature.
 :::
@@ -42,7 +42,7 @@ The different methods that are associated mostly interact with the Blender objec
 ```{python}
 print(f"{len(mol)=}")
 print(f"{mol.object=}")
-print(f"{mol.atom_array[0][:10]=}")
+print(f"{mol.atom_array[:10]=}")
 ```
 
 ```{python}
@@ -72,7 +72,7 @@ for code, style, material in zip(codes, styles, materials):
         canvas.scene_reset()
         canvas.render_engine = "CYCLES"
         canvas.samples_cycles = 32
-        # canvas.cycles_device = "GPU" 
+        # canvas.cycles_device = "GPU"
         canvas.cycles_device = "CPU" # can't do GPU rendering on GitHub actions
         mol = mn.fetch(code)
         mol.material = bpy.data.materials[material]

--- a/docs/api_introduction.qmd
+++ b/docs/api_introduction.qmd
@@ -74,7 +74,7 @@ for code, style, material in zip(codes, styles, materials):
         canvas.samples_cycles = 32
         # canvas.cycles_device = "GPU"
         canvas.cycles_device = "CPU" # can't do GPU rendering on GitHub actions
-        mol = mn.fetch(code)
+        mol = mn.Molecule.fetch(code)
         mol.material = bpy.data.materials[material]
         mol.style = 'ribbon'
         canvas.frame_object(mol)

--- a/docs/api_introduction.qmd
+++ b/docs/api_introduction.qmd
@@ -75,7 +75,8 @@ for code, style, material in zip(codes, styles, materials):
         # canvas.cycles_device = "GPU"
         canvas.cycles_device = "CPU" # can't do GPU rendering on GitHub actions
         mol = mn.Molecule.fetch(code)
-        mol.material = bpy.data.materials[material]
+        # note: materials are not available....
+        # mol.material = bpy.data.materials[material]
         mol.style = 'ribbon'
         canvas.frame_object(mol)
         mol.style = style


### PR DESCRIPTION
There are several broken aspects of the Docs due to API changes. 


##  Problem 1:  Imports

- fetch/parse are now part of `Molecule`
- fix: commented out for now


##  Problem 2:  Molecule

- issue in imports
- I would recommend leaving this out until the API is stable or it will keep breaing.

##  Problem 3: Materials

- the materials aren't available
- is there a change to how Materials are loaded?



