### PR TITLE
Info not error when importing with MN collection disabled

### DIFF
--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -479,7 +479,7 @@ class MN_OT_Import_Fetch(bpy.types.Operator):
                     code=self.code, cache=self.cache_dir, format=self.file_format
                 )
                 .add_style(
-                    style=self.style if self.node_setup else None,
+                    style=self.style if self.node_setup else None,  # type: ignore
                     assembly=self.assembly,
                 )
                 .centre_molecule(self.centre_type if self.centre else None)
@@ -494,8 +494,13 @@ class MN_OT_Import_Fetch(bpy.types.Operator):
                 )
             return {"CANCELLED"}
 
-        bpy.context.view_layer.objects.active = mol.object
-        self.report({"INFO"}, message=f"Imported '{self.code}' as {mol.name}")
+        message = f"Downloaded {self.code} as {mol.name}"
+        try:
+            bpy.context.view_layer.objects.active = mol.object  # type: ignore
+        except RuntimeError:
+            message += " - MolecularNodes collection is disabled"
+
+        self.report({"INFO"}, message=message)
 
         return {"FINISHED"}
 
@@ -517,17 +522,19 @@ class MN_OT_Import_Protein_Local(Import_Molecule):
             Molecule.load(self.filepath)
             .centre_molecule(self.centre_type if self.centre else None)
             .add_style(
-                style=self.style if self.node_setup else None, assembly=self.assembly
+                style=self.style if self.node_setup else None,  # type: ignore
+                assembly=self.assembly,
             )
         )
 
-        # return the good news!
-        bpy.context.view_layer.objects.active = mol.object
-        self.report({"INFO"}, message=f"Imported '{self.filepath}' as {mol.name}")
-        return {"FINISHED"}
+        message = f"Imported '{self.filepath}' as {mol.name}"
+        try:
+            bpy.context.view_layer.objects.active = mol.object  # type: ignore
+        except RuntimeError:
+            message += " - MolecularNodes collection is disabled"
 
-    def invoke(self, context, event):
-        return self.execute(context)
+        self.report({"INFO"}, message=message)
+        return {"FINISHED"}
 
 
 class ImportEnsemble(bpy.types.Operator):


### PR DESCRIPTION
Currently when importing via the GUI with the `MolecularNodes` collection disabled in the outliner, it throws a python error. This instead continues on and reports as part of the `Info` that it was successful but the collection is disabled.
