### PR TITLE
Add Configurable Styles Classes

### DIFF
--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -312,7 +312,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         selection: "str | MoleculeSelector | None" = None,
         assembly: bool = False,
         material: bpy.types.Material | str | None = None,
-        **kwargs,
     ):
         """
         Add a visual style to the molecule.
@@ -387,7 +386,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
             selection=selection,
             material=material,
             frames=self.frames,
-            **kwargs,
         )
 
         if assembly:

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -18,12 +18,6 @@ from ...nodes.geometry import (
     style_interfaces_from_tree,
 )
 from ...nodes.styles import (
-    StyleBallandStick,
-    StyleCartoon,
-    StyleRibbon,
-    StyleSpheres,
-    StyleSticks,
-    StyleSurface,
     StyleBase,
 )
 from ..base import EntityType, MolecularEntity

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -312,6 +312,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         selection: "str | MoleculeSelector | None" = None,
         assembly: bool = False,
         material: bpy.types.Material | str | None = None,
+        **kwargs
     ):
         """
         Add a visual style to the molecule.
@@ -386,6 +387,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
             selection=selection,
             material=material,
             frames=self.frames,
+            **kwargs
         )
 
         if assembly:

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -17,6 +17,16 @@ from ...nodes.geometry import (
     add_style_branch,
     style_interfaces_from_tree,
 )
+from ...nodes.styles import (
+    StyleBallandStick,
+    StyleCartoon,
+    StyleRibbon,
+    StyleSpheres,
+    StyleSticks,
+    StyleSurface,
+    StyleClass,
+    StyleBase,
+)
 from ..base import EntityType, MolecularEntity
 from ..utilities import create_object
 from . import pdb, pdbx, sdf, selections
@@ -307,7 +317,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
 
     def add_style(
         self,
-        style: bpy.types.GeometryNodeTree | str = "spheres",
+        style: StyleBase | str = "spheres",
         color: str | None = "common",
         selection: "str | MoleculeSelector | None" = None,
         assembly: bool = False,

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -312,7 +312,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         selection: "str | MoleculeSelector | None" = None,
         assembly: bool = False,
         material: bpy.types.Material | str | None = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Add a visual style to the molecule.
@@ -387,7 +387,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
             selection=selection,
             material=material,
             frames=self.frames,
-            **kwargs
+            **kwargs,
         )
 
         if assembly:

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -24,7 +24,6 @@ from ...nodes.styles import (
     StyleSpheres,
     StyleSticks,
     StyleSurface,
-    StyleClass,
     StyleBase,
 )
 from ..base import EntityType, MolecularEntity

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -19,7 +19,7 @@ from .nodes import (
     insert_before,
     loc_between,
 )
