### PR TITLE
DOC: Assume quarto installed for GHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     permissions: write-all
     steps:
       - uses: actions/checkout@v4
-      - uses: quarto-dev/quarto-actions/setup@v2
+      # - uses: quarto-dev/quarto-actions/setup@v2
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:


### PR DESCRIPTION
Am currently building docs on self-hosted GHA runner. To install Quarto it's requiring `sudo` permissions. Quarto will already be installed, so instead assuming it is installed and will no longer require password prompt from me and I can leave my computer idle.