### PR TITLE
Small NodeGroup typing fix

### DIFF
--- a/molecularnodes/blender/nodes.py
+++ b/molecularnodes/blender/nodes.py
@@ -780,7 +780,7 @@ def custom_iswitch(
     offset: int = 0,
     panels: Optional[List[str]] = None,
     panels_open: int = 1,
-):
+) -> bpy.types.GeometryNodeTree:
     """
     Creates a named `Index Switch` node.
 
@@ -819,7 +819,7 @@ def custom_iswitch(
 
     Returns
     -------
-    group : bpy.types.NodeGroup
+    group : bpy.types.GeometryNodeTree
         The created node group.
 
     Raises

--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -30,7 +30,7 @@ class MolecularEntity(
         return BlenderObject(self.object)
 
     @property
-    def node_group(self) -> bpy.types.NodeGroup:
+    def node_group(self) -> bpy.types.GeometryNodeTree:
         return self.object.modifiers["MolecularNodes"].node_group
 
     @property

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -304,7 +304,7 @@ def panel_import(layout, context):
 
 
 def ui_from_node(
-    layout: bpy.types.UILayout, node: bpy.types.NodeGroup, context: bpy.types.Context
+    layout: bpy.types.UILayout, node: bpy.types.GeometryNodeGroup, context: bpy.types.Context
 ):
     """
     Generate the UI for a particular node, which displays the relevant node inputs


### PR DESCRIPTION
I'm not really familar with the codebase, just found this by grepping Github to figure when actually NodeGroup is used.

Changes:

1) custom_iswitch - actually returns NodeTree, not NodeGroup. Added more specific type that actually is used - GeometryNodeTree

2) node_group - also returning NodeTree, not NodeGroup

3) ui_from_node - added more specific GeometryNodeGroup. Oddly enough, in Blender GeometryNodeGroup and doesn't inherit from NodeGroup and typing would complain about passing GeometryNodeGroup though it is the one that's intended here.