### PR TITLE
Add UI for entities in 3D Viewport

### DIFF
--- a/molecularnodes/blender/utils.py
+++ b/molecularnodes/blender/utils.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import bpy
-from bpy.app.handlers import persistent  # type: ignore
 
 
 def path_resolve(path: str | Path) -> Path:
@@ -25,47 +24,3 @@ def set_object_visibility(object: bpy.types.Object, visible: bool) -> None:
         # Keyframing object visibility can at times lead to:
         # RuntimeError: Object can't be hidden because it is not in View Layer 'ViewLayer'!
         pass
-
-
-def _msgbus_active_object_callback(*args):
-    """Callback when active object changes"""
-    scene = bpy.context.scene
-    object = bpy.context.active_object
-    # object can be None if it active but hidden
-    if object and object.uuid in scene.MNSession.entities:
-        scene.mn.entities_active_index = bpy.data.objects.find(object.name)
-
-
-def _subscribe_to_active_object_changes():
-    """Subscribe to active object changes"""
-    subscribe_to = (bpy.types.LayerObjects, "active")
-    # all our msgbus subscriptions will use MNSession as owner
-    # so that they can easily be unsubscribed during unregister()
-    bpy.msgbus.subscribe_rna(
-        key=subscribe_to,
-        owner=bpy.context.scene.MNSession,
-        args=(),
-        notify=_msgbus_active_object_callback,
-    )
-
-
-@persistent
-def _subscribe_to_msgbus(dummy):
-    """Load handler to re-subscribe to msgbus"""
-    # Add all required msgbus subscriptions go here
-    _subscribe_to_active_object_changes()  # subscribe to active object changes
-
-
-def register_msgbus_subscriptions():
-    """Subscribe to all required msgbus updates"""
-    # This method is called during register()
-    _subscribe_to_msgbus(None)
-    # create a load handler to re-subscribe on file loads
-    bpy.app.handlers.load_post.append(_subscribe_to_msgbus)
-
-
-def unregister_msgbus_subscriptions():
-    """Clear all msgbus subscriptions"""
-    # This method is called during unregister()
-    bpy.msgbus.clear_by_owner(bpy.context.scene.MNSession)
-    bpy.app.handlers.load_post.remove(_subscribe_to_msgbus)

--- a/molecularnodes/blender/utils.py
+++ b/molecularnodes/blender/utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import bpy
+from bpy.app.handlers import persistent  # type: ignore
 
 
 def path_resolve(path: str | Path) -> Path:
@@ -24,3 +25,47 @@ def set_object_visibility(object: bpy.types.Object, visible: bool) -> None:
         # Keyframing object visibility can at times lead to:
         # RuntimeError: Object can't be hidden because it is not in View Layer 'ViewLayer'!
         pass
+
+
+def _msgbus_active_object_callback(*args):
+    """Callback when active object changes"""
+    scene = bpy.context.scene
+    object = bpy.context.active_object
+    # object can be None if it active but hidden
+    if object and object.uuid in scene.MNSession.entities:
+        scene.mn.entities_active_index = bpy.data.objects.find(object.name)
+
+
+def _subscribe_to_active_object_changes():
+    """Subscribe to active object changes"""
+    subscribe_to = (bpy.types.LayerObjects, "active")
+    # all our msgbus subscriptions will use MNSession as owner
+    # so that they can easily be unsubscribed during unregister()
+    bpy.msgbus.subscribe_rna(
+        key=subscribe_to,
+        owner=bpy.context.scene.MNSession,
+        args=(),
+        notify=_msgbus_active_object_callback,
+    )
+
+
+@persistent
+def _subscribe_to_msgbus(dummy):
+    """Load handler to re-subscribe to msgbus"""
+    # Add all required msgbus subscriptions go here
+    _subscribe_to_active_object_changes()  # subscribe to active object changes
+
+
+def register_msgbus_subscriptions():
+    """Subscribe to all required msgbus updates"""
+    # This method is called during register()
+    _subscribe_to_msgbus(None)
+    # create a load handler to re-subscribe on file loads
+    bpy.app.handlers.load_post.append(_subscribe_to_msgbus)
+
+
+def unregister_msgbus_subscriptions():
+    """Clear all msgbus subscriptions"""
+    # This method is called during unregister()
+    bpy.msgbus.clear_by_owner(bpy.context.scene.MNSession)
+    bpy.app.handlers.load_post.remove(_subscribe_to_msgbus)

