### PR TITLE
Try Blext: Attempt #2

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -51,6 +51,14 @@ BLExtSpec(
 # you need to use the head
 # see https://codeberg.org/so-rose/blext/issues/57
 uvx --from git+https://codeberg.org/so-rose/blext blext build
+uvx --from git+https://codeberg.org/so-rose/blext blext check # not implemented
+uvx --from git+https://codeberg.org/so-rose/blext blext run
+uvx --from git+https://codeberg.org/so-rose/blext blext show blender_manifest # broken
+uvx --from git+https://codeberg.org/so-rose/blext blext show deps
+uvx --from git+https://codeberg.org/so-rose/blext blext show global_config
+uvx --from git+https://codeberg.org/so-rose/blext blext show profile
+uvx --from git+https://codeberg.org/so-rose/blext blext show path
+
 uv add  git+https://codeberg.org/so-rose/blext
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,68 @@
+
+
+## Environment
+
+- [uv](https://docs.astral.sh/uv/)
+- Blender
+- [blext](https://pypi.org/project/blext/)
+
+
+## Starting
+
+
+```python
+# uvx blext show spec
+BLExtSpec(
+    path_proj_root=PosixPath('/Users/zcpowers/Documents/Projects/MolecularNodes'),
+    req_python_version='~=3.11',
+    is_universal_blext=True,
+    bl_platform_pypa_tags={},
+    init_settings_filename='init_settings.toml',
+    manifest_filename='blender_manifest.toml',
+    init_schema_version='0.1.0',
+    use_path_local=False,
+    use_log_file=False,
+    log_file_path=PosixPath('addon.log'),
+    log_file_level=<StrLogLevel.Debug: 'DEBUG'>,
+    use_log_console=True,
+    log_console_level=<StrLogLevel.Debug: 'DEBUG'>,
+    manifest_schema_version='1.0.0',
+    id='molecularnodes',
+    name='BLExt Simple Example',
+    version='4.4.0',
+    tagline='Toolbox for molecular animations with Blender and Geometry Nodes.',
+    maintainer='Brady Johnston <brady.johnston@me.com>',
+    type='add-on',
+    blender_version_min='4.2.0',
+    blender_version_max='4.3.10',
+    permissions={},
+    tags=('Development',),
+    license=('SPDX:GLP',),
+    copyright=('2024 blext Contributors',),
+    website=HttpUrl('https://bradyajohnston.github.io/MolecularNodes'),
+    bl_platforms=frozenset(),
+    wheels=()
+)
+```
+
+
+
+```sh
+# you need to use the head
+# see https://codeberg.org/so-rose/blext/issues/57
+uvx --from git+https://codeberg.org/so-rose/blext blext build
+uv add  git+https://codeberg.org/so-rose/blext
+
+
+# show
+uvx blext show manifest
+uvx blext show init_settings
+uvx blext show spec   # see above
+uvx blext show path_blender # works locally
+
+# build
+uvx blext build
+
+# dev
+uvx blext dev
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "biotite>=1.1",
     "mrcfile",
     "starfile",
-    "blext",
 ]
 maintainers = [{ name = "Brady Johnston", email = "brady.johnston@me.com" }]
 requires-python = "~=3.11"
@@ -24,7 +23,7 @@ Documentation = "https://bradyajohnston.github.io/MolecularNodes"
 [project.optional-dependencies]
 bpy = ["bpy>=4.4"]
 jupyter = ["jupyter", "IPython"]
-dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython"]
+dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython", "blext"]
 test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython", "pytest-xdist"]
 docs = [
     "quartodoc",
@@ -34,10 +33,26 @@ docs = [
     "IPython",
     "jupyter-cache",
 ]
+blender4_3 = [
+    "autopep8==2.3.1", # # ⭳⭳⭳ MANAGED BY BLEXT ⭳⭳⭳
+    "certifi==2021.10.8",
+    "charset_normalizer==2.0.10",
+    "cython==0.29.30",
+    "idna==3.3",
+    "numpy==1.24.3",
+    "pip==24.0",
+    "pycodestyle==2.12.1",
+    "requests==2.27.1",
+    "setuptools==63.2.0",
+    "urllib3==1.26.8",
+    "zstandard==0.16.0", # # ⭱⭱⭱ MANAGED BY BLEXT ⭱⭱⭱
+]
+
 
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=61.0"]
+
 
 [tool.setuptools]
 include-package-data = true
@@ -56,7 +71,6 @@ ignore = [
     "E501",
     # Due to constants and class placeholders defined in functions
     "N806",
-
     # 'molecularnodes' when used as a Blender extension may not actually be named
     # 'molecularnodes' (potentially user_default.molecularnodes for example) so we have to
     # use relative imports:
@@ -82,17 +96,13 @@ order-by-type = true
 # # Ambiguous variable name: `l`
 "molecularnodes/color.py" = ["E741"]
 
-
 [tool.ruff.format]
 exclude = ["molecularnodes/assets/data.py"]
 
 
-####################
-# - Blender Extension
-####################
 [tool.blext]
-pretty_name = "BLExt Simple Example"
-blender_version_min = '4.3.0'
+pretty_name = "MolecularNodes"
+blender_version_min = '4.4.0'
 blender_version_max = '4.4.0'
 bl_tags = ["Development"]
 copyright = ["2024 blext Contributors"]
@@ -103,5 +113,11 @@ supported_platforms = [
 ]
 min_macos_version = [12, 0]
 
-[tool.uv.sources]
-blext = { git = "https://codeberg.org/so-rose/blext" }
+[tool.uv]
+package = false
+conflicts = [
+    [
+        {extra = "blender4_3"}, # # ⭳⭳⭳ MANAGED BY BLEXT ⭳⭳⭳
+    ],
+]
+sources = {blext = { git = "https://codeberg.org/so-rose/blext" }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "molecularnodes"
 version = "4.4.0"
-description = "Toolbox for molecular animations with Blender and Geometry Nodes."
+description = "Toolbox for molecular animations using Geometry Nodes"
 readme = "README.md"
 dependencies = [
     "databpy>=0.0.18",
@@ -9,9 +9,12 @@ dependencies = [
     "biotite>=1.1",
     "mrcfile",
     "starfile",
+    "blext",
 ]
 maintainers = [{ name = "Brady Johnston", email = "brady.johnston@me.com" }]
 requires-python = "~=3.11"
+license = {text = "GPL-3.0"}
+
 
 [project.urls]
 Homepage = "https://bradyajohnston.github.io/MolecularNodes"
@@ -23,7 +26,14 @@ bpy = ["bpy>=4.4"]
 jupyter = ["jupyter", "IPython"]
 dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython"]
 test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython", "pytest-xdist"]
-docs = ["quartodoc", "tomlkit", "nodepad", "jupyter", "IPython", "jupyter-cache"]
+docs = [
+    "quartodoc",
+    "tomlkit",
+    "nodepad",
+    "jupyter",
+    "IPython",
+    "jupyter-cache",
+]
 
 [build-system]
 build-backend = "setuptools.build_meta"
@@ -48,12 +58,12 @@ ignore = [
     "N806",
 
     # 'molecularnodes' when used as a Blender extension may not actually be named
-    # 'molecularnodes' (potentially user_default.molecularnodes for example) so we have to 
-    # use relative imports: 
+    # 'molecularnodes' (potentially user_default.molecularnodes for example) so we have to
+    # use relative imports:
     # https://docs.blender.org/manual/en/latest/advanced/extensions/addons.html#extensions-and-namespace
     "TID252", # Prefer absolute imports over relative imports from parent modules
-    "N813", # Camelcase `MDAnalysis` imported as lowercase `mda`
-    "N801", # Class name `MN_UL_TrajectorySelectionListUI` should use CapWords convention
+    "N813",   # Camelcase `MDAnalysis` imported as lowercase `mda`
+    "N801",   # Class name `MN_UL_TrajectorySelectionListUI` should use CapWords convention
 ]
 
 [tool.ruff.lint.isort]
@@ -75,3 +85,23 @@ order-by-type = true
 
 [tool.ruff.format]
 exclude = ["molecularnodes/assets/data.py"]
+
+
+####################
+# - Blender Extension
+####################
+[tool.blext]
+pretty_name = "BLExt Simple Example"
+blender_version_min = '4.3.0'
+blender_version_max = '4.4.0'
+bl_tags = ["Development"]
+copyright = ["2024 blext Contributors"]
+supported_platforms = [
+   'windows-x64',
+   'macos-arm64',
+   'linux-x64',
+]
+min_macos_version = [12, 0]
+
+[tool.uv.sources]
+blext = { git = "https://codeberg.org/so-rose/blext" }


### PR DESCRIPTION
Related to #792 See also:

- [updated issue](https://codeberg.org/so-rose/blext/issues/57)
- [single file example](https://codeberg.org/so-rose/blext/src/commit/f89488ff5652246ae902ead2e63ee383f4031f82/examples/simple_script.py)


```txt
An update: I've merged a rather large batch of changes to main - please expect instability!

In my limited testing, no extraneous wheels are present any more. This is easiest to see when building for a single platform with --bl-platform.

Here's an example of an extension that uses jupyter-core, which only includes cffi and pywin32 when a Windows-based platform is targeted: https://codeberg.org/so-rose/blext/src/commit/f89488ff5652246ae902ead2e63ee383f4031f82/examples/simple_script.py
```