### PR TITLE
Update oxDNA attribute creation

### DIFF
--- a/molecularnodes/entities/trajectory/oxdna.py
+++ b/molecularnodes/entities/trajectory/oxdna.py
@@ -1,4 +1,4 @@
-import databpy
+import databpy as db
 import numpy as np
 from MDAnalysis import Universe
 from MDAnalysis.coordinates.base import ReaderBase
@@ -9,8 +9,9 @@ from MDAnalysis.core.topologyattrs import (
     ChainIDs,
     Resids,
     Resnames,
-    # Resnums,
 )
+
+# Resnums,
 from MDAnalysis.lib import util
 from MDAnalysis.topology.base import TopologyReaderBase
 from ... import color
@@ -400,7 +401,7 @@ class OXDNA(Trajectory):
         bpy.types.Object
             The created Blender object
         """
-        self.object = databpy.create_object(
+        self.object = db.create_object(
             name=name,
             collection=coll.mn(),
             vertices=self.univ_positions,
@@ -413,18 +414,20 @@ class OXDNA(Trajectory):
                 att_name = "res_num"
             else:
                 att_name = name
-            self.store_named_attribute(getattr(self, att_name), name)
+            self.store_named_attribute(
+                getattr(self, att_name),
+                name,
+                atype=db.AttributeTypes.INT,
+            )
 
         self.store_named_attribute(
             data=color.color_chains_equidistant(self.chain_id),
             name="Color",
-            atype=databpy.AttributeTypes.FLOAT_COLOR,
+            atype=db.AttributeTypes.FLOAT_COLOR,
         )
 
         if style:
             nodes.create_starting_node_tree(self.object, style="oxdna", color=None)
-
-        return self.object
 
     def set_frame(self, frame: int) -> None:
         super()._update_positions(frame)
@@ -437,7 +440,9 @@ class OXDNA(Trajectory):
         for name in self._att_names:
             try:
                 self.store_named_attribute(
-                    self.universe.trajectory.ts.data[name] * self.world_scale, name=name
+                    data=self.universe.trajectory.ts.data[name] * self.world_scale,
+                    name=name,
+                    atype=db.AttributeTypes.FLOAT_VECTOR,
                 )
             except KeyError as e:
                 print(e)

--- a/tests/__snapshots__/test_dna.ambr
+++ b/tests/__snapshots__/test_dna.ambr
@@ -61,18 +61,18 @@
 # ---
 # name: TestOXDNAReading.test_comparing_topologies[top_new].2
   list([
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
-    5.0,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
   ])
 # ---
 # name: TestOXDNAReading.test_comparing_topologies[top_new].3
@@ -137,18 +137,18 @@
 # ---
 # name: TestOXDNAReading.test_comparing_topologies[top_new_custom].2
   list([
-    8.0,
-    8.0,
-    8.0,
-    8.0,
-    8.0,
-    8.0,
-    9.0,
-    9.0,
-    9.0,
-    9.0,
-    9.0,
-    9.0,
+    8,
+    8,
+    8,
+    8,
+    8,
+    8,
+    9,
+    9,
+    9,
+    9,
+    9,
+    9,
   ])
 # ---
 # name: TestOXDNAReading.test_comparing_topologies[top_new_custom].3
@@ -229,18 +229,18 @@
 # ---
 # name: TestOXDNAReading.test_comparing_topologies[top_old].2
   list([
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    2.0,
-    2.0,
-    2.0,
-    2.0,
-    2.0,
-    2.0,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    2,
+    2,
+    2,
   ])
 # ---
 # name: TestOXDNAReading.test_comparing_topologies[top_old].3


### PR DESCRIPTION
Some integer attributes such as `res_id` and `chain_id` were being added as floats, specifies attributes and ruff formats oxdna.py.