--- a/molecularnodes/blender/utils.py
+++ b/molecularnodes/blender/utils.py
@@ -9,3 +9,18 @@ def path_resolve(path: str | Path) -> Path:
         return Path(bpy.path.abspath(str(path)))
     else:
         raise ValueError(f"Unable to resolve path: {path}")
+
+
+def set_object_visibility(object: bpy.types.Object, visible: bool) -> None:
+    """Set visibility of Blender object"""
+    if object.name not in bpy.context.view_layer.objects:
+        return
+    try:
+        object.hide_set(not visible)
+        # obj.hide_viewport = hide
+        # icon incorrect, but causes blender bug for volumes with above
+        object.hide_render = not visible
+    except RuntimeError:
+        # Keyframing object visibility can at times lead to:
+        # RuntimeError: Object can't be hidden because it is not in View Layer 'ViewLayer'!
+        pass

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -9,7 +9,6 @@ from bpy.types import Context  # type: ignore
 from databpy.object import LinkedObjectError, get_from_uuid
 from MDAnalysis.core.groups import AtomGroup
 from .entities import Molecule
-from .entities.base import EntityType
 from .entities.ensemble.base import Ensemble
 from .entities.trajectory.base import Trajectory
 from .nodes.nodes import styles_mapping
@@ -80,33 +79,10 @@ class MNSession:
     def register_entity(self, item: Union[Molecule, Trajectory, Ensemble]) -> None:
         """Add entity to the dictionary"""
         self.entities[item.uuid] = item
-        # add entity to blender properties if it doesn't exist
-        props = bpy.context.scene.mn
-        entities = props.entities  # entities collection
-        if entities.find(item.uuid) == -1:
-            entity = entities.add()  # add new entity to collection
-            entity.name = item.uuid  # immutable name that allows find to get index
-            # EntityType is not available here in most cases as it is set after __init__
-            # In other cases, it is reset later like in case of MD_OXDNA
-            # So, use a simple check based on supported entity types here
-            if isinstance(item, Molecule):
-                entity.type = EntityType.MOLECULE.value
-            elif isinstance(item, Trajectory):
-                entity.type = EntityType.MD.value
-            elif isinstance(item, Ensemble):
-                entity.type = EntityType.ENSEMBLE.value
-            props.entities_active_index = len(entities) - 1
 
     def remove_entity(self, uuid: str) -> None:
         """Remove entity from the dictionary"""
         del self.entities[uuid]
-        # remove entity from blender properties
-        props = bpy.context.scene.mn
-        entities = props.entities
-        index = entities.find(uuid)
-        if index != -1:
-            entities.remove(index)  # remove entity from collection
-            props.entities_active_index = len(entities) - 1
 
     def match(self, obj: bpy.types.Object) -> Union[Molecule, Trajectory, Ensemble]:
         return self.get(obj.uuid)

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -135,12 +135,12 @@ class MNSession:
         # remove any properties that don't exist in session
         props = bpy.context.scene.mn
         entities = props.entities
-        pruned = False
-        for i, entity in enumerate(entities):
-            if entity.name not in self.entities:
-                entities.remove(i)  # remove entity from collection
-                pruned = True
-        if pruned:
+        remove_indices = [
+            i for i, entity in enumerate(entities) if entity.name not in self.entities
+        ]
+        if remove_indices:
+            for i in remove_indices:
+                entities.remove(i)
             props.entities_active_index = len(entities) - 1
 
     @property

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -9,6 +9,7 @@ from bpy.types import Context  # type: ignore
 from databpy.object import LinkedObjectError, get_from_uuid
 from MDAnalysis.core.groups import AtomGroup
 from .entities import Molecule
+from .entities.base import EntityType
 from .entities.ensemble.base import Ensemble
 from .entities.trajectory.base import Trajectory
 from .nodes.nodes import styles_mapping
@@ -79,10 +80,33 @@ class MNSession:
     def register_entity(self, item: Union[Molecule, Trajectory, Ensemble]) -> None:
         """Add entity to the dictionary"""
         self.entities[item.uuid] = item
