### PR TITLE
Consolidate `Molecule` fn interface

### DIFF
--- a/molecularnodes/entities/ensemble/cellpack.py
+++ b/molecularnodes/entities/ensemble/cellpack.py
@@ -7,6 +7,7 @@ from databpy import AttributeTypes, BlenderObject, store_named_attribute
 
 from .base import Ensemble
 from ..molecule.base import Molecule
+from ..utilities import create_object
 from ... import blender as bl
 from ... import color
 
@@ -79,7 +80,7 @@ class CellPack(Ensemble):
             array = self.molecules[mol_id]
             chain_name = array.asym_id[0]
 
-            obj = Molecule.create_object(
+            obj = create_object(
                 array=array,
                 name=mol_id,
                 collection=collection,

--- a/molecularnodes/entities/ensemble/cellpack.py
+++ b/molecularnodes/entities/ensemble/cellpack.py
@@ -10,7 +10,7 @@ from ..molecule.base import Molecule
 from ... import blender as bl
 from ... import color
 
-# from ..molecule.base import _create_object
+
 from .reader import CellPackReader
 from biotite.structure import AtomArray
 
@@ -79,7 +79,7 @@ class CellPack(Ensemble):
             array = self.molecules[mol_id]
             chain_name = array.asym_id[0]
 
-            obj = Molecule._create_object(
+            obj = Molecule.create_object(
                 array=array,
                 name=mol_id,
                 collection=collection,

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -211,7 +211,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
 
     def centre_molecule(self, method: str | None = "centroid"):
         """
-        Offset positions to centre the atoms and vertices over either the geometric cnetroid
+        Offset positions to centre the atoms and vertices over either the geometric centroid
         or the centre of mass.
         """
         if method is None or method == "":
@@ -327,8 +327,8 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
                 continue
 
             # the integer versions of strings have been added as annotations that just
-            # append `_int` onto the name so we don't overrite the original data but when
-            # storing on the meshh we can just remove the `_int`
+            # append `_int` onto the name so we don't overwrite the original data but when
+            # storing on the mesh we can just remove the `_int`
             databpy.store_named_attribute(
                 obj=obj,
                 data=data,

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -65,20 +65,21 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         name: str = "NewObject",
         centre: str | None = None,
         world_scale: float = 0.01,
-        collection: bpy.types.Collection | None = None):
+        collection: bpy.types.Collection | None = None,
+    ):
         """
         Create a 3D model of the molecule, with one vertex for each atom.
         """
 
         array = self.array
         if isinstance(array, AtomArrayStack):
-                array = array[0]
+            array = array[0]
 
         if not collection:
             collection = bl.coll.mn()
 
         bob = databpy.create_bob(
-            vertices= array.coord * world_scale,
+            vertices=array.coord * world_scale,
             edges=array.bonds.as_array()[:, :2] if array.bonds is not None else None,
             name=name,
             collection=collection,

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -61,9 +61,8 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         self._entity_type = EntityType.MOLECULE
         self._reader: ReaderBase | None = reader
         super().__init__()
-
         self.array = array
-        self.object: bpy.types.Object | None = None
+        # self.object: bpy.types.Object | None = None
 
 
     def create_object(self, name: str = "NewObject"):

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -20,7 +20,7 @@ from .reader import ReaderBase
 
 class Molecule(MolecularEntity, metaclass=ABCMeta):
     """
-    Primary Molecular node that coordinates the conversion of structureal bioinfromatic data
+    Primary Molecular Nodes class that coordinates the conversion of structural bioinformatic data
     into raw Blender data.  Most notable the conversion of atoms and bonds into a collection
     of vertices and lines.
 

--- a/molecularnodes/entities/molecule/pdb.py
+++ b/molecularnodes/entities/molecule/pdb.py
@@ -1,5 +1,3 @@
-from io import BytesIO
-from pathlib import Path
 import biotite.structure as struc
 import numpy as np
 from biotite import InvalidFileError

--- a/molecularnodes/entities/molecule/pdbx.py
+++ b/molecularnodes/entities/molecule/pdbx.py
@@ -149,7 +149,7 @@ class PDBXReader(ReaderBase):
             If the 'struct_conf' category is not found in the file.
         """
 
-        # get the annotations for the struc_conf cetegory. Provides start and end
+        # get the annotations for the struc_conf category. Provides start and end
         # residues for the annotations. For most files this will only contain the
         # alpha helices, but will sometimes contain also other secondary structure
         # information such as in AlphaFold predictions

--- a/molecularnodes/entities/utilities.py
+++ b/molecularnodes/entities/utilities.py
@@ -30,14 +30,35 @@ def create_object(
     """
     Create a 3D model of the molecule, with one vertex for each atom.
 
+    This function converts a biotite AtomArray into a Blender object with vertices
+    representing atoms and edges representing bonds. All atomic properties from the
+    AtomArray are stored as named attributes on the Blender mesh, making them
+    accessible for use with Geometry Nodes and other Blender features.
+
     Parameters
     ----------
+    array : AtomArray
+        The molecular structure to convert into a Blender object.
+    name : str, optional
+        Name of the created Blender object. Default is "NewObject".
+    centre : str or None, optional
+        If provided, centers the object according to the specified criteria.
+        Default is None (no centering).
+    world_scale : float, optional
+        Scale factor to apply to atomic coordinates when creating the model.
+        Default is 0.01, which converts Ångströms to a reasonable size in Blender.
+    collection : bpy.types.Collection or None, optional
+        The Blender collection to add the new object to. If None, the object
+        is added to the active collection. Default is None.
 
     Returns
     -------
     bpy.types.Object
         The created 3D model, as an object in the 3D scene.
+        The object contains vertices for atoms and edges for bonds,
+        with all molecular properties stored as named attributes.
     """
+
     if isinstance(array, AtomArrayStack):
         array = array[0]
 
@@ -68,8 +89,35 @@ def create_object(
 
 
 
-def atom_array_to_named_attributes(array, obj, world_scale=0.01):
-    """All annotations in the AtomArray are stored as attributes on the mesh."""
+def atom_array_to_named_attributes(array: AtomArray, obj: bpy.types.Object, world_scale: float = 0.01) -> None:
+    """
+    Store all annotations from an AtomArray as named attributes on Blender vertex data.
+
+    This function iterates through the annotations (properties) of a biotite AtomArray
+    and stores them as named attributes on a Blender mesh object. These attributes can
+    then be accessed and manipulated using Blender's Geometry Nodes system or through Python.
+
+    Only numeric and boolean attributes are stored, as Blender's Geometry Nodes doesn't
+    currently support string attributes. String attributes from the AtomArray should have
+    been converted to numeric representations during the import process.
+
+    Parameters
+    ----------
+    array : AtomArray
+        The biotite AtomArray containing molecular data and annotations to be stored.
+    obj : bpy.types.Object
+        The Blender object (typically a mesh) on which to store the attributes.
+    world_scale : float, optional
+        Scale factor to apply to size-related values like van der Waals radii.
+        Default is 0.01 to convert from Ångströms to Blender units.
+
+    Notes
+    -----
+    - Coordinate data ('coord') is skipped as it's already stored as vertex positions.
+    - 'hetero' flag is also skipped from the annotations.
+    - Any string attributes that were converted to integer codes will have the '_int'
+      suffix removed when stored on the mesh.
+    """
 
     # don't need to add coordinates as those have been stored as `position` on the mesh
     annotations_to_skip = ["coord", "hetero"]

--- a/molecularnodes/entities/utilities.py
+++ b/molecularnodes/entities/utilities.py
@@ -1,0 +1,104 @@
+"""
+Python module for converting molecular structures from biotite into Blender objects.
+
+This module provides functions to:
+1. Create 3D models from biotite AtomArray objects (`create_object`)
+2. Attach molecular information as attributes to Blender objects (`atom_array_to_named_attributes`)
+
+The created Blender objects can be used for visualization and manipulation of molecular
+structures within Blender's 3D environment. Properties like atom positions, bonds, and
+other molecular attributes are preserved as named attributes that can be used with
+Geometry Nodes and other Blender features.
+"""
+
+import bpy
+import databpy
+from databpy import AttributeDomains, AttributeTypes
+from biotite.structure import AtomArray,  AtomArrayStack
+import numpy as np
+
+__all__ = ["create_object", "atom_array_to_named_attributes"]
+
+
+def create_object(
+    array: AtomArray,
+    name="NewObject",
+    centre: str | None = None,
+    world_scale: float = 0.01,
+    collection: bpy.types.Collection | None = None,
+) -> bpy.types.Object:
+    """
+    Create a 3D model of the molecule, with one vertex for each atom.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    bpy.types.Object
+        The created 3D model, as an object in the 3D scene.
+    """
+    if isinstance(array, AtomArrayStack):
+        array = array[0]
+
+    bob = databpy.create_bob(
+        vertices=array.coord * world_scale,
+        edges=array.bonds.as_array()[:, :2] if array.bonds is not None else None,
+        name=name,
+        collection=collection,
+    )
+    # Add information about the bond types to the model on the edge domain
+    # Bond types: 'ANY' = 0, 'SINGLE' = 1, 'DOUBLE' = 2, 'TRIPLE' = 3, 'QUADRUPLE' = 4
+    # 'AROMATIC_SINGLE' = 5, 'AROMATIC_DOUBLE' = 6, 'AROMATIC_TRIPLE' = 7
+    # https://www.biotite-python.org/apidoc/biotite.structure.BondType.html#biotite.structure.BondType
+    if array.bonds:
+        bob.store_named_attribute(
+            array.bonds.as_array()[:, 2],
+            "bond_type",
+            domain=AttributeDomains.EDGE,
+            atype=AttributeTypes.INT,
+        )
+
+    atom_array_to_named_attributes(array, bob.object, world_scale=world_scale)
+
+    if centre is not None:
+        bob.position -= bob.centroid(centre)
+
+    return bob.object
+
+
+
+def atom_array_to_named_attributes(array, obj, world_scale=0.01):
+    """All annotations in the AtomArray are stored as attributes on the mesh."""
+
+    # don't need to add coordinates as those have been stored as `position` on the mesh
+    annotations_to_skip = ["coord", "hetero"]
+
+    for attr in array.get_annotation_categories():
+        if attr in annotations_to_skip:
+            continue
+
+        data = array.get_annotation(attr)  # type: ignore
+
+        if attr == "vdw_radii":
+            data *= world_scale
+
+        # geometry nodes doesn't support strings at the moment so we can only store the
+        # numeric and boolean attributes on the mesh. All string attributes should have
+        # already been converted to a corresponding numeric attribute during the
+        # reader process
+
+        if not (
+            np.issubdtype(data.dtype, np.number)
+            or np.issubdtype(data.dtype, np.bool_)
+        ):
+            continue
+
+        # the integer versions of strings have been added as annotations that just
+        # append `_int` onto the name so we don't overrite the original data but when
+        # storing on the meshh we can just remove the `_int`
+        databpy.store_named_attribute(
+            obj=obj,
+            data=data,
+            name=attr.replace("_int", ""),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "molecularnodes"
-version = "4.2.12"
+version = "4.2.13"
 description = "Toolbox for molecular animations with Blender and Geometry Nodes."
 readme = "README.md"
 dependencies = [
@@ -35,4 +35,3 @@ packages = ["molecularnodes"]
 
 [tool.setuptools.package-data]
 molecularnodes = ["assets/*", "assets/template/*", "**/*.py"]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "molecularnodes"
-version = "4.2.13"
+version = "4.2.12"
 description = "Toolbox for molecular animations with Blender and Geometry Nodes."
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
The `mn.Molecule` class is shaping up to be the primary class around which loading, modifying, and converting data is happening. After the recent large reorg in #766 its worth trying to simplify that class a bit. I noticed that there are 2 fns - `create_object` & `_create_object`.: the first calls the second.  Furthermore, the `Cellpack` file uses `_create_object`.   

To simplify reuse I have:

- moved the `create_object` and dependent `atom_array_to_named_attributes` to its own utility file.  
- updated Molecele to use those
- updated CellPack to use those.

Note: it seems that something similar might be useful for mesh data. In this case these FNs convert:

- biotite--> vertices

We also have a case of:

- MdAnalysis -> Mesh.

