### PR TITLE
Add setup_ccd to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,10 @@ jobs:
       - uses: actions/checkout@v4
       # - uses: quarto-dev/quarto-actions/setup@v2
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
+          enable-cache: true
         
       - name: Install Packages
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
       
       - name: Render Docs
         run: |
+          uv run python -m biotite.setup_ccd
           uv run quarto render docs
   
       - name: Configure pull release name


### PR DESCRIPTION
Random failling of docs building. Adds `biotite.setup_ccd` and caching for `uv` to the workflow.