+        # add entity to blender properties if it doesn't exist
+        props = bpy.context.scene.mn
+        entities = props.entities  # entities collection
+        if entities.find(item.uuid) == -1:
+            entity = entities.add()  # add new entity to collection
+            entity.name = item.uuid  # immutable name that allows find to get index
+            # EntityType is not available here in most cases as it is set after __init__
+            # In other cases, it is reset later like in case of MD_OXDNA
+            # So, use a simple check based on supported entity types here
+            if isinstance(item, Molecule):
+                entity.type = EntityType.MOLECULE.value
+            elif isinstance(item, Trajectory):
+                entity.type = EntityType.MD.value
+            elif isinstance(item, Ensemble):
+                entity.type = EntityType.ENSEMBLE.value
+            props.entities_active_index = len(entities) - 1
 
     def remove_entity(self, uuid: str) -> None:
         """Remove entity from the dictionary"""
         del self.entities[uuid]
+        # remove entity from blender properties
+        props = bpy.context.scene.mn
+        entities = props.entities
+        index = entities.find(uuid)
+        if index != -1:
+            entities.remove(index)  # remove entity from collection
+            props.entities_active_index = len(entities) - 1
 
     def match(self, obj: bpy.types.Object) -> Union[Molecule, Trajectory, Ensemble]:
         return self.get(obj.uuid)

--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -12,13 +12,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
-from bpy.app.handlers import frame_change_pre, load_post, save_post  # type: ignore
-from bpy.props import CollectionProperty, PointerProperty  # type: ignore
+from bpy.app.handlers import frame_change_pre, load_post, save_post
+from bpy.props import CollectionProperty, PointerProperty
 from .. import session
-from ..blender.utils import (
-    register_msgbus_subscriptions,
-    unregister_msgbus_subscriptions,
-)
 from ..handlers import update_entities
 from ..utils import add_current_module_to_path
 from . import node_menu, ops, panel, pref, props
@@ -66,7 +62,6 @@ def register():
     bpy.types.Object.mn_trajectory_selections = CollectionProperty(  # type: ignore
         type=props.TrajectorySelectionItem  # type: ignore
     )
-    register_msgbus_subscriptions()
 
 
 def unregister():
@@ -84,7 +79,6 @@ def unregister():
     save_post.remove(session._pickle)
     load_post.remove(session._load)
     frame_change_pre.remove(update_entities)
-    unregister_msgbus_subscriptions()
     del bpy.types.Scene.MNSession  # type: ignore
     del bpy.types.Scene.mn  # type: ignore
     del bpy.types.Object.mn  # type: ignore

--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -12,9 +12,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
-from bpy.app.handlers import frame_change_pre, load_post, save_post
-from bpy.props import CollectionProperty, PointerProperty
+from bpy.app.handlers import frame_change_pre, load_post, save_post  # type: ignore
+from bpy.props import CollectionProperty, PointerProperty  # type: ignore
 from .. import session
+from ..blender.utils import (
+    register_msgbus_subscriptions,
+    unregister_msgbus_subscriptions,
+)
 from ..handlers import update_entities
 from ..utils import add_current_module_to_path
 from . import node_menu, ops, panel, pref, props
@@ -62,6 +66,7 @@ def register():
     bpy.types.Object.mn_trajectory_selections = CollectionProperty(  # type: ignore
         type=props.TrajectorySelectionItem  # type: ignore
     )
+    register_msgbus_subscriptions()
 
 
 def unregister():
@@ -79,6 +84,7 @@ def unregister():
     save_post.remove(session._pickle)
     load_post.remove(session._load)
     frame_change_pre.remove(update_entities)
+    unregister_msgbus_subscriptions()
     del bpy.types.Scene.MNSession  # type: ignore
     del bpy.types.Scene.mn  # type: ignore
     del bpy.types.Object.mn  # type: ignore

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -564,17 +564,10 @@ class MN_UL_EntitiesList(bpy.types.UIList):
         custom_icon = "WORLD"
         if self.layout_type in {"DEFAULT", "COMPACT"}:
             row = layout.row()
