### PR TITLE
Pre-fetch structural data before download

### DIFF
--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -36,9 +36,16 @@ def panel_wwpdb(layout, scene):
 
     layout.separator()
     if scene.mn.import_display_info != "":
-        info = PDBStructureInfo.from_json(scene.mn.import_display_info)
-        info.as_layout(layout)
-        layout.separator()
+        if scene.mn.import_display_info.startswith("ERROR:"):
+            layout.label(
+                text=scene.mn.import_display_info,
+                icon="ERROR",
+            )
+            row.enabled = False
+        else:
+            info = PDBStructureInfo.from_json(scene.mn.import_display_info)
+            info.as_layout(layout)
+            layout.separator()
 
     layout.label(text="Options", icon="MODIFIER")
     options = layout.column(align=True)

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -3,8 +3,8 @@ from ..entities import trajectory
 from ..nodes import nodes
 from ..session import get_session
 from .pref import addon_preferences
-from .utils import check_online_access_for_ui
 from .query import PDBStructureInfo
+from .utils import check_online_access_for_ui
 
 
 def panel_wwpdb(layout, scene):

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -4,6 +4,7 @@ from ..nodes import nodes
 from ..session import get_session
 from .pref import addon_preferences
 from .utils import check_online_access_for_ui
+from .query import PDBStructureInfo
 
 
 def panel_wwpdb(layout, scene):
@@ -34,6 +35,15 @@ def panel_wwpdb(layout, scene):
     layout.separator(factor=0.4)
 
     layout.separator()
+    if scene.mn.import_display_info != "":
+        info = PDBStructureInfo.from_json(scene.mn.import_display_info)
+        layout.label(text=f"PDB: {info.entry_id.upper()}", icon="FILE_TEXT")
+        layout.label(text=f"Title: {info.title}")
+        if info.resolution:
+            layout.label(text=f"Resolution: {info.resolution} Å")
+        if info.experimental_method:
+            layout.label(text=f"Experimental Method: {info.experimental_method}")
+        layout.separator()
 
     layout.label(text="Options", icon="MODIFIER")
     options = layout.column(align=True)

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -37,12 +37,7 @@ def panel_wwpdb(layout, scene):
     layout.separator()
     if scene.mn.import_display_info != "":
         info = PDBStructureInfo.from_json(scene.mn.import_display_info)
-        layout.label(text=f"PDB: {info.entry_id.upper()}", icon="FILE_TEXT")
-        layout.label(text=f"Title: {info.title}")
-        if info.resolution:
-            layout.label(text=f"Resolution: {info.resolution} Å")
-        if info.experimental_method:
-            layout.label(text=f"Experimental Method: {info.experimental_method}")
+        info.as_layout(layout)
         layout.separator()
 
     layout.label(text="Options", icon="MODIFIER")

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -68,14 +68,12 @@ class MolecularNodesSceneProperties(PropertyGroup):
     import_code_pdb: StringProperty(  # type: ignore
         name="PDB",
         description="The PDB code to download and import",
-        options={"TEXTEDIT_UPDATE"},
+        # options={"TEXTEDIT_UPDATE"},
         maxlen=4,
         update=_update_structure_display_info,
     )
 
