### PR TITLE
Fix UI fetching from AlphaFold

### DIFF
--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -385,7 +385,7 @@ DOWNLOAD_FORMATS = (
 class MN_OT_Import_Fetch(bpy.types.Operator):
     bl_idname = "mn.import_fetch"
     bl_label = "Fetch"
-    bl_description = "Download and open a structure from the Protein Data Bank"
+    bl_description = "Download and open a structure from the PDB"
     bl_options = {"REGISTER", "UNDO"}
 
     code: StringProperty(  # type: ignore
@@ -476,7 +476,10 @@ class MN_OT_Import_Fetch(bpy.types.Operator):
         try:
             mol = (
                 entities.Molecule.fetch(
-                    code=self.code, cache=self.cache_dir, format=self.file_format
+                    code=self.code,
+                    cache=self.cache_dir,
+                    format=self.file_format,
+                    database=self.database,
                 )
                 .add_style(
                     style=self.style if self.node_setup else None,  # type: ignore

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -34,7 +34,6 @@ def test_op_fetch(snapshot_custom: NumpySnapshotExtension, code):
 def test_op_fetch_alphafold(tmpdir):
     scene = bpy.context.scene
     style = "ribbon"
-    format = "cif"
 
     with ObjectTracker() as o:
         bpy.ops.mn.import_fetch(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -31,6 +31,23 @@ def test_op_fetch(snapshot_custom: NumpySnapshotExtension, code):
         np.testing.assert_allclose(test1.position, test2.position)
 
 
+def test_op_fetch_alphafold(tmpdir):
+    scene = bpy.context.scene
+    style = "ribbon"
+    format = "cif"
+
+    with ObjectTracker() as o:
+        bpy.ops.mn.import_fetch(
+            code="Q7Z434",
+            style=style,
+            cache_dir=str(tmpdir),
+            database="alphafold",
+        )
+        mol = scene.MNSession.match(o.latest())
+
+    assert mol.name == "Q7Z434"
+
+
 @pytest.mark.parametrize("code", codes)
 @pytest.mark.parametrize("file_format", ["bcif", "cif", "pdb"])
 def test_op_local(snapshot_custom, code, file_format):


### PR DESCRIPTION
Downloading from from the AlphaFold database via the GUI was failing. The operator wasn't using the `database` input properly so was attempting to fetch from the PDB rather than the AFDB.

This now correctly uses the specified database and downloads successfully using the operator.