### PR TITLE
Bump `bpy` version and fix VDB import

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: test-in-blender
+name: tests
 
 on: 
     push:
@@ -7,7 +7,7 @@ on:
       branches: ["main", "4.4"]
     
 jobs:
-    test-blender:
+    blender:
         runs-on: ${{ matrix.os }}
         strategy:
             max-parallel: 4
@@ -38,7 +38,7 @@ jobs:
               if: matrix.os == 'ubuntu-latest'
               uses: codecov/codecov-action@v3
     
-    test-bpy:
+    bpy:
         runs-on: ${{ matrix.os }}
         strategy:
             max-parallel: 4
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/checkout@v4
             - name: Install uv
               uses: astral-sh/setup-uv@v5
-            - name: Install in Blender
+            - name: Install molecularnodes
               run: |
                 uv venv --python=3.11
                 uv pip install ".[test]"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,6 @@ jobs:
                 uv pip install -e .
             - name: Run Tests
               run: |
-                uv python -m pytest -n auto -k "not density"
-                uv python -m pytest -k density
+                uv run python -m pytest -n auto -k "not density"
+                uv run python -m pytest -k density
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,6 @@ jobs:
                 uv venv --python=3.11
                 uv pip install ".[test]"
                 uv pip install bpy==${{ matrix.version }}
-                uv pip install -e .
             - name: Run Tests
               run: |
                 uv run python -m pytest -n auto -k "not density"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
       branches: ["main", "4.4"]
     
 jobs:
-    build:
+    test-blender:
         runs-on: ${{ matrix.os }}
         strategy:
             max-parallel: 4
@@ -38,3 +38,24 @@ jobs:
               if: matrix.os == 'ubuntu-latest'
               uses: codecov/codecov-action@v3
     
+    test-bpy:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            max-parallel: 4
+            fail-fast: false
+            matrix:
+              version: ["4.4"]
+              os: [ubuntu-latest, macos-14, windows-latest]
+        steps:
+            - uses: actions/checkout@v4
+            - name: Install uv
+              uses: astral-sh/setup-uv@v5
+            - name: Install in Blender
+              run: |
+                uv pip install ".[test]"
+                uv pip install -e .
+            - name: Run Tests
+              run: |
+                uv python -m pytest -n auto -k "not density"
+                uv python -m pytest -k density
+      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
               run: |
                 uv venv --python=3.11
                 uv pip install ".[test]"
+                uv pip install bpy==${{ matrix.version }}
                 uv pip install -e .
             - name: Run Tests
               run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
               uses: astral-sh/setup-uv@v5
             - name: Install in Blender
               run: |
+                uv venv --python=3.11
                 uv pip install ".[test]"
                 uv pip install -e .
             - name: Run Tests

--- a/molecularnodes/entities/density/mrc.py
+++ b/molecularnodes/entities/density/mrc.py
@@ -97,7 +97,7 @@ class MRC(Density):
         str
             The path to the converted .vdb file.
         """
-        import pyopenvdb as vdb
+        import openvdb as vdb
 
         file_path = self.path_to_vdb(file, center=center, invert=invert)
 
@@ -118,13 +118,16 @@ class MRC(Density):
         # Read in the MRC file and convert it to a pyopenvdb grid
         grid = self.map_to_grid(file=file, invert=invert, center=center)
 
-        grid.transform.scale(np.array((1, 1, 1)) * world_scale * grid["MN_voxel_size"])
+        print(f"{dir(grid.transform)}")
+        grid.transform.preScale(
+            np.array((1, 1, 1)) * world_scale * grid["MN_voxel_size"]
+        )
 
         if center:
             offset = -np.array(grid["MN_box_size"]) * 0.5
             offset *= grid["MN_voxel_size"] * world_scale
             print("transforming")
-            grid.transform.translate(offset)
+            grid.transform.postTranslate(offset)
 
         if os.path.exists(file_path):
             os.remove(file_path)
@@ -159,7 +162,7 @@ class MRC(Density):
             A pyopenvdb FloatGrid object containing the density data.
         """
 