-    import_display_info: StringProperty(  # type: ignore
-        name="Display Info", options={"TEXTEDIT_UPDATE"}
-    )
+    import_display_info: StringProperty()  # type: ignore
 
     is_updating: BoolProperty(  # type: ignore
         name="Updating",

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -3,7 +3,7 @@ from bpy.props import BoolProperty, EnumProperty, IntProperty, StringProperty
 from bpy.types import PropertyGroup
 from ..handlers import _update_entities
 from ..session import get_session
-from .query import PDBQueryError, query_pdb_structure
+from .query import _update_structure_display_info
 from .style import STYLE_ITEMS
 
 uuid_property = StringProperty(  # type: ignore
@@ -11,15 +11,6 @@ uuid_property = StringProperty(  # type: ignore
     description="Unique ID for referencing the required objects in the MNSession",
     default="",
 )
-
-
-def _update_structure_display_info(self, context):
-    code = context.scene.mn.import_code_pdb
-    try:
-        info = query_pdb_structure(code)
-        context.scene.mn.import_display_info = info.to_json()
-    except (PDBQueryError, ValueError):
-        context.scene.mn.import_display_info = ""
 
 
 def _get_frame(self):

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -3,6 +3,7 @@ from bpy.props import BoolProperty, EnumProperty, IntProperty, StringProperty
 from bpy.types import PropertyGroup
 from ..handlers import _update_entities
 from ..session import get_session
+from .query import PDBQueryError, query_pdb_structure
 from .style import STYLE_ITEMS
 
 uuid_property = StringProperty(  # type: ignore
@@ -10,6 +11,15 @@ uuid_property = StringProperty(  # type: ignore
     description="Unique ID for referencing the required objects in the MNSession",
     default="",
 )
+
+
+def _update_structure_display_info(self, context):
+    code = context.scene.mn.import_code_pdb
+    try:
+        info = query_pdb_structure(code)
+        context.scene.mn.import_display_info = info.to_json()
+    except (PDBQueryError, ValueError):
+        context.scene.mn.import_display_info = ""
 
 
 def _get_frame(self):
@@ -69,6 +79,11 @@ class MolecularNodesSceneProperties(PropertyGroup):
         description="The PDB code to download and import",
         options={"TEXTEDIT_UPDATE"},
         maxlen=4,
+        update=_update_structure_display_info,
+    )
+
+    import_display_info: StringProperty(  # type: ignore
+        name="Display Info", options={"TEXTEDIT_UPDATE"}
     )
 
     is_updating: BoolProperty(  # type: ignore

--- a/molecularnodes/ui/query.py
+++ b/molecularnodes/ui/query.py
@@ -1,0 +1,270 @@
+import json
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+import bpy
+import requests
+
+
+@dataclass
+class PDBStructureInfo:
+    """Dataclass containing useful information about a PDB structure"""
+
+    entry_id: str
+    title: Optional[str] = None
+    experimental_method: Optional[str] = None
+    resolution: Optional[float] = None
+    deposition_date: Optional[str] = None
+    release_date: Optional[str] = None
+    authors: Optional[List[str]] = None
+    organism_names: Optional[List[str]] = None
+    structure_classification: Optional[str] = None
+    molecular_weight: Optional[float] = None
+    polymer_entity_count: Optional[int] = None
+    chain_count: Optional[int] = None
+    residue_count: Optional[int] = None
+    atom_count: Optional[int] = None
+    space_group: Optional[str] = None
+    unit_cell: Optional[Dict[str, float]] = None
+    r_work: Optional[float] = None
+    r_free: Optional[float] = None
+    doi: Optional[str] = None
+    pubmed_id: Optional[str] = None
+    deposited_modeled_polymer_monomer_count: Optional[int] = None
+
+    def __str__(self) -> str:
+        """String representation of the structure info"""
+        lines = [f"PDB Entry: {self.entry_id}"]
+        if self.title:
+            lines.append(f"Title: {self.title}")
+        if self.experimental_method:
+            lines.append(f"Method: {self.experimental_method}")
+        if self.resolution:
+            lines.append(f"Resolution: {self.resolution} Å")
+        if self.organism_names:
+            lines.append(f"Organisms: {', '.join(self.organism_names)}")
+        return "\n".join(lines)
+
+    def as_layout(self, layout: bpy.types.UILayout):
+        layout = layout.column(align=True)
+        layout.label(text=f"PDB: {self.entry_id.upper()}", icon="FILE_TEXT")
+        layout.label(text=self.title)
+        if self.resolution:
+            layout.label(text=f"Resolution: {self.resolution} Å")
+        if self.experimental_method:
+            layout.label(text=f"Method: {self.experimental_method}")
+
+    def to_json(self) -> str:
+        """Convert the structure info to a JSON string"""
+        return json.dumps(self.__dict__)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "PDBStructureInfo":
+        """Create a PDBStructureInfo instance from a JSON string"""
+        data = json.loads(json_str)
+        return cls(**data)
+
+
+class PDBQueryError(Exception):
+    """Custom exception for PDB query errors"""
+
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(self.message)
+
+
+def query_pdb_structure(entry_id: str, timeout: int = 30) -> PDBStructureInfo:
+    """
+    Query the RCSB PDB database for basic structure information.
+
+    Args:
+        entry_id: The PDB entry ID (e.g., '4HHB', '1ABC')
+        timeout: Request timeout in seconds (default: 30)
+
+    Returns:
+        PDBStructureInfo: Dataclass containing structure information
+
+    Raises:
+        PDBQueryError: If the query fails or structure doesn't exist
+        ValueError: If entry_id is invalid format
+    """
+    # Validate entry_id format
+    if not entry_id or not isinstance(entry_id, str):
+        raise ValueError("entry_id must be a non-empty string")
+
+    entry_id = entry_id.upper().strip()
+    if len(entry_id) != 4:
+        raise ValueError("entry_id must be exactly 4 characters long")
+
+    # Construct the API URL
+    url = f"https://data.rcsb.org/rest/v1/core/entry/{entry_id}"
+
+    try:
+        # Make the API request
+        response = requests.get(url, timeout=timeout)
+
+        # Handle HTTP errors
+        if response.status_code == 404:
+            raise PDBQueryError(f"PDB entry '{entry_id}' not found", 404)
+        elif response.status_code != 200:
+            raise PDBQueryError(
+                f"API request failed with status {response.status_code}: {response.text}",
+                response.status_code,
+            )
+
+        # Parse JSON response
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            raise PDBQueryError(f"Failed to parse JSON response: {e}")
+
+        # Extract information from the response
+        structure_info = PDBStructureInfo(entry_id=entry_id)
+
+        # Basic structure information
+        if "struct" in data:
+            structure_info.title = data["struct"].get("title")
+
+        # Experimental method
+        if "exptl" in data and data["exptl"]:
+            methods = [exp.get("method") for exp in data["exptl"] if exp.get("method")]
+            structure_info.experimental_method = ", ".join(methods) if methods else None
+
+        # Resolution
+        if "rcsb_entry_info" in data:
+            entry_info = data["rcsb_entry_info"]
+            structure_info.resolution = entry_info.get("resolution_combined", [None])[0]
+            structure_info.polymer_entity_count = (
+                entry_info.get("polymer_entity_count_protein", 0)
+                + entry_info.get("polymer_entity_count_DNA", 0)
+                + entry_info.get("polymer_entity_count_RNA", 0)
+            )
+            structure_info.molecular_weight = entry_info.get("molecular_weight")
+            structure_info.deposited_modeled_polymer_monomer_count = entry_info.get(
+                "deposited_modeled_polymer_monomer_count"
+            )
+
+        # Dates
+        if "pdbx_database_status" in data:
+            db_status = data["pdbx_database_status"]
+            structure_info.deposition_date = db_status.get(
+                "recvd_initial_deposition_date"
+            )
+            structure_info.release_date = db_status.get("status_code_mr")
+
+        # Authors
+        if "audit_author" in data:
+            authors = [
+                author.get("name")
+                for author in data["audit_author"]
+                if author.get("name")
+            ]
+            structure_info.authors = authors if authors else None
+
+        # Organism information
+        if "rcsb_entity_source_organism" in data:
+            organisms = []
+            for org_data in data["rcsb_entity_source_organism"]:
+                if "ncbi_scientific_name" in org_data:
+                    organisms.append(org_data["ncbi_scientific_name"])
+            structure_info.organism_names = organisms if organisms else None
+
+        # Structure classification
+        if "struct_keywords" in data:
+            structure_info.structure_classification = data["struct_keywords"].get(
+                "pdbx_keywords"
+            )
+
+        # Crystallographic information
+        if "cell" in data:
+            cell_data = data["cell"]
+            structure_info.unit_cell = {
+                "a": cell_data.get("length_a"),
+                "b": cell_data.get("length_b"),
+                "c": cell_data.get("length_c"),
+                "alpha": cell_data.get("angle_alpha"),
+                "beta": cell_data.get("angle_beta"),
+                "gamma": cell_data.get("angle_gamma"),
+            }
+
+        if "symmetry" in data:
+            structure_info.space_group = data["symmetry"].get("space_group_name_H-M")
+
+        # Refinement statistics
+        if "refine" in data and data["refine"]:
+            refine_data = data["refine"][0]  # Usually one refinement entry
+            structure_info.r_work = refine_data.get("ls_R_factor_R_work")
+            structure_info.r_free = refine_data.get("ls_R_factor_R_free")
+
+        # Citation information
+        if "citation" in data:
+            for citation in data["citation"]:
+                if citation.get("id") == "primary":
+                    structure_info.doi = citation.get("pdbx_database_id_DOI")
+                    structure_info.pubmed_id = citation.get("pdbx_database_id_PubMed")
+                    break
+
+        # Additional counts
+        if "rcsb_entry_info" in data:
+            entry_info = data["rcsb_entry_info"]
+            structure_info.chain_count = entry_info.get(
+                "deposited_polymer_entity_instance_count"
+            )
+            structure_info.residue_count = entry_info.get(
+                "deposited_modeled_polymer_monomer_count"
+            )
+            structure_info.atom_count = entry_info.get("deposited_atom_count")
+
+        return structure_info
+
+    except requests.exceptions.Timeout:
+        raise PDBQueryError(f"Request timed out after {timeout} seconds")
+    except requests.exceptions.ConnectionError:
+        raise PDBQueryError("Failed to connect to RCSB PDB API")
+    except requests.exceptions.RequestException as e:
+        raise PDBQueryError(f"Request failed: {e}")
+
+
+# Simple debouncing with timers
+_pending_queries = {}
+
+
+def _delayed_pdb_query():
+    """Timer function that executes after a delay"""
+    if not _pending_queries:
+        return None  # Stop timer
+
+    # Get the most recent query
+    code = list(_pending_queries.keys())[-1]
+    context = _pending_queries[code]
+
+    # Clear all pending queries
+    _pending_queries.clear()
+
+    # Perform the query
+    try:
+        info = query_pdb_structure(code)
+        context.scene.mn.import_display_info = info.to_json()
+    except (PDBQueryError, ValueError):
+        context.scene.mn.import_display_info = ""
+
+    return None  # Stop timer
+
+
+def _update_structure_display_info(self, context):
+    """Debounced update function"""
+    code = context.scene.mn.import_code_pdb
+
+    # Clear display info immediately
+    context.scene.mn.import_display_info = ""
+
+    # Skip if code is empty or too short
+    if not code or len(code.strip()) < 4:
+        return
+
+    # Store the query request
+    _pending_queries[code] = context
+
+    # Register timer with delay (debounce rapid typing)
+    if not bpy.app.timers.is_registered(_delayed_pdb_query):
+        bpy.app.timers.register(_delayed_pdb_query, first_interval=0.5)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -107,13 +107,13 @@ class TestQueryPDBStructure:
             mock_get.return_value = mock_response
 
             # Test lowercase conversion
-            result = query_pdb_structure("4hhb")
+            query_pdb_structure("4hhb")
             mock_get.assert_called_with(
                 "https://data.rcsb.org/rest/v1/core/entry/4HHB", timeout=30
             )
 
             # Test whitespace stripping
-            result = query_pdb_structure(" 4HHB ")
+            query_pdb_structure(" 4HHB ")
             mock_get.assert_called_with(
                 "https://data.rcsb.org/rest/v1/core/entry/4HHB", timeout=30
             )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,388 @@
+import json
+from unittest.mock import Mock, patch
+import pytest
+from requests.exceptions import ConnectionError, RequestException, Timeout
+from molecularnodes.ui.query import (
+    PDBQueryError,
+    PDBStructureInfo,
+    query_pdb_structure,
+)
+
+# Import the functions and classes to test
+# from rcsb_query import query_pdb_structure, PDBStructureInfo, PDBQueryError
+
+
+class TestPDBStructureInfo:
+    """Test the PDBStructureInfo dataclass"""
+
+    def test_dataclass_initialization(self):
+        """Test basic initialization of PDBStructureInfo"""
+        info = PDBStructureInfo(entry_id="4HHB")
+        assert info.entry_id == "4HHB"
+        assert info.title is None
+        assert info.experimental_method is None
+        assert info.resolution is None
+
+    def test_dataclass_with_data(self):
+        """Test PDBStructureInfo with actual data"""
+        info = PDBStructureInfo(
+            entry_id="4HHB",
+            title="Test Structure",
+            experimental_method="X-RAY DIFFRACTION",
+            resolution=2.5,
+            authors=["Smith, J.", "Doe, J."],
+            organism_names=["Homo sapiens"],
+        )
+        assert info.entry_id == "4HHB"
+        assert info.title == "Test Structure"
+        assert info.experimental_method == "X-RAY DIFFRACTION"
+        assert info.resolution == 2.5
+        assert len(info.authors) == 2
+        assert info.organism_names[0] == "Homo sapiens"
+
+    def test_string_representation(self):
+        """Test __str__ method"""
+        info = PDBStructureInfo(
+            entry_id="4HHB",
+            title="Test Structure",
+            experimental_method="X-RAY DIFFRACTION",
+            resolution=2.5,
+            organism_names=["Homo sapiens"],
+        )
+        str_repr = str(info)
+        assert "PDB Entry: 4HHB" in str_repr
+        assert "Title: Test Structure" in str_repr
+        assert "Method: X-RAY DIFFRACTION" in str_repr
+        assert "Resolution: 2.5 Å" in str_repr
+        assert "Organisms: Homo sapiens" in str_repr
+
+
+class TestPDBQueryError:
+    """Test the PDBQueryError exception"""
+
+    def test_basic_error(self):
+        """Test basic error creation"""
+        error = PDBQueryError("Test error message")
+        assert error.message == "Test error message"
+        assert error.status_code is None
+        assert str(error) == "Test error message"
+
+    def test_error_with_status_code(self):
+        """Test error with status code"""
+        error = PDBQueryError("Not found", 404)
+        assert error.message == "Not found"
+        assert error.status_code == 404
+
+
+class TestQueryPDBStructure:
+    """Test the query_pdb_structure function"""
+
+    def test_invalid_entry_id_formats(self):
+        """Test validation of entry_id formats"""
+        # Test empty string
+        with pytest.raises(ValueError, match="entry_id must be a non-empty string"):
+            query_pdb_structure("")
+
+        # Test None
+        with pytest.raises(ValueError, match="entry_id must be a non-empty string"):
+            query_pdb_structure(None)
+
+        # Test wrong length
+        with pytest.raises(
+            ValueError, match="entry_id must be exactly 4 characters long"
+        ):
+            query_pdb_structure("123")
+
+        with pytest.raises(
+            ValueError, match="entry_id must be exactly 4 characters long"
+        ):
+            query_pdb_structure("12345")
+
+    def test_entry_id_normalization(self):
+        """Test that entry_id is properly normalized (uppercase, stripped)"""
+        with patch("requests.get") as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"struct": {"title": "Test"}}
+            mock_get.return_value = mock_response
+
+            # Test lowercase conversion
+            result = query_pdb_structure("4hhb")
+            mock_get.assert_called_with(
+                "https://data.rcsb.org/rest/v1/core/entry/4HHB", timeout=30
+            )
+
+            # Test whitespace stripping
+            result = query_pdb_structure(" 4HHB ")
+            mock_get.assert_called_with(
+                "https://data.rcsb.org/rest/v1/core/entry/4HHB", timeout=30
+            )
+
+    @patch("requests.get")
+    def test_successful_query(self, mock_get):
+        """Test successful API query with mock data"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "struct": {"title": "Test Hemoglobin Structure"},
+            "exptl": [{"method": "X-RAY DIFFRACTION"}],
+            "rcsb_entry_info": {
+                "resolution_combined": [2.5],
+                "polymer_entity_count_protein": 4,
+                "polymer_entity_count_DNA": 0,
+                "polymer_entity_count_RNA": 0,
+                "molecular_weight": 64500.0,
+                "deposited_modeled_polymer_monomer_count": 574,
+            },
+            "audit_author": [{"name": "Perutz, M.F."}, {"name": "Rossmann, M.G."}],
+            "rcsb_entity_source_organism": [{"ncbi_scientific_name": "Homo sapiens"}],
+            "struct_keywords": {"pdbx_keywords": "OXYGEN TRANSPORT"},
+            "cell": {
+                "length_a": 63.150,
+                "length_b": 83.590,
+                "length_c": 53.800,
+                "angle_alpha": 90.00,
+                "angle_beta": 99.34,
+                "angle_gamma": 90.00,
+            },
+            "symmetry": {"space_group_name_H-M": "P 1 21 1"},
+            "refine": [{"ls_R_factor_R_work": 0.160, "ls_R_factor_R_free": 0.230}],
+        }
+        mock_get.return_value = mock_response
+
+        result = query_pdb_structure("4HHB")
+
+        assert result.entry_id == "4HHB"
+        assert result.title == "Test Hemoglobin Structure"
+        assert result.experimental_method == "X-RAY DIFFRACTION"
+        assert result.resolution == 2.5
+        assert result.polymer_entity_count == 4
+        assert result.authors == ["Perutz, M.F.", "Rossmann, M.G."]
+        assert result.organism_names == ["Homo sapiens"]
+        assert result.structure_classification == "OXYGEN TRANSPORT"
+        assert result.space_group == "P 1 21 1"
+        assert result.r_work == 0.160
+        assert result.r_free == 0.230
+        assert result.unit_cell["a"] == 63.150
+        assert result.unit_cell["beta"] == 99.34
+
+    @patch("requests.get")
+    def test_404_not_found(self, mock_get):
+        """Test handling of 404 response"""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("XXXX")
+
+        assert "PDB entry 'XXXX' not found" in str(exc_info.value)
+        assert exc_info.value.status_code == 404
+
+    @patch("requests.get")
+    def test_other_http_errors(self, mock_get):
+        """Test handling of other HTTP errors"""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_get.return_value = mock_response
+
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("4HHB")
+
+        assert "API request failed with status 500" in str(exc_info.value)
+        assert exc_info.value.status_code == 500
+
+    @patch("requests.get")
+    def test_json_decode_error(self, mock_get):
+        """Test handling of invalid JSON response"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+        mock_get.return_value = mock_response
+
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("4HHB")
+
+        assert "Failed to parse JSON response" in str(exc_info.value)
+
+    @patch("requests.get")
+    def test_timeout_error(self, mock_get):
+        """Test handling of timeout"""
+        mock_get.side_effect = Timeout()
+
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("4HHB", timeout=5)
+
+        assert "Request timed out after 5 seconds" in str(exc_info.value)
+
+    @patch("requests.get")
+    def test_connection_error(self, mock_get):
+        """Test handling of connection error"""
+        mock_get.side_effect = ConnectionError()
+
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("4HHB")
+
+        assert "Failed to connect to RCSB PDB API" in str(exc_info.value)
+
+    @patch("requests.get")
+    def test_general_request_exception(self, mock_get):
+        """Test handling of general request exceptions"""
+        mock_get.side_effect = RequestException("Network error")
+
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("4HHB")
+
+        assert "Request failed: Network error" in str(exc_info.value)
+
+    @patch("requests.get")
+    def test_minimal_response(self, mock_get):
+        """Test handling of minimal API response"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}  # Empty response
+        mock_get.return_value = mock_response
+
+        result = query_pdb_structure("4HHB")
+
+        assert result.entry_id == "4HHB"
+        assert result.title is None
+        assert result.experimental_method is None
+        assert result.resolution is None
+
+    @patch("requests.get")
+    def test_multiple_experimental_methods(self, mock_get):
+        """Test handling of multiple experimental methods"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "exptl": [
+                {"method": "X-RAY DIFFRACTION"},
+                {"method": "NEUTRON DIFFRACTION"},
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        result = query_pdb_structure("4HHB")
+
+        assert result.experimental_method == "X-RAY DIFFRACTION, NEUTRON DIFFRACTION"
+
+    @patch("requests.get")
+    def test_custom_timeout(self, mock_get):
+        """Test custom timeout parameter"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        mock_get.return_value = mock_response
+
+        query_pdb_structure("4HHB", timeout=60)
+
+        mock_get.assert_called_with(
+            "https://data.rcsb.org/rest/v1/core/entry/4HHB", timeout=60
+        )
+
+    @patch("requests.get")
+    def test_citation_parsing(self, mock_get):
+        """Test parsing of citation information"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "citation": [
+                {
+                    "id": "primary",
+                    "pdbx_database_id_DOI": "10.1038/171740a0",
+                    "pdbx_database_id_PubMed": "14882605",
+                },
+                {
+                    "id": "secondary",
+                    "pdbx_database_id_DOI": "10.1016/other",
+                    "pdbx_database_id_PubMed": "12345678",
+                },
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        result = query_pdb_structure("4HHB")
+
+        # Should only get the primary citation
+        assert result.doi == "10.1038/171740a0"
+        assert result.pubmed_id == "14882605"
+
+
+class TestIntegration:
+    """Integration tests (these will make actual API calls)"""
+
+    @pytest.mark.integration
+    def test_real_api_call_valid_structure(self):
+        """Test with a real API call to a known structure"""
+        # Using 1CRN which is a small, stable structure
+        try:
+            result = query_pdb_structure("1CRN")
+            assert result.entry_id == "1CRN"
+            assert result.title is not None
+            assert result.experimental_method is not None
+            # 1CRN should be NMR
+            assert "NMR" in result.experimental_method.upper()
+        except Exception as e:
+            pytest.skip(f"Real API call failed: {e}")
+
+    @pytest.mark.integration
+    def test_real_api_call_invalid_structure(self):
+        """Test with a real API call to an invalid structure"""
+        with pytest.raises(PDBQueryError) as exc_info:
+            query_pdb_structure("ZZZZ")
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in str(exc_info.value).lower()
+
+
+# Pytest fixtures
+@pytest.fixture
+def sample_pdb_data():
+    """Sample PDB data for testing"""
+    return {
+        "struct": {"title": "Test Structure"},
+        "exptl": [{"method": "X-RAY DIFFRACTION"}],
+        "rcsb_entry_info": {
+            "resolution_combined": [2.0],
+            "polymer_entity_count_protein": 1,
+            "polymer_entity_count_DNA": 0,
+            "polymer_entity_count_RNA": 0,
+        },
+        "audit_author": [{"name": "Test Author"}],
+        "rcsb_entity_source_organism": [{"ncbi_scientific_name": "Test organism"}],
+    }
+
+
+@pytest.fixture
+def mock_successful_response(sample_pdb_data):
+    """Mock successful API response"""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = sample_pdb_data
+    return mock_response
+
+
+# Parametrized tests for edge cases
+@pytest.mark.parametrize(
+    "entry_id,expected_normalized",
+    [("4hhb", "4HHB"), ("  4HHB  ", "4HHB"), ("1abc", "1ABC"), ("1A2B", "1A2B")],
+)
+def test_entry_id_normalization_parametrized(entry_id, expected_normalized):
+    """Test entry ID normalization with various inputs"""
+    with patch("requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        mock_get.return_value = mock_response
+
+        query_pdb_structure(entry_id)
+        expected_url = f"https://data.rcsb.org/rest/v1/core/entry/{expected_normalized}"
+        mock_get.assert_called_with(expected_url, timeout=30)
+
+
+if __name__ == "__main__":
+    # Run tests with: python -m pytest test_rcsb_query.py -v
+    # Run integration tests: python -m pytest test_rcsb_query.py -v -m integration
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This fetches data on the given structure, displaying some of it before download of the structure itself.

Lots of potential data to be displayed, unsure on what would be most useful but it's great to get a bit of info to ensure we are attempting to download the correct structure.

![CleanShot 2025-07-08 at 16 54 28@2x](https://github.com/user-attachments/assets/3b6fdcf7-48db-42c9-9e2e-2ac3c3ea6e3e)

| No Structure | Internet Issue | String Error |
|--------|--------|--------|
|![CleanShot 2025-07-08 at 16 55 40@2x](https://github.com/user-attachments/assets/29195e5d-50ca-4fed-82c1-30e7b3eaa736) |![CleanShot 2025-07-08 at 16 56 20@2x](https://github.com/user-attachments/assets/0f4e4a77-d019-46a4-b983-a69426df5476) |![CleanShot 2025-07-08 at 16 56 43@2x](https://github.com/user-attachments/assets/a195938a-5957-4446-bce0-6aa433452af2) |

To-do: 
- [ ] If internet connection is failed but file already exists in cache, the fetch should still be enabled
- [ ] Potentially display _if_ or where the file is already cached
- [ ] Potentially subset the possible file formats that can be downloaded
- [ ] Display number of chains / ligands in the structures
- [ ] random crashes if undoing / deleting objects