-            name = str(index + 1) + ". "
-            split = row.split(factor=0.1)
-            col = split.column()
-            col.label(text=name)
-            col = split.column()
-            session = context.scene.MNSession
-            entity = session.get(item.name)
-            col.prop(entity.object, "name", text="", emboss=False)
-            hide_icon = "HIDE_OFF" if item.visible else "HIDE_ON"
+            row.prop(item, "name", text="", emboss=False)
+            hide_icon = "HIDE_OFF" if item.mn.visible else "HIDE_ON"
             row.prop(
-                item,
+                item.mn,
                 "visible",
                 icon_only=True,
                 icon=hide_icon,
@@ -582,6 +575,21 @@ class MN_UL_EntitiesList(bpy.types.UIList):
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
             layout.label(text="", icon=custom_icon)
+
+    def filter_items(self, context, data, propname):
+        objects = getattr(data, propname)
+        helper_funcs = bpy.types.UI_UL_list
+        filtered = []
+        ordered = []
+        # filter only objects registered in MNSession
+        filtered = [self.bitflag_filter_item] * len(objects)
+        session = context.scene.MNSession
+        for i, object in enumerate(objects):
+            if object.uuid not in session.entities:
+                filtered[i] &= ~self.bitflag_filter_item
+        # order the list by name
+        ordered = helper_funcs.sort_items_by_name(objects, "name")
+        return filtered, ordered
 
 
 class MN_PT_Entities(bpy.types.Panel):
@@ -602,8 +610,8 @@ class MN_PT_Entities(bpy.types.Panel):
         row.template_list(
             "MN_UL_EntitiesList",
             "entities_list",
-            props,
-            "entities",
+            bpy.data,
+            "objects",
             props,
             "entities_active_index",
             rows=3,
@@ -616,10 +624,13 @@ class MN_PT_Entities(bpy.types.Panel):
         remove_op = remove_row.operator(
             "mn.session_remove_item", icon="REMOVE", text=""
         )
-        if props.entities_active_index == -1:
-            remove_row.enabled = False
-        else:
-            remove_op.uuid = props.entities[props.entities_active_index].name
+        remove_row.enabled = False
+        index = props.entities_active_index
+        if 0 <= index < len(bpy.data.objects):
+            object = bpy.data.objects[index]
+            if object.uuid in context.scene.MNSession.entities:
+                remove_row.enabled = True
+                remove_op.uuid = object.uuid
 
 
 class MN_PT_trajectory(bpy.types.Panel):
@@ -636,23 +647,22 @@ class MN_PT_trajectory(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         """Visible only if entity selected is a trajectory"""
-        scene = context.scene
-        active_index = scene.mn.entities_active_index
-        if active_index == -1:
-            return False
-        uuid = scene.mn.entities[active_index].name
-        return scene.MNSession.get(uuid).object.mn.entity_type == EntityType.MD.value
+        index = context.scene.mn.entities_active_index
+        if 0 <= index < len(bpy.data.objects):
+            object = bpy.data.objects[index]
+            if (
+                object.uuid in context.scene.MNSession.entities
+                and object.mn.entity_type == EntityType.MD.value
+            ):
+                return True
+        return False
 
     def draw(self, context):
         layout = self.layout
         # To enable the animatate dot next to property in UI
         # layout.use_property_split = True
         # layout.use_property_decorate = True
-        scene = context.scene
-        active_index = scene.mn.entities_active_index
-        uuid = scene.mn.entities[active_index].name
-        # Use the object corresponding to the entity
-        object = scene.MNSession.get(uuid).object
+        object = bpy.data.objects[context.scene.mn.entities_active_index]
         props = object.mn
         row = layout.row()
         label = "This trajectory has " + str(props.n_frames) + " frames"

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -1,5 +1,6 @@
 import bpy
 from ..entities import trajectory
+from ..entities.base import EntityType
 from ..nodes import nodes
 from ..session import get_session
 from .pref import addon_preferences
@@ -543,4 +544,130 @@ class MN_PT_Scene(bpy.types.Panel):
         which_panel[scene.mn.panel_selection](layout, context)
 
 
-CLASSES = [MN_PT_Scene]
+class MN_UL_EntitiesList(bpy.types.UIList):
+    """
+    UIList of entities in Entities panel (Viewport)
+    """
+
+    def draw_item(
+        self,
+        context,
+        layout,
+        data,
+        item,
+        icon,
+        active_data,
+        active_property,
+        index=0,
+        flt_flag=0,
+    ):
+        custom_icon = "WORLD"
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            row = layout.row()
+            name = str(index + 1) + ". "
+            split = row.split(factor=0.1)
+            col = split.column()
+            col.label(text=name)
+            col = split.column()
+            session = context.scene.MNSession
+            entity = session.get(item.name)
+            col.prop(entity.object, "name", text="", emboss=False)
+            hide_icon = "HIDE_OFF" if item.visible else "HIDE_ON"
+            row.prop(
+                item,
+                "visible",
+                icon_only=True,
+                icon=hide_icon,
+            )
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            layout.label(text="", icon=custom_icon)
+
+
+class MN_PT_Entities(bpy.types.Panel):
+    """
+    Panel to list MN Entities in Viewport
+    """
+
+    bl_idname = "MN_PT_Entities"
+    bl_label = "Entities"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Molecular Nodes"
+
+    def draw(self, context):
+        layout = self.layout
+        props = context.scene.mn
+        row = layout.row()
+        row.template_list(
+            "MN_UL_EntitiesList",
+            "entities_list",
+            props,
+            "entities",
+            props,
+            "entities_active_index",
+            rows=3,
+        )
+        col = row.column()
+        add_row = col.row()
+        add_row.operator("mn.session_create_object", icon="ADD", text="")
+        add_row.enabled = False  # TODO: create object or create entity or remove?
+        remove_row = col.row()
+        remove_op = remove_row.operator(
+            "mn.session_remove_item", icon="REMOVE", text=""
+        )
+        if props.entities_active_index == -1:
+            remove_row.enabled = False
+        else:
+            remove_op.uuid = props.entities[props.entities_active_index].name
+
+
+class MN_PT_trajectory(bpy.types.Panel):
+    """
+    Panel for trajectory details
+    """
+
+    bl_idname = "MN_PT_trajectory"
+    bl_label = "Trajectory"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Molecular Nodes"
+
+    @classmethod
+    def poll(cls, context):
+        """Visible only if entity selected is a trajectory"""
+        scene = context.scene
+        active_index = scene.mn.entities_active_index
+        if active_index == -1:
+            return False
+        uuid = scene.mn.entities[active_index].name
+        return scene.MNSession.get(uuid).object.mn.entity_type == EntityType.MD.value
+
+    def draw(self, context):
+        layout = self.layout
+        # To enable the animatate dot next to property in UI
+        # layout.use_property_split = True
+        # layout.use_property_decorate = True
+        scene = context.scene
+        active_index = scene.mn.entities_active_index
+        uuid = scene.mn.entities[active_index].name
+        # Use the object corresponding to the entity
+        object = scene.MNSession.get(uuid).object
+        props = object.mn
+        row = layout.row()
+        label = "This trajectory has " + str(props.n_frames) + " frames"
+        row.label(text=label)
+        row = layout.row()
+        row.prop(props, "update_with_scene")
+        box = layout.box()
+        row = box.row()
+        row.prop(props, "frame")
+        box.enabled = not props.update_with_scene
+
+
+CLASSES = [
+    MN_PT_Scene,
+    MN_UL_EntitiesList,
+    MN_PT_Entities,
+    MN_PT_trajectory,
+]

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.props import (  # type: ignore
     BoolProperty,
+    CollectionProperty,
     EnumProperty,
     IntProperty,
     StringProperty,
@@ -37,32 +38,26 @@ def _get_entity_visibility(self) -> bool:
 def _set_entity_visibility(self, visible: bool) -> None:
     """set callback for entity visibility property"""
     self["visible"] = visible
-    object = self.id_data
+    object = bpy.context.scene.MNSession.get(self.name).object
     set_object_visibility(object, self.visible)
 
 
-def _entities_active_index_callback(self, context: bpy.context) -> None:
-    """update callback for entities active_index change"""
-    index = self.entities_active_index
-    if not (0 <= index < len(bpy.data.objects)):
-        return
-    active_object = context.active_object
-    entity_object = bpy.data.objects[index]
-    if active_object != entity_object:
-        # just setting view_layer.objects.active is not enough
-        bpy.ops.object.select_all(action="DESELECT")  # deselect all objects
-        context.view_layer.objects.active = entity_object  # make active object
-        bpy.context.view_layer.update()  # update view layer to reflect changes
-        if bpy.context.active_object:
-            bpy.context.active_object.select_set(True)  # set as selected object
+class EntityProperties(bpy.types.PropertyGroup):
+    # name property is implicit and is set to uuid for find lookups
+    # type value is one of EntityType enum
+    type: StringProperty(name="Entity Type", default="")  # type: ignore
+    visible: BoolProperty(
+        name="visible",
+        description="Visibility of the entity",
+        default=True,
+        get=_get_entity_visibility,
+        set=_set_entity_visibility,
+    )  # type: ignore
 
 
 class MolecularNodesSceneProperties(PropertyGroup):
-    entities_active_index: IntProperty(
-        name="Active entity index",
-        default=-1,
-        update=_entities_active_index_callback,
-    )  # type: ignore
+    entities: CollectionProperty(name="Entities", type=EntityProperties)  # type: ignore
+    entities_active_index: IntProperty(default=-1)  # type: ignore
 
     import_del_hydrogen: BoolProperty(  # type: ignore
         name="Remove Hydrogens",
@@ -274,14 +269,6 @@ class MolecularNodesSceneProperties(PropertyGroup):
 
 
 class MolecularNodesObjectProperties(PropertyGroup):
-    visible: BoolProperty(
-        name="visible",
-        description="Visibility of the molecular entity",
-        default=True,
-        get=_get_entity_visibility,
-        set=_set_entity_visibility,
-    )  # type: ignore
-
     biological_assemblies: StringProperty(  # type: ignore
         name="Biological Assemblies",
         description="A list of biological assemblies to be created",
@@ -521,6 +508,7 @@ class MN_OT_Universe_Selection_Delete(bpy.types.Operator):
 
 
 CLASSES = [
+    EntityProperties,
     MolecularNodesObjectProperties,
     MolecularNodesSceneProperties,
     TrajectorySelectionItem,  # item has to be registered the ListUI and to work properly

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -72,23 +72,11 @@ def test_get_trajectory(session, universe):
     assert t1 == t2
 
 
-def test_entity_blender_properties(session, universe):
-    props = bpy.context.scene.mn
-    assert len(props.entities) == 0
-    t1 = session.add_trajectory(universe, name="u1")
-    # test property addition
-    assert len(props.entities) == 1
-    entity = props.entities[0]
-    # test property indexing
-    assert entity.name == t1.uuid
-    # verify entity type
-    assert entity.type == "md"
-    # test visibility changes
+def test_entity_visibility(session, universe):
+    session.add_trajectory(universe, name="u1")
     # check initial visibility
-    assert entity.visible
+    props = bpy.data.objects["u1"].mn
+    assert props.visible
     assert bpy.data.objects["u1"].visible_get()
-    entity.visible = False
+    props.visible = False
     assert not bpy.data.objects["u1"].visible_get()
-    # test property removal
-    session.remove_trajectory("u1")
-    assert len(props.entities) == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -72,11 +72,23 @@ def test_get_trajectory(session, universe):
     assert t1 == t2
 
 
-def test_entity_visibility(session, universe):
-    session.add_trajectory(universe, name="u1")
+def test_entity_blender_properties(session, universe):
+    props = bpy.context.scene.mn
+    assert len(props.entities) == 0
+    t1 = session.add_trajectory(universe, name="u1")
+    # test property addition
+    assert len(props.entities) == 1
+    entity = props.entities[0]
+    # test property indexing
+    assert entity.name == t1.uuid
+    # verify entity type
+    assert entity.type == "md"
+    # test visibility changes
     # check initial visibility
-    props = bpy.data.objects["u1"].mn
-    assert props.visible
+    assert entity.visible
     assert bpy.data.objects["u1"].visible_get()
-    props.visible = False
+    entity.visible = False
     assert not bpy.data.objects["u1"].visible_get()
+    # test property removal
+    session.remove_trajectory("u1")
+    assert len(props.entities) == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -70,3 +70,25 @@ def test_get_trajectory(session, universe):
     t1 = session.add_trajectory(universe, name="u1")
     t2 = session.get_trajectory("u1")
     assert t1 == t2
+
+
+def test_entity_blender_properties(session, universe):
+    props = bpy.context.scene.mn
+    assert len(props.entities) == 0
+    t1 = session.add_trajectory(universe, name="u1")
+    # test property addition
+    assert len(props.entities) == 1
+    entity = props.entities[0]
+    # test property indexing
+    assert entity.name == t1.uuid
+    # verify entity type
+    assert entity.type == "md"
+    # test visibility changes
+    # check initial visibility
+    assert entity.visible
+    assert bpy.data.objects["u1"].visible_get()
+    entity.visible = False
+    assert not bpy.data.objects["u1"].visible_get()
+    # test property removal
+    session.remove_trajectory("u1")
+    assert len(props.entities) == 0


### PR DESCRIPTION
* Add blender properties corresponding to entities that hold `uuid` and entity type
* Link creation/deletion of session entities to corresponding blender properties
* Add panels for entities listing and trajectory details
* Add tests for all new functionality
