### PR TITLE
Remove micrograph tests

### DIFF
--- a/molecularnodes/entities/ensemble/star.py
+++ b/molecularnodes/entities/ensemble/star.py
@@ -32,7 +32,6 @@ class StarFile(Ensemble):
         self.object = blender_object
         self.data = self._read()
         self._create_mn_columns()
-        bpy.app.handlers.depsgraph_update_post.append(self._update_micrograph_texture)
         return self
 
     @property

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -53,21 +53,3 @@ def test_micrograph_conversion():
     tiff_path = data_dir / "starfile/montage.tiff"
     ensemble._convert_mrc_to_tiff()
     assert tiff_path.exists()
-
-
-def test_micrograph_loading():
-    import bpy
-
-    file = data_dir / "starfile/cistem.star"
-    tiff_path = data_dir / "starfile/montage.tiff"
-    ensemble = mn.entities.ensemble.load_starfile(file)
-    ensemble.star_node.inputs["Show Micrograph"].default_value = True
-    bpy.context.evaluated_depsgraph_get().update()
-    assert tiff_path.exists()
-    # Ensure montage get only loaded once
-    assert sum(1 for image in bpy.data.images.keys() if "montage" in image) == 1
-    assert (
-        ensemble.micrograph_material.node_tree.nodes["Image Texture"].image.name
-        == "montage.tiff"
-    )
-    assert ensemble.star_node.inputs["Micrograph"].default_value.name == "montage.tiff"


### PR DESCRIPTION
In Blender 5.0 the daily tests are failing specifically for the micrograph loading of .star files. 

I haven't been happy with how this is handled for a while, given it's done in the background all on one node. We should have a single node for displaying an ensemble, then another node that can potentially display a micrograph:

<img width="724" height="914" alt="CleanShot 2025-07-10 at 18 29 05@2x" src="https://github.com/user-attachments/assets/2574254c-2706-4316-a26f-3c0cc1202d0f" />

This current node could essentially be split into two, and the image loaded when the additional node is added rather than subscribing to depsgraph changes and trying to update then.