-from .styles import StyleClass
+from .styles import StyleBase
 
 
 def insert_set_color(
@@ -78,7 +78,7 @@ def insert_animate_frames(
 
 def add_style_branch(
     tree: bpy.types.GeometryNodeTree,
-    style: str | bpy.types.GeometryNodeTree | StyleClass,
+    style: str | bpy.types.GeometryNodeTree | StyleBase,
     color: str | None = None,
     selection: str | None = None,
     material: bpy.types.Material | str | None = None,
@@ -99,11 +99,11 @@ def add_style_branch(
     if isinstance(style, str):
         style_name = nodes.styles_mapping[style]
         nodes.append(style_name)
-    elif isinstance(style, bpy.types.GeometryNodeTree):
-        style_name = style.name
-    elif isinstance(style, StyleClass):
+    elif isinstance(style, StyleBase):
         style_name = style.style
         nodes.append(style_name)
+    elif isinstance(style, bpy.types.GeometryNodeTree):
+        style_name = style.name
     else:
         raise ValueError(
             f"Style must be a string or a GeometryNodeTree, not {type(style)=}"
@@ -139,6 +139,11 @@ def add_style_branch(
         insert_animate_frames(node_style, frames)
 
     arrange_tree(tree)
+
+    if isinstance(style, StyleBase):
+        style.update_style_node(node_style)
+
+
 
 
 

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -144,10 +144,6 @@ def add_style_branch(
         style.update_style_node(node_style)
 
 
-
-
-
-
 def get_final_style_nodes(
     tree: bpy.types.GeometryNodeTree,
 ) -> List[bpy.types.Node | None]:

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -83,7 +83,7 @@ def add_style_branch(
     selection: str | None = None,
     material: bpy.types.Material | str | None = None,
     frames: bpy.types.Collection | str | None = None,
-    **kwargs
+    **kwargs,
 ) -> None:
     """
     Add a style branch to the tree.
@@ -152,15 +152,14 @@ def apply_style(style_node, style_name, kwargs):
     for input in style_node.inputs:
         if input.type != "GEOMETRY":
             for args in style_specific_args:
-                name = args['name']
-                blendername = args['blendername']
-                input_type = args['type']
-                default = args['default']
+                name = args["name"]
+                blendername = args["blendername"]
+                input_type = args["type"]
+                default = args["default"]
                 if input.name == blendername:
                     # potentially check type match here
-                     if new_value := kwargs.get(name):
+                    if new_value := kwargs.get(name):
                         input.default_value = new_value
-
 
 
 def get_final_style_nodes(

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -100,7 +100,7 @@ def add_style_branch(
         style_name = nodes.styles_mapping[style]
         nodes.append(style_name)
     elif isinstance(style, StyleBase):
-        style_name = style.style
+        style_name = nodes.styles_mapping[style.style]
         nodes.append(style_name)
     elif isinstance(style, bpy.types.GeometryNodeTree):
         style_name = style.name

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -19,6 +19,7 @@ from .nodes import (
     insert_before,
     loc_between,
 )
+from .styles import STYLE_DATA
 
 
 def insert_set_color(
@@ -82,6 +83,7 @@ def add_style_branch(
     selection: str | None = None,
     material: bpy.types.Material | str | None = None,
     frames: bpy.types.Collection | str | None = None,
+    **kwargs
 ) -> None:
     """
     Add a style branch to the tree.
@@ -135,6 +137,30 @@ def add_style_branch(
         insert_animate_frames(node_style, frames)
 
     arrange_tree(tree)
+
+    # Override default styles here.
+    if style_name in STYLE_DATA.keys():
+        apply_style(node_style, style_name, kwargs)
+    else:
+        raise ValueError(f"Style Name {style_name} is not found in the STYLE_DATA")
+
+
+# not sure is something like this exists already...
+def apply_style(style_node, style_name, kwargs):
+    "iterate over style node. if there is a matching kw-key then override it with the kw-val"
+    style_specific_args = STYLE_DATA[style_name]
+    for input in style_node.inputs:
+        if input.type != "GEOMETRY":
+            for args in style_specific_args:
+                name = args['name']
+                blendername = args['blendername']
+                input_type = args['type']
+                default = args['default']
+                if input.name == blendername:
+                    # potentially check type match here
+                     if new_value := kwargs.get(name):
+                        input.default_value = new_value
+
 
 
 def get_final_style_nodes(

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -19,7 +19,7 @@ from .nodes import (
     insert_before,
     loc_between,
 )
-from .styles import STYLE_DATA
+from .styles import StyleClass
 
 
 def insert_set_color(
@@ -78,7 +78,7 @@ def insert_animate_frames(
 
 def add_style_branch(
     tree: bpy.types.GeometryNodeTree,
-    style: str | bpy.types.GeometryNodeTree,
+    style: str | bpy.types.GeometryNodeTree | StyleClass,
     color: str | None = None,
     selection: str | None = None,
     material: bpy.types.Material | str | None = None,
@@ -101,6 +101,9 @@ def add_style_branch(
         nodes.append(style_name)
     elif isinstance(style, bpy.types.GeometryNodeTree):
         style_name = style.name
+    elif isinstance(style, StyleClass):
+        style_name = style.style
+        nodes.append(style_name)
     else:
         raise ValueError(
             f"Style must be a string or a GeometryNodeTree, not {type(style)=}"

--- a/molecularnodes/nodes/geometry.py
+++ b/molecularnodes/nodes/geometry.py
@@ -83,7 +83,6 @@ def add_style_branch(
     selection: str | None = None,
     material: bpy.types.Material | str | None = None,
     frames: bpy.types.Collection | str | None = None,
-    **kwargs,
 ) -> None:
     """
     Add a style branch to the tree.
@@ -138,28 +137,7 @@ def add_style_branch(
 
     arrange_tree(tree)
 
-    # Override default styles here.
-    if style_name in STYLE_DATA.keys():
-        apply_style(node_style, style_name, kwargs)
-    else:
-        raise ValueError(f"Style Name {style_name} is not found in the STYLE_DATA")
 
-
-# not sure is something like this exists already...
-def apply_style(style_node, style_name, kwargs):
-    "iterate over style node. if there is a matching kw-key then override it with the kw-val"
-    style_specific_args = STYLE_DATA[style_name]
-    for input in style_node.inputs:
-        if input.type != "GEOMETRY":
-            for args in style_specific_args:
-                name = args["name"]
-                blendername = args["blendername"]
-                input_type = args["type"]
-                default = args["default"]
-                if input.name == blendername:
-                    # potentially check type match here
-                    if new_value := kwargs.get(name):
-                        input.default_value = new_value
 
 
 def get_final_style_nodes(

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -40,39 +40,27 @@ class StyleBallandStick(StyleBase):
     # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
-        { "name": "as_mesh", "blendername": "As Mesh", "type": bool, "default": True },
-        { "name": "sphere_radii", "blendername": "Sphere Radii", "type": float, "default": 0.3 },
+        { "name": "sphere_radii", "blendername": "Sphere Radii", "type": float, "default": 0.30000001192092896 },
         { "name": "bond_split", "blendername": "Bond Split", "type": bool, "default": False },
-        { "name": "bond_find", "blendername": "Bond Find", "type": bool, "default": True },
-        { "name": "bond_radius", "blendername": "Bond Radius", "type": float, "default": 0.3 },
+        { "name": "bond_find", "blendername": "Bond Find", "type": bool, "default": False },
+        { "name": "bond_radius", "blendername": "Bond Radius", "type": float, "default": 0.30000001192092896 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
-
-    # Quality 2
-    # Sphere Geometry Instance
-    # Sphere Radii 0.30000001192092896
-    # Bond Split False
-    # Bond Find False
-    # Bond Radius 0.30000001192092896
-    # Color Blur False
-    # Shade Smooth True
     style="ball_and_stick"
     # fmt: on
 
     def __init__(
         self,
         quality: int = 2,
-        as_mesh: bool = True,
         sphere_radii: float = 0.3,
         bond_split: bool = False,
-        bond_find: bool = True,
+        bond_find: bool = False,
         bond_radius: float = 0.3,
         color_blur: bool = False,
         shade_smooth: bool = True,
     ):
         self.quality = quality
-        self.as_mesh = as_mesh
         self.sphere_radii = sphere_radii
         self.bond_split = bond_split
         self.bond_find = bond_find
@@ -85,36 +73,23 @@ class StyleCartoon(StyleBase):
     # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
-        { "name": "dssp", "blendername": "DSSP", "type": bool, "default": False },
-        { "name": "cylinders", "blendername": "Cylinders", "type": bool, "default": False },
-        { "name": "arrows", "blendername": "Arrows", "type": bool, "default": True },
-        { "name": "rounded", "blendername": "Rounded", "type": bool, "default": False },
-        { "name": "thickness", "blendername": "Thickness", "type": float, "default": 0.6 },
-        { "name": "width", "blendername": "Width", "type": float, "default": 2.2 },
-        { "name": "loop_radius", "blendername": "Loop Radius", "type": float, "default": 0.3 },
-        { "name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.5 },
-        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
+        { "name": "dssp", "blendername": "Peptide DSSP", "type": bool, "default": False },
+        { "name": "cylinders", "blendername": "Peptide Cylinders", "type": bool, "default": False },
+        { "name": "arrows", "blendername": "Peptide Arrows", "type": bool, "default": True },
+        { "name": "rounded", "blendername": "Peptide Rounded", "type": bool, "default": False },
+        { "name": "thickness", "blendername": "Peptide Thickness", "type": float, "default": 0.6000000238418579 },
+        { "name": "width", "blendername": "Peptide Width", "type": float, "default": 2.200000047683716 },
+        { "name": "loop_radius", "blendername": "Peptide Loop Radius", "type": float, "default": 0.30000001192092896 },
+        { "name": "smoothing", "blendername": "Peptide Smoothing", "type": float, "default": 0.5 },
+        { "name": "backbone_shape", "blendername": "Backbone Shape", "type": str, "default": "Cylinder" },
+        { "name": "backbone_radius", "blendername": "Backbone Radius", "type": float, "default": 2.0 },
+        { "name": "base_shape", "blendername": "Base Shape", "type": str, "default": "Rectangle" },
+        { "name": "base_realize", "blendername": "Base Realize", "type": bool, "default": False },
+        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": True },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
     # fmt: on
     style="cartoon"
-
-    # Quality 2
-    # Peptide DSSP False
-    # Peptide Cylinders False
-    # Peptide Arrows True
-    # Peptide Rounded False
-    # Peptide Thickness 0.6000000238418579
-    # Peptide Width 2.200000047683716
-    # Peptide Loop Radius 0.30000001192092896
-    # Peptide Smoothing 0.5
-    # Backbone Shape Cylinder
-    # Backbone Radius 2.0
-    # Base Shape Rectangle
-    # Base Realize False
-    # Color Blur True
-    # Shade Smooth True
-
 
     def __init__(
         self,
@@ -123,11 +98,15 @@ class StyleCartoon(StyleBase):
         cylinders: bool = False,
         arrows: bool = True,
         rounded: bool = False,
-        thickness: float = 0.6,
-        width: float = 2.2,
-        loop_radius: float = 0.3,
+        thickness: float = 0.6000000238418579,
+        width: float = 2.200000047683716,
+        loop_radius: float = 0.30000001192092896,
         smoothing: float = 0.5,
-        color_blur: bool = False,
+        backbone_shape: str = "Cylinder",
+        backbone_radius: float = 2.0,
+        base_shape: str = "Rectangle",
+        base_realize: bool = False,
+        color_blur: bool = True,
         shade_smooth: bool = True,
     ):
         self.quality = quality
@@ -139,9 +118,12 @@ class StyleCartoon(StyleBase):
         self.width = width
         self.loop_radius = loop_radius
         self.smoothing = smoothing
+        self.backbone_shape = backbone_shape
+        self.backbone_radius = backbone_radius
+        self.base_shape = base_shape
+        self.base_realize = base_realize
         self.color_blur = color_blur
         self.shade_smooth = shade_smooth
-
 
 class StyleRibbon(StyleBase):
     # fmt: off

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -9,9 +9,15 @@ will simply override the base styles.
 Because the nodetrees in the MN_data_file_{version}.blend are the source of truth, we add
 function to parity between the nodetrees and the class representations.
 
+Each style uses a Socket dataclass to define the mapping between class attributes and
+Blender node inputs, making it easier to maintain and extend the styles. The Socket
+dataclass establishes a clear relationship between Python attribute names and the corresponding
+Blender node input socket names, providing type safety and better IDE support than the
+previous dictionary-based approach.
 """
 
-from typing import List, Tuple, Union, Any, Dict
+from dataclasses import dataclass
+from typing import List, Tuple, Optional
 from bpy.types import GeometryNodeGroup
 
 __all__ = [
@@ -24,34 +30,49 @@ __all__ = [
     "StyleBase",
 ]
 
-SocketDataMapping = Dict[str, Any]
-SocketInfo = List[SocketDataMapping]
+
+@dataclass
+class Socket:
+    """Represents a mapping between a class attribute and a Blender node input socket.
+
+    Attributes:
+        name: The name of the attribute in the Style class
+        blendername: The corresponding name of the input socket in the Blender node
+    """
+    name: str
+    blendername: Optional[str] = None
+
+SocketInfo = List[Socket]
+
 
 class StyleBase:
     style: str
     portdata: SocketInfo = []
 
     def update_style_node(self, node_style: GeometryNodeGroup):
+        """Update the Blender node inputs with values from this style's attributes.
+
+        Args:
+            node_style: The Blender GeometryNodeGroup to update
+        """
         for input in node_style.inputs:
             if input.type != "GEOMETRY":
                 for arg in self.portdata:
-                    name = arg["name"]
-                    blendername = arg.get("blendername")
-                    if input.name == blendername:
-                        input.default_value = getattr(self, name)
+                    if input.name == arg.blendername:
+                        input.default_value = getattr(self, arg.name)
 
 
 class StyleBallandStick(StyleBase):
     style = "ball_and_stick"
     portdata: SocketInfo = [
-        {"name": "quality", "blendername": "Quality"},
-        {"name": "geometry", "blendername": "Sphere Geometry"},
-        {"name": "sphere_radii", "blendername": "Sphere Radii"},
-        {"name": "bond_split", "blendername": "Bond Split"},
-        {"name": "bond_find", "blendername": "Bond Find"},
-        {"name": "bond_radius", "blendername": "Bond Radius"},
-        {"name": "color_blur", "blendername": "Color Blur"},
-        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+        Socket(name="quality", blendername="Quality"),
+        Socket(name="geometry", blendername="Sphere Geometry"),
+        Socket(name="sphere_radii", blendername="Sphere Radii"),
+        Socket(name="bond_split", blendername="Bond Split"),
+        Socket(name="bond_find", blendername="Bond Find"),
+        Socket(name="bond_radius", blendername="Bond Radius"),
+        Socket(name="color_blur", blendername="Color Blur"),
+        Socket(name="shade_smooth", blendername="Shade Smooth"),
     ]
 
     def __init__(
@@ -78,21 +99,21 @@ class StyleBallandStick(StyleBase):
 class StyleCartoon(StyleBase):
     style = "cartoon"
     portdata: SocketInfo = [
-        {"name": "quality", "blendername": "Quality"},
-        {"name": "dssp", "blendername": "Peptide DSSP"},
-        {"name": "cylinders", "blendername": "Peptide Cylinders"},
-        {"name": "arrows", "blendername": "Peptide Arrows"},
-        {"name": "rounded", "blendername": "Peptide Rounded"},
-        {"name": "thickness", "blendername": "Peptide Thickness"},
-        {"name": "width", "blendername": "Peptide Width"},
-        {"name": "loop_radius", "blendername": "Peptide Loop Radius"},
-        {"name": "smoothing", "blendername": "Peptide Smoothing"},
-        {"name": "backbone_shape", "blendername": "Backbone Shape"},
-        {"name": "backbone_radius", "blendername": "Backbone Radius"},
-        {"name": "base_shape", "blendername": "Base Shape"},
-        {"name": "base_realize", "blendername": "Base Realize"},
-        {"name": "color_blur", "blendername": "Color Blur"},
-        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+        Socket(name="quality", blendername="Quality"),
+        Socket(name="dssp", blendername="Peptide DSSP"),
+        Socket(name="cylinders", blendername="Peptide Cylinders"),
+        Socket(name="arrows", blendername="Peptide Arrows"),
+        Socket(name="rounded", blendername="Peptide Rounded"),
+        Socket(name="thickness", blendername="Peptide Thickness"),
+        Socket(name="width", blendername="Peptide Width"),
+        Socket(name="loop_radius", blendername="Peptide Loop Radius"),
+        Socket(name="smoothing", blendername="Peptide Smoothing"),
+        Socket(name="backbone_shape", blendername="Backbone Shape"),
+        Socket(name="backbone_radius", blendername="Backbone Radius"),
+        Socket(name="base_shape", blendername="Base Shape"),
+        Socket(name="base_realize", blendername="Base Realize"),
+        Socket(name="color_blur", blendername="Color Blur"),
+        Socket(name="shade_smooth", blendername="Shade Smooth"),
     ]
 
     def __init__(
@@ -133,18 +154,18 @@ class StyleCartoon(StyleBase):
 class StyleRibbon(StyleBase):
     style = "ribbon"
     portdata: SocketInfo = [
-        {"name": "quality", "blendername": "Quality"},
-        {"name": "color_blur", "blendername": "Color Blur"},
-        {"name": "shade_smooth", "blendername": "Shade Smooth"},
-        {"name": "backbone_smoothing", "blendername": "Backbone Smoothing"},
-        {"name": "backbone_threshold", "blendername": "Backbone Threshold"},
-        {"name": "backbone_radius", "blendername": "Backbone Radius"},
-        {"name": "backbone_shape", "blendername": "Backbone Shape"},
-        {"name": "base_scale", "blendername": "Base Scale"},
-        {"name": "base_resolution", "blendername": "Base Resolution"},
-        {"name": "base_realize", "blendername": "Base Realize"},
-        {"name": "uv_map", "blendername": "UV Map"},
-        {"name": "u_component", "blendername": "U Component"},
+        Socket(name="quality", blendername="Quality"),
+        Socket(name="color_blur", blendername="Color Blur"),
+        Socket(name="shade_smooth", blendername="Shade Smooth"),
+        Socket(name="backbone_smoothing", blendername="Backbone Smoothing"),
+        Socket(name="backbone_threshold", blendername="Backbone Threshold"),
+        Socket(name="backbone_radius", blendername="Backbone Radius"),
+        Socket(name="backbone_shape", blendername="Backbone Shape"),
+        Socket(name="base_scale", blendername="Base Scale"),
+        Socket(name="base_resolution", blendername="Base Resolution"),
+        Socket(name="base_realize", blendername="Base Realize"),
+        Socket(name="uv_map", blendername="UV Map"),
+        Socket(name="u_component", blendername="U Component"),
     ]
 
     def __init__(
@@ -180,10 +201,10 @@ class StyleRibbon(StyleBase):
 class StyleSpheres(StyleBase):
     style = "spheres"
     portdata: SocketInfo = [
-        {"name": "geometry", "blendername": "Sphere Geometry"},
-        {"name": "radii", "blendername": "Sphere Radii"},
-        {"name": "sphere_subdivisions", "blendername": "Sphere Subdivisions"},
-        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+        Socket(name="geometry", blendername="Sphere Geometry"),
+        Socket(name="radii", blendername="Sphere Radii"),
+        Socket(name="sphere_subdivisions", blendername="Sphere Subdivisions"),
+        Socket(name="shade_smooth", blendername="Shade Smooth"),
     ]
 
     def __init__(
@@ -202,10 +223,10 @@ class StyleSpheres(StyleBase):
 class StyleSticks(StyleBase):
     style = "sticks"
     portdata: SocketInfo = [
-        {"name": "quality", "blendername": "Quality"},
-        {"name": "radius", "blendername": "Radius"},
-        {"name": "color_blur", "blendername": "Color Blur"},
-        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+        Socket(name="quality", blendername="Quality"),
+        Socket(name="radius", blendername="Radius"),
+        Socket(name="color_blur", blendername="Color Blur"),
+        Socket(name="shade_smooth", blendername="Shade Smooth"),
     ]
 
     def __init__(
@@ -224,15 +245,15 @@ class StyleSticks(StyleBase):
 class StyleSurface(StyleBase):
     style = "surface"
     portdata: SocketInfo = [
-        {"name": "quality", "blendername": "Quality"},
-        {"name": "scale_radii", "blendername": "Scale Radii"},
-        {"name": "probe_size", "blendername": "Probe Size"},
-        {"name": "relaxation_steps", "blendername": "Relaxation Steps"},
-        {"name": "separate", "blendername": "Separate By"},
-        {"name": "group_id", "blendername": "Group ID"},
-        {"name": "color_source", "blendername": "Color Source"},
-        {"name": "blur", "blendername": "Color Blur"},
-        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+        Socket(name="quality", blendername="Quality"),
+        Socket(name="scale_radii", blendername="Scale Radii"),
+        Socket(name="probe_size", blendername="Probe Size"),
+        Socket(name="relaxation_steps", blendername="Relaxation Steps"),
+        Socket(name="separate", blendername="Separate By"),
+        Socket(name="group_id", blendername="Group ID"),
+        Socket(name="color_source", blendername="Color Source"),
+        Socket(name="blur", blendername="Color Blur"),
+        Socket(name="shade_smooth", blendername="Shade Smooth"),
     ]
 
     def __init__(

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,9 +1,14 @@
-# mol.add_style(mn.StyleSpheres(geometry="mesh"), selection = "Protein")
-
 from dataclasses import dataclass, replace, field, fields
 from typing import List, Tuple, Union, Any, Dict
 
-StyleClass = Union["StyleBallandStick", "StyleCartoon", "StyleRibbon", "StyleSpheres", "StyleSticks", "StyleSurface"]
+StyleClass = Union[
+    "StyleBallandStick",
+    "StyleCartoon",
+    "StyleRibbon",
+    "StyleSpheres",
+    "StyleSticks",
+    "StyleSurface",
+]
 
 # Define the type for a single port data entry for clarity
 PortDataEntry = Dict[str, Any]
@@ -17,6 +22,7 @@ class StyleBase:
 
 
 class StyleBallandStick(StyleBase):
+    # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
         { "name": "as_mesh", "blendername": "As Mesh", "type": bool, "default": True },
@@ -27,9 +33,19 @@ class StyleBallandStick(StyleBase):
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
+    # fmt: on
 
-    def __init__(self, style: str = "ball+stick", quality: int = 2, as_mesh: bool = True, sphere_radii: float = 0.3, bond_split: bool = False, bond_find: bool = True, bond_radius: float = 0.3, color_blur: bool = False, shade_smooth: bool = True):
-        self.style = style
+    def __init__(
+        self,
+        quality: int = 2,
+        as_mesh: bool = True,
+        sphere_radii: float = 0.3,
+        bond_split: bool = False,
+        bond_find: bool = True,
+        bond_radius: float = 0.3,
+        color_blur: bool = False,
+        shade_smooth: bool = True,
+    ):
         self.quality = quality
         self.as_mesh = as_mesh
         self.sphere_radii = sphere_radii
@@ -41,6 +57,7 @@ class StyleBallandStick(StyleBase):
 
 
 class StyleCartoon(StyleBase):
+    # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
         { "name": "dssp", "blendername": "DSSP", "type": bool, "default": False },
@@ -54,9 +71,22 @@ class StyleCartoon(StyleBase):
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
+    # fmt: on
 
-    def __init__(self, style: str = "cartoon", quality: int = 2, dssp: bool = False, cylinders: bool = False, arrows: bool = True, rounded: bool = False, thickness: float = 0.6, width: float = 2.2, loop_radius: float = 0.3, smoothing: float = 0.5, color_blur: bool = False, shade_smooth: bool = True):
-        self.style = style
+    def __init__(
+        self,
+        quality: int = 2,
+        dssp: bool = False,
+        cylinders: bool = False,
+        arrows: bool = True,
+        rounded: bool = False,
+        thickness: float = 0.6,
+        width: float = 2.2,
+        loop_radius: float = 0.3,
+        smoothing: float = 0.5,
+        color_blur: bool = False,
+        shade_smooth: bool = True,
+    ):
         self.quality = quality
         self.dssp = dssp
         self.cylinders = cylinders
@@ -72,14 +102,37 @@ class StyleCartoon(StyleBase):
 
 class StyleRibbon(StyleBase):
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
-        { "name": "radius", "blendername": "Radius", "type": float, "default": 1.6 },
-        { "name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.6 },
-        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
+        {"name": "quality", "blendername": "Quality", "type": int, "default": 3},
+        {"name": "radius", "blendername": "Radius", "type": float, "default": 1.6},
+        {
+            "name": "smoothing",
+            "blendername": "Smoothing",
+            "type": float,
+            "default": 0.6,
+        },
+        {
+            "name": "color_blur",
+            "blendername": "Color Blur",
+            "type": bool,
+            "default": False,
+        },
+        {
+            "name": "shade_smooth",
+            "blendername": "Shade Smooth",
+            "type": bool,
+            "default": False,
+        },
     ]
 
-    def __init__(self, style: str = "ribbon", quality: int = 3, radius: float = 1.6, smoothing: float = 0.6, color_blur: bool = False, shade_smooth: bool = False):
+    def __init__(
+        self,
+        style: str = "ribbon",
+        quality: int = 3,
+        radius: float = 1.6,
+        smoothing: float = 0.6,
+        color_blur: bool = False,
+        shade_smooth: bool = False,
+    ):
         self.style = style
         self.quality = quality
         self.radius = radius
@@ -90,31 +143,62 @@ class StyleRibbon(StyleBase):
 
 class StyleSpheres(StyleBase):
     portdata: PortDataList = [
-        # Note: The 'geometry' entry here has type bool but default "Point",
-        # matching the original STYLE_DATA. The __init__ uses 'as_mesh'.
-        { "name": "geometry", "blendername": "Sphere Geometry", "type": bool, "default": "Point" },
-        { "name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8 },
-        { "name": "subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2 },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
+        # fmt: off
+        {
+            "name": "geometry",
+            "blendername": "Sphere Geometry",
+            "type": bool,
+            "default": "Point",
+        },
+        {"name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8},
+        {
+            "name": "subdivisions",
+            "blendername": "Sphere Subdivisions",
+            "type": int,
+            "default": 2,
+        },
+        {
+            "name": "shade_smooth",
+            "blendername": "Shade Smooth",
+            "type": bool,
+            "default": False,
+        },
+        # fmt: on
     ]
 
-    def __init__(self, style: str = "sphere", as_mesh: bool = True, radii: float = 0.8, subdivisions: int = 2, shade_smooth: bool = False):
+    def __init__(
+        self,
+        style: str = "sphere",
+        as_mesh: bool = True,
+        radii: float = 0.8,
+        subdivisions: int = 2,
+        shade_smooth: bool = False,
+    ):
         self.style = style
-        self.as_mesh = as_mesh # This corresponds to a geometry option, but the portdata has a different key "geometry"
+        self.as_mesh = as_mesh  # This corresponds to a geometry option, but the portdata has a different key "geometry"
         self.radii = radii
         self.subdivisions = subdivisions
         self.shade_smooth = shade_smooth
 
 
 class StyleSticks(StyleBase):
+    # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
         { "name": "radius", "blendername": "Radius", "type": float, "default": 0.2 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
     ]
+    # fmt: on
 
-    def __init__(self, style: str = "sticks", quality: int = 2, radius: float = 0.2, color_blur: bool = False, shade_smooth: bool = False):
+    def __init__(
+        self,
+        style: str = "sticks",
+        quality: int = 2,
+        radius: float = 0.2,
+        color_blur: bool = False,
+        shade_smooth: bool = False,
+    ):
         self.style = style
         self.quality = quality
         self.radius = radius
@@ -123,6 +207,7 @@ class StyleSticks(StyleBase):
 
 
 class StyleSurface(StyleBase):
+    # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
         { "name": "separate", "blendername": "Separate", "type": bool, "default": True },
@@ -135,8 +220,22 @@ class StyleSurface(StyleBase):
         { "name": "blur", "blendername": "Blur", "type": int, "default": 2 },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
+    # fmt: on
 
-    def __init__(self, style: str = "surface", quality: int = 3, separate: bool = True, attribute: str = "chain_id", scale_radii: float = 1.5, probe_size: float = 1.0, triangulate: bool = False, relaxation_steps: int = 10, by_ca: bool = False, blur: int = 2, shade_smooth: bool = True):
+    def __init__(
+        self,
+        style: str = "surface",
+        quality: int = 3,
+        separate: bool = True,
+        attribute: str = "chain_id",
+        scale_radii: float = 1.5,
+        probe_size: float = 1.0,
+        triangulate: bool = False,
+        relaxation_steps: int = 10,
+        by_ca: bool = False,
+        blur: int = 2,
+        shade_smooth: bool = True,
+    ):
         self.style = style
         self.quality = quality
         self.separate = separate

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,4 +1,16 @@
-from dataclasses import dataclass, replace, field, fields
+"""
+Style Classes
+
+MolecularNodes uses Geometry Nodes to define molecule representations within blender. However,
+it is desireable to make these nodes accessible for scripting. The classes defined in this file
+provide a way to script against the GeometryNode nodetrees. When invoked on a style these classes
+will simply override the base styles.
+
+Because the nodetrees in the MN_data_file_{version}.blend are the source of truth, we add
+function to parity between the nodetrees and the class representations.
+
+"""
+
 from typing import List, Tuple, Union, Any, Dict
 from bpy.types import GeometryNodeGroup
 
@@ -20,24 +32,15 @@ PortDataList = List[PortDataEntry]
 class StyleBase:
     portdata: PortDataList = []
 
+
     def update_style_node(self, node_style: GeometryNodeGroup):
         for input in node_style.inputs:
             if input.type != "GEOMETRY":
-                print(
-                    input.name,
-                    input.default_value,
-                )
                 for arg in self.portdata:
-                    # print(arg)
                     name = arg["name"]
-                    blendername = arg.get(
-                        "blendername", name
-                    )  # Use name if blendername not
+                    blendername = arg.get("blendername")
                     if input.name == blendername:
-                        # print(f"setting! Val : {getattr(self, name)}")
-                        # print(f"Initial Val : {input.default_value}")
                         input.default_value = getattr(self, name)
-                        # print(f"AfterSetting Val : {input.default_value}")
 
 
 class StyleBallandStick(StyleBase):

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -8,6 +8,8 @@ __all__ = [
     "StyleSpheres",
     "StyleSticks",
     "StyleSurface",
+    "StyleClass",
+    "StyleBase",
 ]
 
 StyleClass = Union[
@@ -26,9 +28,29 @@ PortDataList = List[PortDataEntry]
 
 
 class StyleBase:
-    # Base class for styles. Subclasses will define their own portdata attribute.
     portdata: PortDataList = []
 
+
+# current implemented representations
+styles_mapping = {
+    "preset_1": "Style Preset 1",
+    "preset_2": "Style Preset 2",
+    "preset_3": "Style Preset 3",
+    "preset_4": "Style Preset 4",
+    "atoms": "Style Spheres",
+    "spheres": "Style Spheres",
+    "vdw": "Style Spheres",
+    "sphere": "Style Spheres",
+    "cartoon": "Style Cartoon",
+    "sticks": "Style Sticks",
+    "ribbon": "Style Ribbon",
+    "surface": "Style Surface",
+    "ball_and_stick": "Style Ball and Stick",
+    "ball+stick": "Style Ball and Stick",
+    "oxdna": "MN_oxdna_style_ribbon",
+    "density_surface": "Style Density Surface",
+    "density_wire": "Style Density Wire",
+}
 
 class StyleBallandStick(StyleBase):
     # fmt: off
@@ -42,6 +64,7 @@ class StyleBallandStick(StyleBase):
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
+    self.style="ball_and_stick"
     # fmt: on
 
     def __init__(
@@ -81,6 +104,7 @@ class StyleCartoon(StyleBase):
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
     # fmt: on
+    self.style="cartoon"
 
     def __init__(
         self,
@@ -110,39 +134,24 @@ class StyleCartoon(StyleBase):
 
 
 class StyleRibbon(StyleBase):
+    # fmt: off
     portdata: PortDataList = [
         {"name": "quality", "blendername": "Quality", "type": int, "default": 3},
         {"name": "radius", "blendername": "Radius", "type": float, "default": 1.6},
-        {
-            "name": "smoothing",
-            "blendername": "Smoothing",
-            "type": float,
-            "default": 0.6,
-        },
-        {
-            "name": "color_blur",
-            "blendername": "Color Blur",
-            "type": bool,
-            "default": False,
-        },
-        {
-            "name": "shade_smooth",
-            "blendername": "Shade Smooth",
-            "type": bool,
-            "default": False,
-        },
+        {"name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.6},
+        {"name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False},
+        {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
     ]
-
+    # fmt: on
+    style = "ribbon"
     def __init__(
         self,
-        style: str = "ribbon",
         quality: int = 3,
         radius: float = 1.6,
         smoothing: float = 0.6,
         color_blur: bool = False,
         shade_smooth: bool = False,
     ):
-        self.style = style
         self.quality = quality
         self.radius = radius
         self.smoothing = smoothing
@@ -159,16 +168,16 @@ class StyleSpheres(StyleBase):
         {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
         # fmt: on
     ]
+    style = "spheres"
+
     def __init__(
         self,
-        style: str = "sphere",
         as_mesh: bool = True,
         radii: float = 0.8,
         subdivisions: int = 2,
         shade_smooth: bool = False,
     ):
-        self.style = style
-        self.as_mesh = as_mes
+        self.as_mesh = as_mesh
         self.radii = radii
         self.subdivisions = subdivisions
         self.shade_smooth = shade_smooth
@@ -182,17 +191,15 @@ class StyleSticks(StyleBase):
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
     ]
+    style = "sticks"
     # fmt: on
-
     def __init__(
         self,
-        style: str = "sticks",
         quality: int = 2,
         radius: float = 0.2,
         color_blur: bool = False,
         shade_smooth: bool = False,
     ):
-        self.style = style
         self.quality = quality
         self.radius = radius
         self.color_blur = color_blur
@@ -214,10 +221,10 @@ class StyleSurface(StyleBase):
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
     # fmt: on
+    style = "surface"
 
     def __init__(
         self,
-        style: str = "surface",
         quality: int = 3,
         separate: bool = True,
         attribute: str = "chain_id",
@@ -229,7 +236,6 @@ class StyleSurface(StyleBase):
         blur: int = 2,
         shade_smooth: bool = True,
     ):
-        self.style = style
         self.quality = quality
         self.separate = separate
         self.attribute = attribute

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -13,46 +13,49 @@ __all__ = [
 ]
 
 
-# Define the type for a single port data entry for clarity
 PortDataEntry = Dict[str, Any]
-# Define the type for the list of port data entries
 PortDataList = List[PortDataEntry]
-
 
 class StyleBase:
     portdata: PortDataList = []
+
     def update_style_node(self, node_style: GeometryNodeGroup):
         for input in node_style.inputs:
             if input.type != "GEOMETRY":
-                print(input.name, input.default_value,)
+                print(
+                    input.name,
+                    input.default_value,
+                )
                 for arg in self.portdata:
                     # print(arg)
-                    name = arg['name']
-                    blendername = arg.get('blendername', name)  # Use name if blendername not
+                    name = arg["name"]
+                    blendername = arg.get(
+                        "blendername", name
+                    )  # Use name if blendername not
                     if input.name == blendername:
-                        #print(f"setting! Val : {getattr(self, name)}")
-                        #print(f"Initial Val : {input.default_value}")
+                        # print(f"setting! Val : {getattr(self, name)}")
+                        # print(f"Initial Val : {input.default_value}")
                         input.default_value = getattr(self, name)
-                        #print(f"AfterSetting Val : {input.default_value}")
+                        # print(f"AfterSetting Val : {input.default_value}")
 
 
 class StyleBallandStick(StyleBase):
-    # fmt: off
+    style = "ball_and_stick"
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
-        { "name": "sphere_radii", "blendername": "Sphere Radii", "type": float, "default": 0.30000001192092896 },
-        { "name": "bond_split", "blendername": "Bond Split", "type": bool, "default": False },
-        { "name": "bond_find", "blendername": "Bond Find", "type": bool, "default": False },
-        { "name": "bond_radius", "blendername": "Bond Radius", "type": float, "default": 0.30000001192092896 },
-        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
+        {"name": "quality", "blendername": "Quality"},
+        {"name": "geometry", "blendername": "Sphere Geometry"},
+        {"name": "sphere_radii", "blendername": "Sphere Radii"},
+        {"name": "bond_split", "blendername": "Bond Split"},
+        {"name": "bond_find", "blendername": "Bond Find"},
+        {"name": "bond_radius", "blendername": "Bond Radius"},
+        {"name": "color_blur", "blendername": "Color Blur"},
+        {"name": "shade_smooth", "blendername": "Shade Smooth"},
     ]
-    style="ball_and_stick"
-    # fmt: on
 
     def __init__(
         self,
         quality: int = 2,
+        geometry: str = "Instance", # enum
         sphere_radii: float = 0.3,
         bond_split: bool = False,
         bond_find: bool = False,
@@ -61,6 +64,7 @@ class StyleBallandStick(StyleBase):
         shade_smooth: bool = True,
     ):
         self.quality = quality
+        self.geometry = geometry
         self.sphere_radii = sphere_radii
         self.bond_split = bond_split
         self.bond_find = bond_find
@@ -70,26 +74,24 @@ class StyleBallandStick(StyleBase):
 
 
 class StyleCartoon(StyleBase):
-    # fmt: off
+    style = "cartoon"
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
-        { "name": "dssp", "blendername": "Peptide DSSP", "type": bool, "default": False },
-        { "name": "cylinders", "blendername": "Peptide Cylinders", "type": bool, "default": False },
-        { "name": "arrows", "blendername": "Peptide Arrows", "type": bool, "default": True },
-        { "name": "rounded", "blendername": "Peptide Rounded", "type": bool, "default": False },
-        { "name": "thickness", "blendername": "Peptide Thickness", "type": float, "default": 0.6000000238418579 },
-        { "name": "width", "blendername": "Peptide Width", "type": float, "default": 2.200000047683716 },
-        { "name": "loop_radius", "blendername": "Peptide Loop Radius", "type": float, "default": 0.30000001192092896 },
-        { "name": "smoothing", "blendername": "Peptide Smoothing", "type": float, "default": 0.5 },
-        { "name": "backbone_shape", "blendername": "Backbone Shape", "type": str, "default": "Cylinder" },
-        { "name": "backbone_radius", "blendername": "Backbone Radius", "type": float, "default": 2.0 },
-        { "name": "base_shape", "blendername": "Base Shape", "type": str, "default": "Rectangle" },
-        { "name": "base_realize", "blendername": "Base Realize", "type": bool, "default": False },
-        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": True },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
+        { "name": "quality", "blendername": "Quality" },
+        { "name": "dssp", "blendername": "Peptide DSSP" },
+        { "name": "cylinders", "blendername": "Peptide Cylinders" },
+        { "name": "arrows", "blendername": "Peptide Arrows" },
+        { "name": "rounded", "blendername": "Peptide Rounded" },
+        { "name": "thickness", "blendername": "Peptide Thickness" },
+        { "name": "width", "blendername": "Peptide Width" },
+        { "name": "loop_radius", "blendername": "Peptide Loop Radius" },
+        { "name": "smoothing", "blendername": "Peptide Smoothing" },
+        { "name": "backbone_shape", "blendername": "Backbone Shape" },
+        { "name": "backbone_radius", "blendername": "Backbone Radius" },
+        { "name": "base_shape", "blendername": "Base Shape" },
+        { "name": "base_realize", "blendername": "Base Realize" },
+        { "name": "color_blur", "blendername": "Color Blur" },
+        { "name": "shade_smooth", "blendername": "Shade Smooth" }
     ]
-    # fmt: on
-    style="cartoon"
 
     def __init__(
         self,
@@ -98,13 +100,13 @@ class StyleCartoon(StyleBase):
         cylinders: bool = False,
         arrows: bool = True,
         rounded: bool = False,
-        thickness: float = 0.6000000238418579,
-        width: float = 2.200000047683716,
-        loop_radius: float = 0.30000001192092896,
+        thickness: float = 0.6,
+        width: float = 2.2,
+        loop_radius: float = 0.3,
         smoothing: float = 0.5,
-        backbone_shape: str = "Cylinder",
+        backbone_shape: str = "Cylinder", # enum?
         backbone_radius: float = 2.0,
-        base_shape: str = "Rectangle",
+        base_shape: str = "Rectangle", # enum?
         base_realize: bool = False,
         color_blur: bool = True,
         shade_smooth: bool = True,
@@ -125,26 +127,25 @@ class StyleCartoon(StyleBase):
         self.color_blur = color_blur
         self.shade_smooth = shade_smooth
 
+
 class StyleRibbon(StyleBase):
-    # fmt: off
+    style = "ribbon"
     portdata: PortDataList = [
-        {"name": "quality", "blendername": "Quality", "type": int, "default": 3},
-        {"name": "radius", "blendername": "Radius", "type": float, "default": 1.6},
-        {"name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.6},
-        {"name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False},
-        {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
-        {"name": "backbone_smoothing", "blendername": "Backbone Smoothing", "type": float, "default": 0.5},
-        {"name": "backbone_threshold", "blendername": "Backbone Threshold", "type": float, "default": 4.5},
-        {"name": "backbone_radius", "blendername": "Backbone Radius", "type": float, "default": 1.6},
-        {"name": "backbone_shape", "blendername": "Backbone Shape", "type": str, "default": "Cylinder"},
-        {"name": "base_resolution", "blendername": "Base Resolution", "type": int, "default": 4},
-        {"name": "base_realize", "blendername": "Base Realize", "type": bool, "default": False},
-        {"name": "uv_map", "blendername": "UV Map", "type": bool, "default": False},
-        {"name": "u_component_factor", "blendername": "U Component Factor", "type": float, "default": None},
+        {"name": "quality", "blendername": "Quality"},
+        {"name": "radius", "blendername": "Radius"},
+        {"name": "smoothing", "blendername": "Smoothing"},
+        {"name": "color_blur", "blendername": "Color Blur"},
+        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+        {"name": "backbone_smoothing", "blendername": "Backbone Smoothing"},
+        {"name": "backbone_threshold", "blendername": "Backbone Threshold"},
+        {"name": "backbone_radius", "blendername": "Backbone Radius"},
+        {"name": "backbone_shape", "blendername": "Backbone Shape"},
+        {"name": "base_resolution", "blendername": "Base Resolution"},
+        {"name": "base_realize", "blendername": "Base Realize"},
+        {"name": "uv_map", "blendername": "UV Map"},
+        {"name": "u_component_factor", "blendername": "U Component Factor"},
     ]
 
-    # fmt: on
-    style = "ribbon"
     def __init__(
         self,
         quality: int = 3,
@@ -169,29 +170,26 @@ class StyleRibbon(StyleBase):
         self.backbone_smoothing = backbone_smoothing
         self.backbone_threshold = backbone_threshold
         self.backbone_radius = backbone_radius
-        self.backbone_shape = backbone_shape
+        self.backbone_shape = backbone_shape  # enum?
         self.base_resolution = base_resolution
         self.base_realize = base_realize
         self.uv_map = uv_map
         self.u_component_factor = u_component_factor
 
 
-
 class StyleSpheres(StyleBase):
-    # fmt: off
-    portdata: PortDataList = [
-        {"name": "geometry", "blendername": "Sphere Geometry", "type": str, "default": "Point"},
-        {"name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.800000011920929},
-        {"name": "sphere_subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2},
-        {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True},
-    ]
-    # fmt: on
     style = "spheres"
+    portdata: PortDataList = [
+        {"name": "geometry", "blendername": "Sphere Geometry"},
+        {"name": "radii", "blendername": "Sphere Radii"},
+        {"name": "sphere_subdivisions", "blendername": "Sphere Subdivisions"},
+        {"name": "shade_smooth", "blendername": "Shade Smooth"},
+    ]
 
     def __init__(
         self,
-        geometry: str = "Point",  # make enum
-        radii: float = 0.800000011920929,
+        geometry: str = "Point",  # enum: "Point" (Point Cloud), "Instances" (Instances of a mesh Icosphere), or "Mesh" (realised Mesh)
+        radii: float = 0.8,
         sphere_subdivisions: int = 2,
         shade_smooth: bool = True,
     ):
@@ -202,15 +200,13 @@ class StyleSpheres(StyleBase):
 
 
 class StyleSticks(StyleBase):
-    # fmt: off
-    portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
-        { "name": "radius", "blendername": "Radius", "type": float, "default": 0.20000000298023224 },
-        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
-    ]
-    # fmt: on
     style = "sticks"
+    portdata: PortDataList = [
+        { "name": "quality", "blendername": "Quality" },
+        { "name": "radius", "blendername": "Radius" },
+        { "name": "color_blur", "blendername": "Color Blur" },
+        { "name": "shade_smooth", "blendername": "Shade Smooth" }
+    ]
 
     def __init__(
         self,
@@ -226,20 +222,18 @@ class StyleSticks(StyleBase):
 
 
 class StyleSurface(StyleBase):
-    # fmt: off
-    portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
-        { "name": "scale_radii", "blendername": "Scale Radii", "type": float, "default": 1.5 },
-        { "name": "probe_size", "blendername": "Probe Size", "type": float, "default": 1.0 },
-        { "name": "relaxation_steps", "blendername": "Relaxation Steps", "type": int, "default": 10 },
-        { "name": "separate", "blendername": "Separate By", "type": str, "default": "chain_id" },
-        { "name": "group_id", "blendername": "Group ID", "type": int, "default": 0 },
-        { "name": "color_source", "blendername": "Color Source", "type": str, "default": "Alpha Carbon" },
-        { "name": "blur", "blendername": "Color Blur", "type": int, "default": 2 },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
-    ]
-    # fmt: on
     style = "surface"
+    portdata: PortDataList = [
+        { "name": "quality", "blendername": "Quality" },
+        { "name": "scale_radii", "blendername": "Scale Radii" },
+        { "name": "probe_size", "blendername": "Probe Size" },
+        { "name": "relaxation_steps", "blendername": "Relaxation Steps" },
+        { "name": "separate", "blendername": "Separate By" },
+        { "name": "group_id", "blendername": "Group ID" },
+        { "name": "color_source", "blendername": "Color Source" },
+        { "name": "blur", "blendername": "Color Blur" },
+        { "name": "shade_smooth", "blendername": "Shade Smooth" }
+    ]
 
     def __init__(
         self,
@@ -247,9 +241,9 @@ class StyleSurface(StyleBase):
         scale_radii: float = 1.5,
         probe_size: float = 1.0,
         relaxation_steps: int = 10,
-        separate: str = "chain_id",
+        separate: str = "chain_id",   # enum?
         group_id: int = 0,
-        color_source: str = "Alpha Carbon",
+        color_source: str = "Alpha Carbon", # enum?
         blur: int = 2,
         shade_smooth: bool = True,
     ):

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -175,29 +175,25 @@ class StyleRibbon(StyleBase):
         self.uv_map = uv_map
         self.u_component_factor = u_component_factor
 
+
+
 class StyleSpheres(StyleBase):
+    # fmt: off
     portdata: PortDataList = [
-        # fmt: off
-        {"name": "geometry", "blendername": "Sphere Geometry", "type": bool, "default": "Point"},
-        {"name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8},
+        {"name": "geometry", "blendername": "Sphere Geometry", "type": str, "default": "Point"},
+        {"name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.800000011920929},
         {"name": "sphere_subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2},
-        {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
-        # fmt: on
+        {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True},
     ]
+    # fmt: on
     style = "spheres"
-
-
-    # Sphere Geometry Point
-    # Sphere Radii 0.800000011920929
-    # Sphere Subdivisions 2
-    # Shade Smooth True
 
     def __init__(
         self,
         geometry: str = "Point",  # make enum
-        radii: float = 0.8,
+        radii: float = 0.800000011920929,
         sphere_subdivisions: int = 2,
-        shade_smooth: bool = False,
+        shade_smooth: bool = True,
     ):
         self.geometry = geometry
         self.radii = radii
@@ -208,25 +204,20 @@ class StyleSpheres(StyleBase):
 class StyleSticks(StyleBase):
     # fmt: off
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
-        { "name": "radius", "blendername": "Radius", "type": float, "default": 0.2 },
+        { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
+        { "name": "radius", "blendername": "Radius", "type": float, "default": 0.20000000298023224 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
-        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
+    # fmt: on
     style = "sticks"
 
-    # Quality 3
-    # Radius 0.20000000298023224
-    # Color Blur False
-    # Shade Smooth True
-
-    # fmt: on
     def __init__(
         self,
-        quality: int = 2,
-        radius: float = 0.2,
+        quality: int = 3,
+        radius: float = 0.20000000298023224,
         color_blur: bool = False,
-        shade_smooth: bool = False,
+        shade_smooth: bool = True,
     ):
         self.quality = quality
         self.radius = radius
@@ -238,48 +229,36 @@ class StyleSurface(StyleBase):
     # fmt: off
     portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
-        { "name": "separate", "blendername": "Separate", "type": bool, "default": True },
-        { "name": "attribute", "blendername": "Attribute", "type": str, "default": "chain_id" },
         { "name": "scale_radii", "blendername": "Scale Radii", "type": float, "default": 1.5 },
         { "name": "probe_size", "blendername": "Probe Size", "type": float, "default": 1.0 },
-        { "name": "triangulate", "blendername": "Triangulate", "type": bool, "default": False },
         { "name": "relaxation_steps", "blendername": "Relaxation Steps", "type": int, "default": 10 },
-        { "name": "by_ca", "blendername": "by CA", "type": bool, "default": False },
-        { "name": "blur", "blendername": "Blur", "type": int, "default": 2 },
+        { "name": "separate", "blendername": "Separate By", "type": str, "default": "chain_id" },
+        { "name": "group_id", "blendername": "Group ID", "type": int, "default": 0 },
+        { "name": "color_source", "blendername": "Color Source", "type": str, "default": "Alpha Carbon" },
+        { "name": "blur", "blendername": "Color Blur", "type": int, "default": 2 },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
     # fmt: on
     style = "surface"
 
-    # Quality 3
-    # Scale Radii 1.5
-    # Probe Size 1.0
-    # Relaxation Steps 10
-    # Separate By chain_id
-    # Group ID 0
-    # Color Source Alpha Carbon
-    # Color Blur 2
-    # Shade Smooth True
     def __init__(
         self,
         quality: int = 3,
-        separate: bool = True,
-        attribute: str = "chain_id",
         scale_radii: float = 1.5,
         probe_size: float = 1.0,
-        triangulate: bool = False,
         relaxation_steps: int = 10,
-        by_ca: bool = False,
+        separate: str = "chain_id",
+        group_id: int = 0,
+        color_source: str = "Alpha Carbon",
         blur: int = 2,
         shade_smooth: bool = True,
     ):
         self.quality = quality
-        self.separate = separate
-        self.attribute = attribute
         self.scale_radii = scale_radii
         self.probe_size = probe_size
-        self.triangulate = triangulate
         self.relaxation_steps = relaxation_steps
-        self.by_ca = by_ca
+        self.separate = separate
+        self.group_id = group_id
+        self.color_source = color_source
         self.blur = blur
         self.shade_smooth = shade_smooth

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -13,6 +13,9 @@ function to parity between the nodetrees and the class representations.
 
 from typing import List, Tuple, Union, Any, Dict
 from bpy.types import GeometryNodeGroup
+# from .nodes import styles_mapping
+# import databpy import db
+# from databpy.nodes import (append_from_blend)
 
 __all__ = [
     "StyleBallandStick",
@@ -30,8 +33,8 @@ PortDataList = List[PortDataEntry]
 
 
 class StyleBase:
+    style: str
     portdata: PortDataList = []
-
 
     def update_style_node(self, node_style: GeometryNodeGroup):
         for input in node_style.inputs:
@@ -144,9 +147,11 @@ class StyleRibbon(StyleBase):
         {"name": "backbone_threshold", "blendername": "Backbone Threshold"},
         {"name": "backbone_radius", "blendername": "Backbone Radius"},
         {"name": "backbone_shape", "blendername": "Backbone Shape"},
+        {"name": "base_scale", "blendername": "Base Scale"},
         {"name": "base_resolution", "blendername": "Base Resolution"},
         {"name": "base_realize", "blendername": "Base Realize"},
         {"name": "uv_map", "blendername": "UV Map"},
+        {"name": "u_component", "blendername": "U Component"},
         {"name": "u_component_factor", "blendername": "U Component Factor"},
     ]
 
@@ -159,11 +164,13 @@ class StyleRibbon(StyleBase):
         shade_smooth: bool = False,
         backbone_smoothing: float = 0.5,
         backbone_threshold: float = 4.5,
+        base_scale: Tuple[float, float, float] = (2.5, 0.5, 7.0),
         backbone_radius: float = 1.6,
-        backbone_shape: str = "Cylinder",
+        # backbone_shape: str = "Cylinder",
         base_resolution: int = 4,
         base_realize: bool = False,
         uv_map: bool = False,
+        u_component=None,
         u_component_factor=None,
     ):
         self.quality = quality
@@ -174,10 +181,12 @@ class StyleRibbon(StyleBase):
         self.backbone_smoothing = backbone_smoothing
         self.backbone_threshold = backbone_threshold
         self.backbone_radius = backbone_radius
-        self.backbone_shape = backbone_shape  # enum?
+        # self.backbone_shape = backbone_shape  # enum?
+        self.base_scale = base_scale
         self.base_resolution = base_resolution
         self.base_realize = base_realize
         self.uv_map = uv_map
+        self.u_component = u_component
         self.u_component_factor = u_component_factor
 
 

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -39,8 +39,10 @@ class Socket:
         name: The name of the attribute in the Style class
         blendername: The corresponding name of the input socket in the Blender node
     """
+
     name: str
     blendername: Optional[str] = None
+
 
 SocketInfo = List[Socket]
 

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -139,8 +139,8 @@ class StyleRibbon(StyleBase):
     style = "ribbon"
     portdata: PortDataList = [
         {"name": "quality", "blendername": "Quality"},
-        {"name": "radius", "blendername": "Radius"},
-        {"name": "smoothing", "blendername": "Smoothing"},
+        # {"name": "radius", "blendername": "Radius"},
+        # {"name": "smoothing", "blendername": "Smoothing"},
         {"name": "color_blur", "blendername": "Color Blur"},
         {"name": "shade_smooth", "blendername": "Shade Smooth"},
         {"name": "backbone_smoothing", "blendername": "Backbone Smoothing"},
@@ -152,42 +152,42 @@ class StyleRibbon(StyleBase):
         {"name": "base_realize", "blendername": "Base Realize"},
         {"name": "uv_map", "blendername": "UV Map"},
         {"name": "u_component", "blendername": "U Component"},
-        {"name": "u_component_factor", "blendername": "U Component Factor"},
+        # {"name": "u_component_factor", "blendername": "U Component Factor"},
     ]
 
     def __init__(
         self,
         quality: int = 3,
-        radius: float = 1.6,
-        smoothing: float = 0.6,
+        # radius: float = 1.6,
+        # smoothing: float = 0.6,
         color_blur: bool = False,
         shade_smooth: bool = False,
         backbone_smoothing: float = 0.5,
         backbone_threshold: float = 4.5,
         base_scale: Tuple[float, float, float] = (2.5, 0.5, 7.0),
-        backbone_radius: float = 1.6,
-        # backbone_shape: str = "Cylinder",
+        backbone_radius: float = 2.0,
+        backbone_shape: str = "Cylinder",
         base_resolution: int = 4,
         base_realize: bool = False,
         uv_map: bool = False,
         u_component=None,
-        u_component_factor=None,
+        # u_component_factor=None,
     ):
         self.quality = quality
-        self.radius = radius
-        self.smoothing = smoothing
+        # self.radius = radius
+        # self.smoothing = smoothing
         self.color_blur = color_blur
         self.shade_smooth = shade_smooth
         self.backbone_smoothing = backbone_smoothing
         self.backbone_threshold = backbone_threshold
         self.backbone_radius = backbone_radius
-        # self.backbone_shape = backbone_shape  # enum?
+        self.backbone_shape = backbone_shape  # enum?
         self.base_scale = base_scale
         self.base_resolution = base_resolution
         self.base_realize = base_realize
         self.uv_map = uv_map
         self.u_component = u_component
-        self.u_component_factor = u_component_factor
+        # self.u_component_factor = u_component_factor
 
 
 class StyleSpheres(StyleBase):

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, replace, field, fields
 from typing import List, Tuple, Union, Any, Dict
+from bpy.types import GeometryNodeGroup
 
 __all__ = [
     "StyleBallandStick",
@@ -8,18 +9,9 @@ __all__ = [
     "StyleSpheres",
     "StyleSticks",
     "StyleSurface",
-    "StyleClass",
     "StyleBase",
 ]
 
-StyleClass = Union[
-    "StyleBallandStick",
-    "StyleCartoon",
-    "StyleRibbon",
-    "StyleSpheres",
-    "StyleSticks",
-    "StyleSurface",
-]
 
 # Define the type for a single port data entry for clarity
 PortDataEntry = Dict[str, Any]
@@ -29,28 +21,15 @@ PortDataList = List[PortDataEntry]
 
 class StyleBase:
     portdata: PortDataList = []
+    def update_style_node(self, node_style: GeometryNodeGroup):
+        for input in node_style.inputs:
+            if input.type != "GEOMETRY":
+                for arg in self.portdata:
+                    name = arg['name']
+                    blendername = arg.get('blendername', name)  # Use name if blendername not
+                    if input.name == blendername:
+                        input.default_value = getattr(self, name)
 
-
-# current implemented representations
-styles_mapping = {
-    "preset_1": "Style Preset 1",
-    "preset_2": "Style Preset 2",
-    "preset_3": "Style Preset 3",
-    "preset_4": "Style Preset 4",
-    "atoms": "Style Spheres",
-    "spheres": "Style Spheres",
-    "vdw": "Style Spheres",
-    "sphere": "Style Spheres",
-    "cartoon": "Style Cartoon",
-    "sticks": "Style Sticks",
-    "ribbon": "Style Ribbon",
-    "surface": "Style Surface",
-    "ball_and_stick": "Style Ball and Stick",
-    "ball+stick": "Style Ball and Stick",
-    "oxdna": "MN_oxdna_style_ribbon",
-    "density_surface": "Style Density Surface",
-    "density_wire": "Style Density Wire",
-}
 
 class StyleBallandStick(StyleBase):
     # fmt: off
@@ -64,7 +43,7 @@ class StyleBallandStick(StyleBase):
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
-    self.style="ball_and_stick"
+    style="ball_and_stick"
     # fmt: on
 
     def __init__(
@@ -104,7 +83,7 @@ class StyleCartoon(StyleBase):
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
     # fmt: on
-    self.style="cartoon"
+    style="cartoon"
 
     def __init__(
         self,

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -13,9 +13,6 @@ function to parity between the nodetrees and the class representations.
 
 from typing import List, Tuple, Union, Any, Dict
 from bpy.types import GeometryNodeGroup
-# from .nodes import styles_mapping
-# import databpy import db
-# from databpy.nodes import (append_from_blend)
 
 __all__ = [
     "StyleBallandStick",
@@ -27,10 +24,8 @@ __all__ = [
     "StyleBase",
 ]
 
-
 PortDataEntry = Dict[str, Any]
 PortDataList = List[PortDataEntry]
-
 
 class StyleBase:
     style: str
@@ -139,8 +134,6 @@ class StyleRibbon(StyleBase):
     style = "ribbon"
     portdata: PortDataList = [
         {"name": "quality", "blendername": "Quality"},
-        # {"name": "radius", "blendername": "Radius"},
-        # {"name": "smoothing", "blendername": "Smoothing"},
         {"name": "color_blur", "blendername": "Color Blur"},
         {"name": "shade_smooth", "blendername": "Shade Smooth"},
         {"name": "backbone_smoothing", "blendername": "Backbone Smoothing"},
@@ -152,14 +145,11 @@ class StyleRibbon(StyleBase):
         {"name": "base_realize", "blendername": "Base Realize"},
         {"name": "uv_map", "blendername": "UV Map"},
         {"name": "u_component", "blendername": "U Component"},
-        # {"name": "u_component_factor", "blendername": "U Component Factor"},
     ]
 
     def __init__(
         self,
         quality: int = 3,
-        # radius: float = 1.6,
-        # smoothing: float = 0.6,
         color_blur: bool = False,
         shade_smooth: bool = False,
         backbone_smoothing: float = 0.5,
@@ -174,8 +164,6 @@ class StyleRibbon(StyleBase):
         # u_component_factor=None,
     ):
         self.quality = quality
-        # self.radius = radius
-        # self.smoothing = smoothing
         self.color_blur = color_blur
         self.shade_smooth = shade_smooth
         self.backbone_smoothing = backbone_smoothing
@@ -187,7 +175,6 @@ class StyleRibbon(StyleBase):
         self.base_realize = base_realize
         self.uv_map = uv_map
         self.u_component = u_component
-        # self.u_component_factor = u_component_factor
 
 
 class StyleSpheres(StyleBase):

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,117 +1,56 @@
-"""Constant style definitions for molecular visualization in Blender.
-
-This module contains predefined style settings for different molecular visualization
-modes including ball-and-stick, cartoon, ribbon, spheres, sticks and surface
-representations.
-
-"""
-
-from dataclasses import dataclass, replace, field, fields
-from typing import List, Tuple, Union
-
-
-@dataclass(frozen=True)
-class StyleBase:
-    def get_by_key(self, original_key: str):
-        for f in fields(self):
-            if f.metadata.get('key') == original_key:
-                return getattr(self, f.name)
-        return None
-
-    def update_properties(self, **changes):
-        return replace(self, **changes)
-
-@dataclass(frozen=True)
-class BallStickStyle(StyleBase):
-    style: str = field(default="ball+stick", metadata={"key": "Style"})
-    quality: int = field(default=2, metadata={"key": "Quality"})
-    as_mesh: bool = field(default=True, metadata={"key": "As Mesh"})
-    sphere_radii: float = field(default=0.3, metadata={"key": "Sphere Radii"})
-    bond_split: bool = field(default=False, metadata={"key": "Bond Split"})
-    bond_find: bool = field(default=True, metadata={"key": "Bond Find"})
-    bond_radius: float = field(default=0.3, metadata={"key": "Bond Radius"})
-    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
-    shade_smooth: bool = field(default=True, metadata={"key": "Shade Smooth"})
-
-
-@dataclass(frozen=True)
-class CartoonStyle(StyleBase):
-    style: str = field(default="cartoon", metadata={"key": "Style"})
-    quality: int = field(default=2, metadata={"key": "Quality"})
-    dssp: bool = field(default=False, metadata={"key": "DSSP"})
-    cylinders: bool = field(default=False, metadata={"key": "Cylinders"})
-    arrows: bool = field(default=True, metadata={"key": "Arrows"})
-    rounded: bool = field(default=False, metadata={"key": "Rounded"})
-    thickness: float = field(default=0.6, metadata={"key": "Thickness"})
-    width: float = field(default=2.2, metadata={"key": "Width"})
-    loop_radius: float = field(default=0.3, metadata={"key": "Loop Radius"})
-    smoothing: float = field(default=0.5, metadata={"key": "Smoothing"})
-    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
-    shade_smooth: bool = field(default=True, metadata={"key": "Shade Smooth"})
-
-
-@dataclass(frozen=True)
-class RibbonStyle(StyleBase):
-    style: str = field(default="ribbon", metadata={"key": "Style"})
-    quality: int = field(default=3, metadata={"key": "Quality"})
-    radius: float = field(default=1.6, metadata={"key": "Radius"})
-    smoothing: float = field(default=0.6, metadata={"key": "Smoothing"})
-    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
-    shade_smooth: bool = field(default=False, metadata={"key": "Shade Smooth"})
-
-@dataclass(frozen=True)
-class SpheresStyle(StyleBase):
-    style: str = field(default="sphere", metadata={"key": "Style"})
-    as_mesh: bool = field(default=True, metadata={"key": "Sphere As Mesh"})
-    radii: float = field(default=0.8, metadata={"key": "Sphere Radii"})
-    subdivisions: int = field(default=2, metadata={"key": "Sphere Subdivisions"})
-    shade_smooth: bool = field(default=False, metadata={"key": "Shade Smooth"})
-
-
-@dataclass(frozen=True)
-class SticksStyle(StyleBase):
-    style: str = field(default="sticks", metadata={"key": "Style"})
-    quality: int = field(default=2, metadata={"key": "Quality"})
-    radius: float = field(default=0.2, metadata={"key": "Radius"})
-    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
-    shade_smooth: bool = field(default=False, metadata={"key": "Shade Smooth"})
-
-
-@dataclass(frozen=True)
-class SurfaceStyle(StyleBase):
-    style: str = field(default="surface", metadata={"key": "Style"})
-    quality: int = field(default=3, metadata={"key": "Quality"})
-    separate: bool = field(default=True, metadata={"key": "Separate"})
-    attribute: str = field(default="chain_id", metadata={"key": "Attribute"})
-    scale_radii: float = field(default=1.5, metadata={"key": "Scale Radii"})
-    probe_size: float = field(default=1.0, metadata={"key": "Probe Size"})
-    triangulate: bool = field(default=False, metadata={"key": "Triangulate"})
-    relaxation_steps: int = field(default=10, metadata={"key": "Relaxation Steps"})
-    by_ca: bool = field(default=False, metadata={"key": "by CA"})
-    blur: int = field(default=2, metadata={"key": "Blur"})
-    shade_smooth: bool = field(default=True, metadata={"key": "Shade Smooth"})
-
-
-StyleType = Union[BallStickStyle, CartoonStyle, RibbonStyle, SpheresStyle, SticksStyle, SurfaceStyle]
-
-class StyleCreator():
-    def new() -> StyleType:
-        return CartoonStyle()
-
-    def ball_stick() -> BallStickStyle:
-        return BallStickStyle()
-
-    def cartoon() -> CartoonStyle:
-        return CartoonStyle()
-
-    def ribbon() -> RibbonStyle:
-        return RibbonStyle()
-
-    def spheres() -> SpheresStyle:
-        return SpheresStyle()
-
-    def sticks() -> SticksStyle:
-        return SticksStyle()
-
-    def surface() -> SurfaceStyle:
-        return SurfaceStyle()
+STYLE_DATA = {
+    "Style Ball and Stick": [
+        { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
+        { "name": "as_mesh", "blendername": "As Mesh", "type": bool, "default": True },
+        { "name": "sphere_radii", "blendername": "Sphere Radii", "type": float, "default": 0.3 },
+        { "name": "bond_split", "blendername": "Bond Split", "type": bool, "default": False },
+        { "name": "bond_find", "blendername": "Bond Find", "type": bool, "default": True },
+        { "name": "bond_radius", "blendername": "Bond Radius", "type": float, "default": 0.3 },
+        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
+    ],
+    "Style Cartoon": [
+        { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
+        { "name": "dssp", "blendername": "DSSP", "type": bool, "default": False },
+        { "name": "cylinders", "blendername": "Cylinders", "type": bool, "default": False },
+        { "name": "arrows", "blendername": "Arrows", "type": bool, "default": True },
+        { "name": "rounded", "blendername": "Rounded", "type": bool, "default": False },
+        { "name": "thickness", "blendername": "Thickness", "type": float, "default": 0.6 },
+        { "name": "width", "blendername": "Width", "type": float, "default": 2.2 },
+        { "name": "loop_radius", "blendername": "Loop Radius", "type": float, "default": 0.3 },
+        { "name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.5 },
+        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
+    ],
+    "Style Ribbon": [
+        { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
+        { "name": "radius", "blendername": "Radius", "type": float, "default": 1.6 },
+        { "name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.6 },
+        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
+    ],
+    "Style Spheres": [
+        { "name": "as_mesh", "blendername": "Sphere As Mesh", "type": bool, "default": True },
+        { "name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8 },
+        { "name": "subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2 },
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
+    ],
+    "Style Sticks": [
+        { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
+        { "name": "radius", "blendername": "Radius", "type": float, "default": 0.2 },
+        { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
+    ],
+    "Style Sruface": [
+        { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
+        { "name": "separate", "blendername": "Separate", "type": bool, "default": True },
+        { "name": "attribute", "blendername": "Attribute", "type": str, "default": "chain_id" },
+        { "name": "scale_radii", "blendername": "Scale Radii", "type": float, "default": 1.5 },
+        { "name": "probe_size", "blendername": "Probe Size", "type": float, "default": 1.0 },
+        { "name": "triangulate", "blendername": "Triangulate", "type": bool, "default": False },
+        { "name": "relaxation_steps", "blendername": "Relaxation Steps", "type": int, "default": 10 },
+        { "name": "by_ca", "blendername": "by CA", "type": bool, "default": False },
+        { "name": "blur", "blendername": "Blur", "type": int, "default": 2 },
+        { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
+    ]
+}

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -49,7 +49,7 @@ SocketInfo = List[Socket]
 
 class StyleBase:
     style: str
-    portdata: SocketInfo = []
+    socketdata: SocketInfo = []
 
     def update_style_node(self, node_style: GeometryNodeGroup):
         """Update the Blender node inputs with values from this style's attributes.
@@ -59,14 +59,14 @@ class StyleBase:
         """
         for input in node_style.inputs:
             if input.type != "GEOMETRY":
-                for arg in self.portdata:
+                for arg in self.socketdata:
                     if input.name == arg.blendername:
                         input.default_value = getattr(self, arg.name)
 
 
 class StyleBallandStick(StyleBase):
     style = "ball_and_stick"
-    portdata: SocketInfo = [
+    socketdata: SocketInfo = [
         Socket(name="quality", blendername="Quality"),
         Socket(name="geometry", blendername="Sphere Geometry"),
         Socket(name="sphere_radii", blendername="Sphere Radii"),
@@ -100,7 +100,7 @@ class StyleBallandStick(StyleBase):
 
 class StyleCartoon(StyleBase):
     style = "cartoon"
-    portdata: SocketInfo = [
+    socketdata: SocketInfo = [
         Socket(name="quality", blendername="Quality"),
         Socket(name="dssp", blendername="Peptide DSSP"),
         Socket(name="cylinders", blendername="Peptide Cylinders"),
@@ -155,7 +155,7 @@ class StyleCartoon(StyleBase):
 
 class StyleRibbon(StyleBase):
     style = "ribbon"
-    portdata: SocketInfo = [
+    socketdata: SocketInfo = [
         Socket(name="quality", blendername="Quality"),
         Socket(name="color_blur", blendername="Color Blur"),
         Socket(name="shade_smooth", blendername="Shade Smooth"),
@@ -202,7 +202,7 @@ class StyleRibbon(StyleBase):
 
 class StyleSpheres(StyleBase):
     style = "spheres"
-    portdata: SocketInfo = [
+    socketdata: SocketInfo = [
         Socket(name="geometry", blendername="Sphere Geometry"),
         Socket(name="radii", blendername="Sphere Radii"),
         Socket(name="sphere_subdivisions", blendername="Sphere Subdivisions"),
@@ -224,7 +224,7 @@ class StyleSpheres(StyleBase):
 
 class StyleSticks(StyleBase):
     style = "sticks"
-    portdata: SocketInfo = [
+    socketdata: SocketInfo = [
         Socket(name="quality", blendername="Quality"),
         Socket(name="radius", blendername="Radius"),
         Socket(name="color_blur", blendername="Color Blur"),
@@ -234,7 +234,7 @@ class StyleSticks(StyleBase):
     def __init__(
         self,
         quality: int = 3,
-        radius: float = 0.20000000298023224,
+        radius: float = 0.2,
         color_blur: bool = False,
         shade_smooth: bool = True,
     ):
@@ -246,7 +246,7 @@ class StyleSticks(StyleBase):
 
 class StyleSurface(StyleBase):
     style = "surface"
-    portdata: SocketInfo = [
+    socketdata: SocketInfo = [
         Socket(name="quality", blendername="Quality"),
         Socket(name="scale_radii", blendername="Scale Radii"),
         Socket(name="probe_size", blendername="Probe Size"),

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -41,7 +41,7 @@ STYLE_DATA = {
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
     ],
-    "Style Sruface": [
+    "Style Surface": [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
         { "name": "separate", "blendername": "Separate", "type": bool, "default": True },
         { "name": "attribute", "blendername": "Attribute", "type": str, "default": "chain_id" },

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,6 +1,15 @@
 from dataclasses import dataclass, replace, field, fields
 from typing import List, Tuple, Union, Any, Dict
 
+__all__ = [
+    "StyleBallandStick",
+    "StyleCartoon",
+    "StyleRibbon",
+    "StyleSpheres",
+    "StyleSticks",
+    "StyleSurface",
+]
+
 StyleClass = Union[
     "StyleBallandStick",
     "StyleCartoon",
@@ -144,28 +153,12 @@ class StyleRibbon(StyleBase):
 class StyleSpheres(StyleBase):
     portdata: PortDataList = [
         # fmt: off
-        {
-            "name": "geometry",
-            "blendername": "Sphere Geometry",
-            "type": bool,
-            "default": "Point",
-        },
+        {"name": "geometry", "blendername": "Sphere Geometry", "type": bool, "default": "Point"},
         {"name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8},
-        {
-            "name": "subdivisions",
-            "blendername": "Sphere Subdivisions",
-            "type": int,
-            "default": 2,
-        },
-        {
-            "name": "shade_smooth",
-            "blendername": "Shade Smooth",
-            "type": bool,
-            "default": False,
-        },
+        {"name": "subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2},
+        {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
         # fmt: on
     ]
-
     def __init__(
         self,
         style: str = "sphere",
@@ -175,7 +168,7 @@ class StyleSpheres(StyleBase):
         shade_smooth: bool = False,
     ):
         self.style = style
-        self.as_mesh = as_mesh  # This corresponds to a geometry option, but the portdata has a different key "geometry"
+        self.as_mesh = as_mes
         self.radii = radii
         self.subdivisions = subdivisions
         self.shade_smooth = shade_smooth

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -24,11 +24,16 @@ class StyleBase:
     def update_style_node(self, node_style: GeometryNodeGroup):
         for input in node_style.inputs:
             if input.type != "GEOMETRY":
+                print(input.name, input.default_value,)
                 for arg in self.portdata:
+                    # print(arg)
                     name = arg['name']
                     blendername = arg.get('blendername', name)  # Use name if blendername not
                     if input.name == blendername:
+                        #print(f"setting! Val : {getattr(self, name)}")
+                        #print(f"Initial Val : {input.default_value}")
                         input.default_value = getattr(self, name)
+                        #print(f"AfterSetting Val : {input.default_value}")
 
 
 class StyleBallandStick(StyleBase):
@@ -43,6 +48,16 @@ class StyleBallandStick(StyleBase):
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
+
+    # Quality 2
+    # Selection True
+    # Sphere Geometry Instance
+    # Sphere Radii 0.30000001192092896
+    # Bond Split False
+    # Bond Find False
+    # Bond Radius 0.30000001192092896
+    # Color Blur False
+    # Shade Smooth True
     style="ball_and_stick"
     # fmt: on
 
@@ -120,7 +135,16 @@ class StyleRibbon(StyleBase):
         {"name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.6},
         {"name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False},
         {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
+        {"name": "backbone_smoothing", "blendername": "Backbone Smoothing", "type": float, "default": 0.5},
+        {"name": "backbone_threshold", "blendername": "Backbone Threshold", "type": float, "default": 4.5},
+        {"name": "backbone_radius", "blendername": "Backbone Radius", "type": float, "default": 1.6},
+        {"name": "backbone_shape", "blendername": "Backbone Shape", "type": str, "default": "Cylinder"},
+        {"name": "base_resolution", "blendername": "Base Resolution", "type": int, "default": 4},
+        {"name": "base_realize", "blendername": "Base Realize", "type": bool, "default": False},
+        {"name": "uv_map", "blendername": "UV Map", "type": bool, "default": False},
+        {"name": "u_component_factor", "blendername": "U Component Factor", "type": float, "default": None},
     ]
+
     # fmt: on
     style = "ribbon"
     def __init__(
@@ -130,13 +154,28 @@ class StyleRibbon(StyleBase):
         smoothing: float = 0.6,
         color_blur: bool = False,
         shade_smooth: bool = False,
+        backbone_smoothing: float = 0.5,
+        backbone_threshold: float = 4.5,
+        backbone_radius: float = 1.6,
+        backbone_shape: str = "Cylinder",
+        base_resolution: int = 4,
+        base_realize: bool = False,
+        uv_map: bool = False,
+        u_component_factor=None,
     ):
         self.quality = quality
         self.radius = radius
         self.smoothing = smoothing
         self.color_blur = color_blur
         self.shade_smooth = shade_smooth
-
+        self.backbone_smoothing = backbone_smoothing
+        self.backbone_threshold = backbone_threshold
+        self.backbone_radius = backbone_radius
+        self.backbone_shape = backbone_shape
+        self.base_resolution = base_resolution
+        self.base_realize = base_realize
+        self.uv_map = uv_map
+        self.u_component_factor = u_component_factor
 
 class StyleSpheres(StyleBase):
     portdata: PortDataList = [

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -17,7 +17,7 @@ previous dictionary-based approach.
 """
 
 from dataclasses import dataclass
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 from bpy.types import GeometryNodeGroup
 
 __all__ = [

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,0 +1,117 @@
+"""Constant style definitions for molecular visualization in Blender.
+
+This module contains predefined style settings for different molecular visualization
+modes including ball-and-stick, cartoon, ribbon, spheres, sticks and surface
+representations.
+
+"""
+
+from dataclasses import dataclass, replace, field, fields
+from typing import List, Tuple, Union
+
+
+@dataclass(frozen=True)
+class StyleBase:
+    def get_by_key(self, original_key: str):
+        for f in fields(self):
+            if f.metadata.get('key') == original_key:
+                return getattr(self, f.name)
+        return None
+
+    def update_properties(self, **changes):
+        return replace(self, **changes)
+
+@dataclass(frozen=True)
+class BallStickStyle(StyleBase):
+    style: str = field(default="ball+stick", metadata={"key": "Style"})
+    quality: int = field(default=2, metadata={"key": "Quality"})
+    as_mesh: bool = field(default=True, metadata={"key": "As Mesh"})
+    sphere_radii: float = field(default=0.3, metadata={"key": "Sphere Radii"})
+    bond_split: bool = field(default=False, metadata={"key": "Bond Split"})
+    bond_find: bool = field(default=True, metadata={"key": "Bond Find"})
+    bond_radius: float = field(default=0.3, metadata={"key": "Bond Radius"})
+    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
+    shade_smooth: bool = field(default=True, metadata={"key": "Shade Smooth"})
+
+
+@dataclass(frozen=True)
+class CartoonStyle(StyleBase):
+    style: str = field(default="cartoon", metadata={"key": "Style"})
+    quality: int = field(default=2, metadata={"key": "Quality"})
+    dssp: bool = field(default=False, metadata={"key": "DSSP"})
+    cylinders: bool = field(default=False, metadata={"key": "Cylinders"})
+    arrows: bool = field(default=True, metadata={"key": "Arrows"})
+    rounded: bool = field(default=False, metadata={"key": "Rounded"})
+    thickness: float = field(default=0.6, metadata={"key": "Thickness"})
+    width: float = field(default=2.2, metadata={"key": "Width"})
+    loop_radius: float = field(default=0.3, metadata={"key": "Loop Radius"})
+    smoothing: float = field(default=0.5, metadata={"key": "Smoothing"})
+    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
+    shade_smooth: bool = field(default=True, metadata={"key": "Shade Smooth"})
+
+
+@dataclass(frozen=True)
+class RibbonStyle(StyleBase):
+    style: str = field(default="ribbon", metadata={"key": "Style"})
+    quality: int = field(default=3, metadata={"key": "Quality"})
+    radius: float = field(default=1.6, metadata={"key": "Radius"})
+    smoothing: float = field(default=0.6, metadata={"key": "Smoothing"})
+    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
+    shade_smooth: bool = field(default=False, metadata={"key": "Shade Smooth"})
+
+@dataclass(frozen=True)
+class SpheresStyle(StyleBase):
+    style: str = field(default="sphere", metadata={"key": "Style"})
+    as_mesh: bool = field(default=True, metadata={"key": "Sphere As Mesh"})
+    radii: float = field(default=0.8, metadata={"key": "Sphere Radii"})
+    subdivisions: int = field(default=2, metadata={"key": "Sphere Subdivisions"})
+    shade_smooth: bool = field(default=False, metadata={"key": "Shade Smooth"})
+
+
+@dataclass(frozen=True)
+class SticksStyle(StyleBase):
+    style: str = field(default="sticks", metadata={"key": "Style"})
+    quality: int = field(default=2, metadata={"key": "Quality"})
+    radius: float = field(default=0.2, metadata={"key": "Radius"})
+    color_blur: bool = field(default=False, metadata={"key": "Color Blur"})
+    shade_smooth: bool = field(default=False, metadata={"key": "Shade Smooth"})
+
+
+@dataclass(frozen=True)
+class SurfaceStyle(StyleBase):
+    style: str = field(default="surface", metadata={"key": "Style"})
+    quality: int = field(default=3, metadata={"key": "Quality"})
+    separate: bool = field(default=True, metadata={"key": "Separate"})
+    attribute: str = field(default="chain_id", metadata={"key": "Attribute"})
+    scale_radii: float = field(default=1.5, metadata={"key": "Scale Radii"})
+    probe_size: float = field(default=1.0, metadata={"key": "Probe Size"})
+    triangulate: bool = field(default=False, metadata={"key": "Triangulate"})
+    relaxation_steps: int = field(default=10, metadata={"key": "Relaxation Steps"})
+    by_ca: bool = field(default=False, metadata={"key": "by CA"})
+    blur: int = field(default=2, metadata={"key": "Blur"})
+    shade_smooth: bool = field(default=True, metadata={"key": "Shade Smooth"})
+
+
+StyleType = Union[BallStickStyle, CartoonStyle, RibbonStyle, SpheresStyle, SticksStyle, SurfaceStyle]
+
+class StyleCreator():
+    def new() -> StyleType:
+        return CartoonStyle()
+
+    def ball_stick() -> BallStickStyle:
+        return BallStickStyle()
+
+    def cartoon() -> CartoonStyle:
+        return CartoonStyle()
+
+    def ribbon() -> RibbonStyle:
+        return RibbonStyle()
+
+    def spheres() -> SpheresStyle:
+        return SpheresStyle()
+
+    def sticks() -> SticksStyle:
+        return SticksStyle()
+
+    def surface() -> SurfaceStyle:
+        return SurfaceStyle()

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -24,12 +24,12 @@ __all__ = [
     "StyleBase",
 ]
 
-PortDataEntry = Dict[str, Any]
-PortDataList = List[PortDataEntry]
+SocketDataMapping = Dict[str, Any]
+SocketInfo = List[SocketDataMapping]
 
 class StyleBase:
     style: str
-    portdata: PortDataList = []
+    portdata: SocketInfo = []
 
     def update_style_node(self, node_style: GeometryNodeGroup):
         for input in node_style.inputs:
@@ -43,7 +43,7 @@ class StyleBase:
 
 class StyleBallandStick(StyleBase):
     style = "ball_and_stick"
-    portdata: PortDataList = [
+    portdata: SocketInfo = [
         {"name": "quality", "blendername": "Quality"},
         {"name": "geometry", "blendername": "Sphere Geometry"},
         {"name": "sphere_radii", "blendername": "Sphere Radii"},
@@ -77,7 +77,7 @@ class StyleBallandStick(StyleBase):
 
 class StyleCartoon(StyleBase):
     style = "cartoon"
-    portdata: PortDataList = [
+    portdata: SocketInfo = [
         {"name": "quality", "blendername": "Quality"},
         {"name": "dssp", "blendername": "Peptide DSSP"},
         {"name": "cylinders", "blendername": "Peptide Cylinders"},
@@ -132,7 +132,7 @@ class StyleCartoon(StyleBase):
 
 class StyleRibbon(StyleBase):
     style = "ribbon"
-    portdata: PortDataList = [
+    portdata: SocketInfo = [
         {"name": "quality", "blendername": "Quality"},
         {"name": "color_blur", "blendername": "Color Blur"},
         {"name": "shade_smooth", "blendername": "Shade Smooth"},
@@ -179,7 +179,7 @@ class StyleRibbon(StyleBase):
 
 class StyleSpheres(StyleBase):
     style = "spheres"
-    portdata: PortDataList = [
+    portdata: SocketInfo = [
         {"name": "geometry", "blendername": "Sphere Geometry"},
         {"name": "radii", "blendername": "Sphere Radii"},
         {"name": "sphere_subdivisions", "blendername": "Sphere Subdivisions"},
@@ -201,7 +201,7 @@ class StyleSpheres(StyleBase):
 
 class StyleSticks(StyleBase):
     style = "sticks"
-    portdata: PortDataList = [
+    portdata: SocketInfo = [
         {"name": "quality", "blendername": "Quality"},
         {"name": "radius", "blendername": "Radius"},
         {"name": "color_blur", "blendername": "Color Blur"},
@@ -223,7 +223,7 @@ class StyleSticks(StyleBase):
 
 class StyleSurface(StyleBase):
     style = "surface"
-    portdata: PortDataList = [
+    portdata: SocketInfo = [
         {"name": "quality", "blendername": "Quality"},
         {"name": "scale_radii", "blendername": "Scale Radii"},
         {"name": "probe_size", "blendername": "Probe Size"},

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -16,6 +16,7 @@ __all__ = [
 PortDataEntry = Dict[str, Any]
 PortDataList = List[PortDataEntry]
 
+
 class StyleBase:
     portdata: PortDataList = []
 
@@ -55,7 +56,7 @@ class StyleBallandStick(StyleBase):
     def __init__(
         self,
         quality: int = 2,
-        geometry: str = "Instance", # enum
+        geometry: str = "Instance",  # enum
         sphere_radii: float = 0.3,
         bond_split: bool = False,
         bond_find: bool = False,
@@ -76,21 +77,21 @@ class StyleBallandStick(StyleBase):
 class StyleCartoon(StyleBase):
     style = "cartoon"
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality" },
-        { "name": "dssp", "blendername": "Peptide DSSP" },
-        { "name": "cylinders", "blendername": "Peptide Cylinders" },
-        { "name": "arrows", "blendername": "Peptide Arrows" },
-        { "name": "rounded", "blendername": "Peptide Rounded" },
-        { "name": "thickness", "blendername": "Peptide Thickness" },
-        { "name": "width", "blendername": "Peptide Width" },
-        { "name": "loop_radius", "blendername": "Peptide Loop Radius" },
-        { "name": "smoothing", "blendername": "Peptide Smoothing" },
-        { "name": "backbone_shape", "blendername": "Backbone Shape" },
-        { "name": "backbone_radius", "blendername": "Backbone Radius" },
-        { "name": "base_shape", "blendername": "Base Shape" },
-        { "name": "base_realize", "blendername": "Base Realize" },
-        { "name": "color_blur", "blendername": "Color Blur" },
-        { "name": "shade_smooth", "blendername": "Shade Smooth" }
+        {"name": "quality", "blendername": "Quality"},
+        {"name": "dssp", "blendername": "Peptide DSSP"},
+        {"name": "cylinders", "blendername": "Peptide Cylinders"},
+        {"name": "arrows", "blendername": "Peptide Arrows"},
+        {"name": "rounded", "blendername": "Peptide Rounded"},
+        {"name": "thickness", "blendername": "Peptide Thickness"},
+        {"name": "width", "blendername": "Peptide Width"},
+        {"name": "loop_radius", "blendername": "Peptide Loop Radius"},
+        {"name": "smoothing", "blendername": "Peptide Smoothing"},
+        {"name": "backbone_shape", "blendername": "Backbone Shape"},
+        {"name": "backbone_radius", "blendername": "Backbone Radius"},
+        {"name": "base_shape", "blendername": "Base Shape"},
+        {"name": "base_realize", "blendername": "Base Realize"},
+        {"name": "color_blur", "blendername": "Color Blur"},
+        {"name": "shade_smooth", "blendername": "Shade Smooth"},
     ]
 
     def __init__(
@@ -104,9 +105,9 @@ class StyleCartoon(StyleBase):
         width: float = 2.2,
         loop_radius: float = 0.3,
         smoothing: float = 0.5,
-        backbone_shape: str = "Cylinder", # enum?
+        backbone_shape: str = "Cylinder",  # enum?
         backbone_radius: float = 2.0,
-        base_shape: str = "Rectangle", # enum?
+        base_shape: str = "Rectangle",  # enum?
         base_realize: bool = False,
         color_blur: bool = True,
         shade_smooth: bool = True,
@@ -202,10 +203,10 @@ class StyleSpheres(StyleBase):
 class StyleSticks(StyleBase):
     style = "sticks"
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality" },
-        { "name": "radius", "blendername": "Radius" },
-        { "name": "color_blur", "blendername": "Color Blur" },
-        { "name": "shade_smooth", "blendername": "Shade Smooth" }
+        {"name": "quality", "blendername": "Quality"},
+        {"name": "radius", "blendername": "Radius"},
+        {"name": "color_blur", "blendername": "Color Blur"},
+        {"name": "shade_smooth", "blendername": "Shade Smooth"},
     ]
 
     def __init__(
@@ -224,15 +225,15 @@ class StyleSticks(StyleBase):
 class StyleSurface(StyleBase):
     style = "surface"
     portdata: PortDataList = [
-        { "name": "quality", "blendername": "Quality" },
-        { "name": "scale_radii", "blendername": "Scale Radii" },
-        { "name": "probe_size", "blendername": "Probe Size" },
-        { "name": "relaxation_steps", "blendername": "Relaxation Steps" },
-        { "name": "separate", "blendername": "Separate By" },
-        { "name": "group_id", "blendername": "Group ID" },
-        { "name": "color_source", "blendername": "Color Source" },
-        { "name": "blur", "blendername": "Color Blur" },
-        { "name": "shade_smooth", "blendername": "Shade Smooth" }
+        {"name": "quality", "blendername": "Quality"},
+        {"name": "scale_radii", "blendername": "Scale Radii"},
+        {"name": "probe_size", "blendername": "Probe Size"},
+        {"name": "relaxation_steps", "blendername": "Relaxation Steps"},
+        {"name": "separate", "blendername": "Separate By"},
+        {"name": "group_id", "blendername": "Group ID"},
+        {"name": "color_source", "blendername": "Color Source"},
+        {"name": "blur", "blendername": "Color Blur"},
+        {"name": "shade_smooth", "blendername": "Shade Smooth"},
     ]
 
     def __init__(
@@ -241,9 +242,9 @@ class StyleSurface(StyleBase):
         scale_radii: float = 1.5,
         probe_size: float = 1.0,
         relaxation_steps: int = 10,
-        separate: str = "chain_id",   # enum?
+        separate: str = "chain_id",  # enum?
         group_id: int = 0,
-        color_source: str = "Alpha Carbon", # enum?
+        color_source: str = "Alpha Carbon",  # enum?
         blur: int = 2,
         shade_smooth: bool = True,
     ):

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -1,5 +1,23 @@
-STYLE_DATA = {
-    "Style Ball and Stick": [
+# mol.add_style(mn.StyleSpheres(geometry="mesh"), selection = "Protein")
+
+from dataclasses import dataclass, replace, field, fields
+from typing import List, Tuple, Union, Any, Dict
+
+StyleClass = Union["StyleBallandStick", "StyleCartoon", "StyleRibbon", "StyleSpheres", "StyleSticks", "StyleSurface"]
+
+# Define the type for a single port data entry for clarity
+PortDataEntry = Dict[str, Any]
+# Define the type for the list of port data entries
+PortDataList = List[PortDataEntry]
+
+
+class StyleBase:
+    # Base class for styles. Subclasses will define their own portdata attribute.
+    portdata: PortDataList = []
+
+
+class StyleBallandStick(StyleBase):
+    portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
         { "name": "as_mesh", "blendername": "As Mesh", "type": bool, "default": True },
         { "name": "sphere_radii", "blendername": "Sphere Radii", "type": float, "default": 0.3 },
@@ -8,8 +26,22 @@ STYLE_DATA = {
         { "name": "bond_radius", "blendername": "Bond Radius", "type": float, "default": 0.3 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
-    ],
-    "Style Cartoon": [
+    ]
+
+    def __init__(self, style: str = "ball+stick", quality: int = 2, as_mesh: bool = True, sphere_radii: float = 0.3, bond_split: bool = False, bond_find: bool = True, bond_radius: float = 0.3, color_blur: bool = False, shade_smooth: bool = True):
+        self.style = style
+        self.quality = quality
+        self.as_mesh = as_mesh
+        self.sphere_radii = sphere_radii
+        self.bond_split = bond_split
+        self.bond_find = bond_find
+        self.bond_radius = bond_radius
+        self.color_blur = color_blur
+        self.shade_smooth = shade_smooth
+
+
+class StyleCartoon(StyleBase):
+    portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
         { "name": "dssp", "blendername": "DSSP", "type": bool, "default": False },
         { "name": "cylinders", "blendername": "Cylinders", "type": bool, "default": False },
@@ -21,27 +53,77 @@ STYLE_DATA = {
         { "name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.5 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
-    ],
-    "Style Ribbon": [
+    ]
+
+    def __init__(self, style: str = "cartoon", quality: int = 2, dssp: bool = False, cylinders: bool = False, arrows: bool = True, rounded: bool = False, thickness: float = 0.6, width: float = 2.2, loop_radius: float = 0.3, smoothing: float = 0.5, color_blur: bool = False, shade_smooth: bool = True):
+        self.style = style
+        self.quality = quality
+        self.dssp = dssp
+        self.cylinders = cylinders
+        self.arrows = arrows
+        self.rounded = rounded
+        self.thickness = thickness
+        self.width = width
+        self.loop_radius = loop_radius
+        self.smoothing = smoothing
+        self.color_blur = color_blur
+        self.shade_smooth = shade_smooth
+
+
+class StyleRibbon(StyleBase):
+    portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
         { "name": "radius", "blendername": "Radius", "type": float, "default": 1.6 },
         { "name": "smoothing", "blendername": "Smoothing", "type": float, "default": 0.6 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
-    ],
-    "Style Spheres": [
-        { "name": "as_mesh", "blendername": "Sphere As Mesh", "type": bool, "default": True },
+    ]
+
+    def __init__(self, style: str = "ribbon", quality: int = 3, radius: float = 1.6, smoothing: float = 0.6, color_blur: bool = False, shade_smooth: bool = False):
+        self.style = style
+        self.quality = quality
+        self.radius = radius
+        self.smoothing = smoothing
+        self.color_blur = color_blur
+        self.shade_smooth = shade_smooth
+
+
+class StyleSpheres(StyleBase):
+    portdata: PortDataList = [
+        # Note: The 'geometry' entry here has type bool but default "Point",
+        # matching the original STYLE_DATA. The __init__ uses 'as_mesh'.
+        { "name": "geometry", "blendername": "Sphere Geometry", "type": bool, "default": "Point" },
         { "name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8 },
         { "name": "subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2 },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
-    ],
-    "Style Sticks": [
+    ]
+
+    def __init__(self, style: str = "sphere", as_mesh: bool = True, radii: float = 0.8, subdivisions: int = 2, shade_smooth: bool = False):
+        self.style = style
+        self.as_mesh = as_mesh # This corresponds to a geometry option, but the portdata has a different key "geometry"
+        self.radii = radii
+        self.subdivisions = subdivisions
+        self.shade_smooth = shade_smooth
+
+
+class StyleSticks(StyleBase):
+    portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 2 },
         { "name": "radius", "blendername": "Radius", "type": float, "default": 0.2 },
         { "name": "color_blur", "blendername": "Color Blur", "type": bool, "default": False },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
-    ],
-    "Style Surface": [
+    ]
+
+    def __init__(self, style: str = "sticks", quality: int = 2, radius: float = 0.2, color_blur: bool = False, shade_smooth: bool = False):
+        self.style = style
+        self.quality = quality
+        self.radius = radius
+        self.color_blur = color_blur
+        self.shade_smooth = shade_smooth
+
+
+class StyleSurface(StyleBase):
+    portdata: PortDataList = [
         { "name": "quality", "blendername": "Quality", "type": int, "default": 3 },
         { "name": "separate", "blendername": "Separate", "type": bool, "default": True },
         { "name": "attribute", "blendername": "Attribute", "type": str, "default": "chain_id" },
@@ -53,4 +135,16 @@ STYLE_DATA = {
         { "name": "blur", "blendername": "Blur", "type": int, "default": 2 },
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": True }
     ]
-}
+
+    def __init__(self, style: str = "surface", quality: int = 3, separate: bool = True, attribute: str = "chain_id", scale_radii: float = 1.5, probe_size: float = 1.0, triangulate: bool = False, relaxation_steps: int = 10, by_ca: bool = False, blur: int = 2, shade_smooth: bool = True):
+        self.style = style
+        self.quality = quality
+        self.separate = separate
+        self.attribute = attribute
+        self.scale_radii = scale_radii
+        self.probe_size = probe_size
+        self.triangulate = triangulate
+        self.relaxation_steps = relaxation_steps
+        self.by_ca = by_ca
+        self.blur = blur
+        self.shade_smooth = shade_smooth

--- a/molecularnodes/nodes/styles.py
+++ b/molecularnodes/nodes/styles.py
@@ -50,7 +50,6 @@ class StyleBallandStick(StyleBase):
     ]
 
     # Quality 2
-    # Selection True
     # Sphere Geometry Instance
     # Sphere Radii 0.30000001192092896
     # Bond Split False
@@ -99,6 +98,23 @@ class StyleCartoon(StyleBase):
     ]
     # fmt: on
     style="cartoon"
+
+    # Quality 2
+    # Peptide DSSP False
+    # Peptide Cylinders False
+    # Peptide Arrows True
+    # Peptide Rounded False
+    # Peptide Thickness 0.6000000238418579
+    # Peptide Width 2.200000047683716
+    # Peptide Loop Radius 0.30000001192092896
+    # Peptide Smoothing 0.5
+    # Backbone Shape Cylinder
+    # Backbone Radius 2.0
+    # Base Shape Rectangle
+    # Base Realize False
+    # Color Blur True
+    # Shade Smooth True
+
 
     def __init__(
         self,
@@ -182,22 +198,28 @@ class StyleSpheres(StyleBase):
         # fmt: off
         {"name": "geometry", "blendername": "Sphere Geometry", "type": bool, "default": "Point"},
         {"name": "radii", "blendername": "Sphere Radii", "type": float, "default": 0.8},
-        {"name": "subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2},
+        {"name": "sphere_subdivisions", "blendername": "Sphere Subdivisions", "type": int, "default": 2},
         {"name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False},
         # fmt: on
     ]
     style = "spheres"
 
+
+    # Sphere Geometry Point
+    # Sphere Radii 0.800000011920929
+    # Sphere Subdivisions 2
+    # Shade Smooth True
+
     def __init__(
         self,
-        as_mesh: bool = True,
+        geometry: str = "Point",  # make enum
         radii: float = 0.8,
-        subdivisions: int = 2,
+        sphere_subdivisions: int = 2,
         shade_smooth: bool = False,
     ):
-        self.as_mesh = as_mesh
+        self.geometry = geometry
         self.radii = radii
-        self.subdivisions = subdivisions
+        self.sphere_subdivisions = sphere_subdivisions
         self.shade_smooth = shade_smooth
 
 
@@ -210,6 +232,12 @@ class StyleSticks(StyleBase):
         { "name": "shade_smooth", "blendername": "Shade Smooth", "type": bool, "default": False }
     ]
     style = "sticks"
+
+    # Quality 3
+    # Radius 0.20000000298023224
+    # Color Blur False
+    # Shade Smooth True
+
     # fmt: on
     def __init__(
         self,
@@ -241,6 +269,15 @@ class StyleSurface(StyleBase):
     # fmt: on
     style = "surface"
 
+    # Quality 3
+    # Scale Radii 1.5
+    # Probe Size 1.0
+    # Relaxation Steps 10
+    # Separate By chain_id
+    # Group ID 0
+    # Color Source Alpha Carbon
+    # Color Blur 2
+    # Shade Smooth True
     def __init__(
         self,
         quality: int = 3,

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,4 +1,3 @@
-# import bpy
 import random
 import bpy
 import numpy as np

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -15,16 +15,19 @@ from molecularnodes.nodes.styles import (
 
 DONT_COMPARE = {"Atoms", "Selection", "Material"}
 
-
 def assess_node_equivalency(name, style):
+    """
+    1. Loads Node from MN file vie classic route
+    2. Directly loads class
+    3. Compares the fields and defualts for each
+    """
+
     # get the names and default values of the blender style ndoes
     mol = mn.Molecule.fetch("4ozs").add_style(name)
 
     style_node = get_style_node(mol.object)
-    print(name)
-    for input in style_node.inputs:
-        print(input.name, input.type)
-
+    # for input in style_node.inputs:
+    #     print(input.name, input.type)
     blender_inputs = [
         [input.name, input.default_value]
         for input in style_node.inputs
@@ -35,6 +38,7 @@ def assess_node_equivalency(name, style):
     # get the style class name
     style_class = style()
     style_class_bnames = set(sc.get("blendername") for sc in style_class.portdata)
+
 
     # check names bidirectionally
     for bname in blender_names:
@@ -51,11 +55,8 @@ def assess_node_equivalency(name, style):
             if pdata.get("blendername") == bname:
                 local_name = pdata.get("name")
                 local_val = getattr(style_class, local_name)
-
-                print(f"Local Val of {local_name} is {local_val}")
                 # floats come from C++ and are artificially long
                 if isinstance(bvalue, float):
-                    print(f"Local Val of {local_name} is {local_val}")
                     assert math.isclose(bvalue, local_val, rel_tol=0.1, abs_tol=0.1), (
                         f"( Checking Floats ) In style {name}, field {local_name}: Values {bvalue} and {local_val} are not equivalent"
                     )
@@ -75,7 +76,7 @@ def test_styles():
     assess_node_equivalency("ball+stick", StyleBallandStick)
     assess_node_equivalency("cartoon", StyleCartoon)
     # note backbone radius of ribbon seems to switch between 1.6 and 2.0
-    #assess_node_equivalency("ribbon", StyleRibbon)
+    # assess_node_equivalency("ribbon", StyleRibbon)
     assess_node_equivalency("spheres", StyleSpheres)
     assess_node_equivalency("sticks", StyleSticks)
     assess_node_equivalency("surface", StyleSurface)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -17,17 +17,15 @@ DONT_COMPARE = {"Atoms", "Selection", "Material"}
 
 def assess_node_equivalency(name, style):
     """
-    1. Loads Node from MN file vie classic route
+    1. Loads Node from MN file via classic route
     2. Directly loads class
-    3. Compares the fields and defualts for each
+    3. Compares the fields and defaults for each
     """
 
     # get the names and default values of the blender style ndoes
     mol = mn.Molecule.fetch("4ozs").add_style(name)
 
     style_node = get_style_node(mol.object)
-    # for input in style_node.inputs:
-    #     print(input.name, input.type)
     blender_inputs = [
         [input.name, input.default_value]
         for input in style_node.inputs
@@ -37,8 +35,7 @@ def assess_node_equivalency(name, style):
 
     # get the style class name
     style_class = style()
-    style_class_bnames = set(sc.get("blendername") for sc in style_class.portdata)
-
+    style_class_bnames = set(sc.blendername for sc in style_class.portdata)
 
     # check names bidirectionally
     for bname in blender_names:
@@ -52,8 +49,8 @@ def assess_node_equivalency(name, style):
 
     for [bname, bvalue] in blender_inputs:
         for pdata in style_class.portdata:
-            if pdata.get("blendername") == bname:
-                local_name = pdata.get("name")
+            if pdata.blendername == bname:
+                local_name = pdata.name
                 local_val = getattr(style_class, local_name)
                 # floats come from C++ and are artificially long
                 if isinstance(bvalue, float):

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -27,9 +27,7 @@ def assess_node_equivalency(name, style):
     blender_inputs = [
         [input.name, input.default_value]
         for input in style_node.inputs
-            if input.type != "GEOMETRY" and
-            input.name not in DONT_COMPARE
-
+        if input.type != "GEOMETRY" and input.name not in DONT_COMPARE
     ]
     blender_names = set(name for [name, _] in blender_inputs)
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,0 +1,77 @@
+import bpy
+import numpy as np
+import molecularnodes as mn
+from molecularnodes.nodes.nodes import get_style_node
+from molecularnodes.nodes.styles import (
+    StyleBallandStick,
+    StyleCartoon,
+    StyleRibbon,
+    StyleSpheres,
+    StyleSticks,
+    StyleSurface,
+)
+
+
+DONT_COMPARE = {"Atoms", "Selection", "Material"}
+
+
+def assess_node_equivalency(name, style):
+    # get the names and default values of the blender style ndoes
+    mol = mn.Molecule.fetch("4ozs").add_style(name)
+
+    style_node = get_style_node(mol.object)
+    print(name)
+    for input in style_node.inputs:
+        print(input.name, input.type)
+
+    blender_inputs = [
+        [input.name, input.default_value]
+        for input in style_node.inputs
+            if input.type != "GEOMETRY" and
+            input.name not in DONT_COMPARE
+
+    ]
+    blender_names = set(name for [name, _] in blender_inputs)
+
+    # get the style class name
+    style_class = style()
+    style_class_bnames = set(sc.get("blendername") for sc in style_class.portdata)
+
+    # check names bidirectionally
+    for bname in blender_names:
+        assert bname in style_class_bnames, (
+            f"MN Style {name} has field {bname} that is not found in the styles class"
+        )
+    for sname in style_class_bnames:
+        assert sname in blender_names, (
+            f"Internal Style class for {name} has field {bname} that is not found in the upstream MN Style Node"
+        )
+
+    for [bname, bvalue] in blender_inputs:
+        for pdata in style_class.portdata:
+            if pdata.get("blendername") == bname:
+                local_name = pdata.get("name")
+                local_val = getattr(style_class, local_name)
+
+                # floats come from C++ and are artificaially long
+                if isinstance(bvalue, float):
+                    bvalue = round(bvalue, 2)
+
+                assert local_val == bvalue, (
+                    "Values {bvalue} and {local_val} are not equivalent"
+                )
+
+    # equivalency check.
+    assert style_class_bnames.difference(blender_names) == set()
+    assert blender_names.difference(style_class_bnames) == set()
+
+    bpy.data.objects.remove(mol.object)
+
+
+def test_styles():
+    assess_node_equivalency("ball+stick", StyleBallandStick)
+    assess_node_equivalency("cartoon", StyleCartoon)
+    assess_node_equivalency("ribbon", StyleRibbon)
+    assess_node_equivalency("spheres", StyleSpheres)
+    assess_node_equivalency("sticks", StyleSticks)
+    assess_node_equivalency("surface", StyleSurface)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -15,6 +15,7 @@ from molecularnodes.nodes.styles import (
 
 DONT_COMPARE = {"Atoms", "Selection", "Material"}
 
+
 def assess_node_equivalency(name, style):
     """
     1. Loads Node from MN file via classic route

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,17 +1,14 @@
-import bpy
 import math
-import numpy as np
+import bpy
 import molecularnodes as mn
 from molecularnodes.nodes.nodes import get_style_node
 from molecularnodes.nodes.styles import (
     StyleBallandStick,
     StyleCartoon,
-    StyleRibbon,
     StyleSpheres,
     StyleSticks,
     StyleSurface,
 )
-
 
 DONT_COMPARE = {"Atoms", "Selection", "Material"}
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -33,7 +33,7 @@ def assess_node_equivalency(name, style):
 
     # get the style class name
     style_class = style()
-    style_class_bnames = set(sc.blendername for sc in style_class.portdata)
+    style_class_bnames = set(sc.blendername for sc in style_class.socketdata)
 
     # check names bidirectionally
     for bname in blender_names:
@@ -46,7 +46,7 @@ def assess_node_equivalency(name, style):
         )
 
     for [bname, bvalue] in blender_inputs:
-        for pdata in style_class.portdata:
+        for pdata in style_class.socketdata:
             if pdata.blendername == bname:
                 local_name = pdata.name
                 local_val = getattr(style_class, local_name)


### PR DESCRIPTION
This PR adds support for modifying styles when adding styles to MN. Some initial discussion in #850 

```python
%load_ext autoreload
%autoreload 2


import bpy
import molecularnodes as mn
from molecularnodes.scene.base import Canvas
from molecularnodes.nodes.styles import StyleBallandStick, StyleRibbon, StyleSticks


can = Canvas()
mn.register()
can.scene_reset()

try:
    cube_object = bpy.data.objects.get("Cube")
    bpy.data.objects.remove(cube_object, do_unlink=True)
    print("Default Cube deleted successfully!")
except:
    pass

structure = mn.Molecule.fetch("1EMA", centre="centroid")
# structure.add_style("spheres")
structure.add_style(StyleRibbon())
can.frame_object(structure)
can.snapshot()
```
![image](https://github.com/user-attachments/assets/2b957309-3031-4878-bb40-73618467028d)


```python
# same as above except
structure = mn.Molecule.fetch("1EMA", centre="centroid")
structure.add_style(StyleRibbon(backbone_radius=3, quality=5))
```

![image](https://github.com/user-attachments/assets/1f81edc5-83f2-425c-b785-34349976a4ad)