-        import pyopenvdb as vdb
+        import openvdb as vdb
 
         volume = mrcfile.read(file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "molecularnodes"
-version = "4.2.12"
+version = "4.4.0"
 description = "Toolbox for molecular animations with Blender and Geometry Nodes."
 readme = "README.md"
 dependencies = [
@@ -19,7 +19,7 @@ Repository = "https://github.com/bradyajohnston/MolecularNodes"
 Documentation = "https://bradyajohnston.github.io/MolecularNodes"
 
 [project.optional-dependencies]
-bpy = ["bpy>=4.2"]
+bpy = ["bpy>=4.4"]
 jupyter = ["jupyter", "IPython"]
 dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython"]
 test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython", "pytest-xdist"]

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -7,10 +7,8 @@ from .constants import data_dir
 from .utils import NumpySnapshotExtension
 from databpy import ObjectTracker
 
-try:
-    import pyopenvdb
-except ImportError:
-    pytest.skip("pyopenvdb not installed", allow_module_level=True)
+bpy.utils.expose_bundled_modules()
+import openvdb
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ css = [
 
 [[package]]
 name = "bpy"
-version = "4.3.0"
+version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cython" },
@@ -249,10 +249,11 @@ dependencies = [
     { name = "zstandard" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/fc/5902fa508a13f4f1669bc2e2cd8f37adf1caeeed0a344f627c0ffc3bdc40/bpy-4.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82c3486e9762e8cfce4bbc1d6752f5625da8515f6b217e02810350627d693897", size = 217245993 },
-    { url = "https://files.pythonhosted.org/packages/81/39/4e763b150ff05412ab25d5eae91da7f0ade474b5d66509b39a67066d35ec/bpy-4.3.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:490aa94699664a99eee755047485a3ad70470fc6267c55a73459660f52299ade", size = 230465428 },
-    { url = "https://files.pythonhosted.org/packages/9c/4d/897bf3c247d7c6a4e75397f4c5dd5d201fb147981d2271ac35ac955959ab/bpy-4.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1620199392a7e7aab58672aa47c50b3c5b1e4d39d46af5a7f9bbe2af561ea942", size = 377434308 },
-    { url = "https://files.pythonhosted.org/packages/7f/da/c255b626cab58c69c49f4a65d0410b36aa1086dc63862d1c3de653f0a5a0/bpy-4.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a7b2c516aa7a95c31fcaae8842addd07fa86c1ce4768e88a34b480d17e2e93a", size = 333159335 },
+    { url = "https://files.pythonhosted.org/packages/78/9a/3602426e41e1c912e0557774a69ec4cddca5a2251687db265a2817c9a62b/bpy-4.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3b8736699a6ea06fed33d2e3042cdd5555409d0b51e2b7274f38be3f9bf774f4", size = 217733774 },
+    { url = "https://files.pythonhosted.org/packages/0f/5e/7f64271fb211d02859917c786b0273964570b9242b497f29913955eeca72/bpy-4.4.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:9609454d84fd4d668adc82f839d14817f56a14179dd0ddf02ac24580be5ca77b", size = 231678638 },
+    { url = "https://files.pythonhosted.org/packages/99/ef/28b7850065934fa9797f612cd52f13b9fd74574907bb886882fb18e13065/bpy-4.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:50ee92155cdb8740214fa3b29d9a45ee90cda9dc15eb978860916de468b8580f", size = 368892624 },
+    { url = "https://files.pythonhosted.org/packages/a9/b1/bb03b0c4f78c13f30e871d5f1d68cf27c85096aef3cb2de1e061bd8766bd/bpy-4.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:6281ddd11ebe6008db143f422d7dd709c520f3f3574814dd37dda6d9cd85a1ae", size = 324938053 },
+    { url = "https://files.pythonhosted.org/packages/40/9b/a9acaf9ec0a88a065bd92328c35ff7ba17af93bc7b2611ad01ee26bdcfa8/bpy-4.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:5658b7f9e13dc90a64419038a52585a581fc9ab53ec909bf5199946226f4b0c0", size = 189065128 },
 ]
 
 [[package]]
@@ -1410,7 +1411,7 @@ wheels = [
 
 [[package]]
 name = "molecularnodes"
-version = "4.2.12"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },
@@ -1455,7 +1456,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "biotite", specifier = ">=1.1" },
-    { name = "bpy", marker = "extra == 'bpy'", specifier = ">=4.2" },
+    { name = "bpy", marker = "extra == 'bpy'", specifier = ">=4.4" },
     { name = "databpy", specifier = ">=0.0.16" },
     { name = "fake-bpy-module", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },


### PR DESCRIPTION
Bump versions to 4.4 for MN & `bpy`. Fixes problems with importing `pyopenvdb` (now `openvdb` for density import.

Fixes #717 