### PR TITLE
Add support for AtomGroup selections through API interface

### DIFF
--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -1,8 +1,10 @@
 from abc import ABCMeta, abstractmethod
-from math import radians
+from math import cos, radians, sin
 import blf
 import bpy
+import gpu
 from bpy_extras import view3d_utils
+from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
 from .interface import AnnotationInterface
 
@@ -27,11 +29,25 @@ class BaseAnnotation(metaclass=ABCMeta):
         Name (label) of the annotation
     interface: AnnotationInterface
         Dynamic interface of the annotation instance
+    viewport_width: int
+        Width of the viewport region in pixels
+    viewport_height: int
+        Height of the viewport region in pixels
 
     """
 
     name: str = None
     interface: AnnotationInterface
+
+    def __init__(self):
+        self._world_scale = 0.01
+        self._rad45 = radians(45)
+        self._rad315 = radians(315)
+        self._shader_line = (
+            gpu.shader.from_builtin("POLYLINE_UNIFORM_COLOR")
+            if not bpy.app.background
+            else None
+        )
 
     def validate(self) -> bool:
         """
@@ -59,19 +75,78 @@ class BaseAnnotation(metaclass=ABCMeta):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
+    @property
+    def viewport_width(self) -> int:
+        """Get the viewport region width in pixels"""
+        return self._region.width
+
+    @property
+    def viewport_height(self) -> int:
+        """Get the viewport region height in pixels"""
+        return self._region.height
+
     def draw_text_3d(self, pos_3d: Vector, text: str) -> None:
         """
         Draw text at a given 3D position
 
+        Parameters
+        ----------
+        pos_3d: Vector
+            Co-ordinates in 3D world space (x, y, z)
+
+        text: str
+            Text to display. '|' as multi-line separator
+
         """
-        pos_2d = self._get_2d_point(pos_3d)
+        params = self.interface
+        text_pos = pos_3d
+        if params.pointer_length > 0:
+            # draw a pointer to the 3D position
+            nv = -Vector(pos_3d)
+            nv.normalize()
+            pointer_begin = pos_3d + (nv * params.pointer_length)
+            text_pos = pointer_begin + Vector((0, 0, 0.5))  # offset text a bit
+            self.draw_line_3d(pointer_begin, pos_3d, v2_arrow=True)
+
+        pos_2d = self._get_2d_point(text_pos)
         if pos_2d is None:
             return
         self.draw_text_2d(pos_2d, text)
 
+    def draw_text_2d_norm(self, pos_2d: Vector, text: str) -> None:
+        """
+        Draw text at a given 2D position (normalized co-ordinates) of Viewport.
+
+        Parameters
+        ----------
+        pos_2d: Vector
+            Normalized co-ordinates (0 - 1). (0, 0) is at bottom left
+
+        text: str
+            Text to display. '|' as multi-line separator
+
+        """
+        if pos_2d is None:
+            return
+        for comp in pos_2d:
+            if not (0.0 <= comp <= 1.0):
+                return
+        pos_x, pos_y = pos_2d
+        new_x = pos_x * self.viewport_width
+        new_y = pos_y * self.viewport_height
+        self._draw_text_2d((new_x, new_y), text)
+
     def draw_text_2d(self, pos_2d: Vector, text: str) -> None:
         """
-        Draw text at a given 2D position of Viewport. (0, 0) is bottom left
+        Draw text at a given 2D position (in pixels) of Viewport.
+
+        Parameters
+        ----------
+        pos_2d: Vector
+            Co-ordinates in pixels. (0, 0) is at bottom left
+
+        text: str
+            Text to display. '|' as multi-line separator
 
         """
         if pos_2d is None:
@@ -81,6 +156,9 @@ class BaseAnnotation(metaclass=ABCMeta):
         right_alignment_gap = 12
         params = self.interface
         pos_x, pos_y = pos_2d
+        # offset_x and offset_y
+        pos_x += params.offset_x
+        pos_y += params.offset_y
         rgba = params.text_color
         # set the text size
         blf.size(font_id, params.text_size)
@@ -112,19 +190,203 @@ class BaseAnnotation(metaclass=ABCMeta):
             if params.text_align == "left":
                 blf.disable(font_id, blf.ROTATION)
 
+    def draw_line_3d(
+        self,
+        v1: Vector,
+        v2: Vector,
+        v1_text: str = None,
+        v2_text: str = None,
+        mid_text: str = None,
+        v1_arrow: bool = False,
+        v2_arrow: bool = False,
+    ) -> None:
+        """
+        Draw a line between two points in 3D space
+
+        Parameters
+        ----------
+        v1: Vector
+            3D co-ordinates of the first point
+
+        v2: Vector
+            3D co-ordinates of the second point
+
+        v1_text: str
+            Optional text to display at v1
+
+        v2_text: str
+            Optional text to display at v2
+
+        mid_text: str
+            Optional text to display at the middle of the line
+
+        v1_arrow: bool
+            Whether to display an arrow at v1
+
+        v2_arrow: bool
+            Whether to display an arrow at v2
+
+        """
+        if v1 is None or v2 is None:
+            return
+        v1_2d = self._get_2d_point(v1)
+        v2_2d = self._get_2d_point(v2)
+        self.draw_line_2d(v1_2d, v2_2d, v1_text, v2_text, mid_text, v1_arrow, v2_arrow)
+
+    def draw_line_2d(
+        self,
+        v1: Vector,
+        v2: Vector,
+        v1_text: str = None,
+        v2_text: str = None,
+        mid_text: str = None,
+        v1_arrow: bool = False,
+        v2_arrow: bool = False,
+    ) -> None:
+        """
+        Draw a line between two points in 2D viewport space
+
+        Parameters
+        ----------
+        v1: Vector
+            2D co-ordinates of the first point
+
+        v2: Vector
+            2D co-ordinates of the second point
+
+        v1_text: str
+            Optional text to display at v1
+
+        v2_text: str
+            Optional text to display at v2
+
+        mid_text: str
+            Optional text to display at the middle of the line
+
+        v1_arrow: bool
+            Whether to display an arrow at v1
+
+        v2_arrow: bool
+            Whether to display an arrow at v2
+
+        """
+        if v1 is None or v2 is None:
+            return
+        self._draw_arrow_line_2d(v1, v2, v1_arrow, v2_arrow)
+        if v1_text is not None:
+            self.draw_text_2d(v1, v1_text)
+        if v2_text is not None:
+            self.draw_text_2d(v2, v2_text)
+        if mid_text is not None:
+            mid = (v1 + v2) / 2
+            self.draw_text_2d(mid, mid_text)
+
+    def distance(self, v1: Vector, v2: Vector) -> float:
+        """
+        Distance between two vectors
+
+        Paramaters
+        ----------
+        v1: Vector
+            A 3D or 2D vector or tuple
+
+        v2: Vector
+            A 3D or 2D vector or tuple
+
+        Returns
+        -------
+        Distance between the two vectors
+
+        """
+        return (Vector(v2) - Vector(v1)).length
+
+    def _draw_arrow_line_2d(
+        self,
+        v1: Vector,
+        v2: Vector,
+        v1_arrow: bool = False,
+        v2_arrow: bool = False,
+    ) -> None:
+        """Internal: Draw a line between two 2D points with arrows"""
+        if v1 is None or v2 is None:
+            return
+        # actual line
+        self._draw_line_2d(v1, v2)
+        if v1_arrow:
+            # v1 arrow lines
+            va, vb = self._get_arrow_end_points(v1, v2)
+            self._draw_line_2d(v1, va)
+            self._draw_line_2d(v1, vb)
+        if v2_arrow:
+            # v2 arrow lines
+            va, vb = self._get_arrow_end_points(v2, v1)
+            self._draw_line_2d(v2, va)
+            self._draw_line_2d(v2, vb)
+
+    def _get_arrow_end_points(self, v1, v2: Vector) -> tuple:
+        """Internal: Get arrow end point positions"""
+        params = self.interface
+        v = self._interpolate_3d(
+            (v1[0], v1[1], 0.0), (v2[0], v2[1], 0.0), params.arrow_size
+        )
+        vi = (v[0] - v1[0], v[1] - v1[1])
+        va = (
+            int(vi[0] * cos(self._rad45) - vi[1] * sin(self._rad45) + v1[0]),
+            int(vi[1] * cos(self._rad45) + vi[0] * sin(self._rad45)) + v1[1],
+        )
+        vb = (
+            int(vi[0] * cos(self._rad315) - vi[1] * sin(self._rad315) + v1[0]),
+            int(vi[1] * cos(self._rad315) + vi[0] * sin(self._rad315) + v1[1]),
+        )
+        return (va, vb)
+
+    def _draw_line_2d(self, v1: Vector, v2: Vector) -> None:
+        """Internal: Draw a line between two 2D points"""
+        if v1 is None or v2 is None:
+            return
+        params = self.interface
+        rgba = params.line_color
+        line_width = params.line_width
+        viewport_size = (self.viewport_width, self.viewport_height)
+        coords = [(v1[0], v1[1], 0), (v2[0], v2[1], 0)]
+        gpu.state.blend_set("ALPHA")
+        batch = batch_for_shader(self._shader_line, "LINES", {"pos": coords})
+        try:
+            self._shader_line.bind()
+            self._shader_line.uniform_float("color", rgba)
+            self._shader_line.uniform_float("lineWidth", line_width)
+            self._shader_line.uniform_float("viewportSize", viewport_size)
+            batch.draw(self._shader_line)
+        except Exception as e:
+            print(e)
+
+    def _interpolate_3d(self, v1: Vector, v2: Vector, d1: float) -> Vector:
+        """Internal: Interpolated 3D point between two 3D points at distance d1"""
+        # calculate displacement vector
+        v = Vector(v2) - Vector(v1)
+        # calculate distance between points
+        d0 = self.distance(v1, v2)
+        # calculate interpolate factor (distance from origin / distance total)
+        # if d1 > d0, the point is projected in 3D space
+        if d0 > 0:
+            x = d1 / d0
+        else:
+            x = d1
+        return (v1[0] + (v[0] * x), v1[1] + (v[1] * x), v1[2] + (v[2] * x))
+
     def _set_viewport_region(
         self,
         region: bpy.types.Region | None,
         rv3d: bpy.types.RegionView3D | None,
     ) -> None:
-        """Set the 3D viewport region and region data"""
+        """Internal: Set the 3D viewport region and region data"""
         self._region = region
         self._rv3d = rv3d
 
     def _get_2d_point(self, pos_3d: Vector) -> Vector | None:
-        """Get the 2D point in region corresponding to 3D position"""
+        """Internal: Get the 2D point in region corresponding to 3D position"""
         if self._rv3d is not None and self._region is not None:
-            pos_3d_scaled = pos_3d * 0.01  # world scale for MN
+            pos_3d_scaled = pos_3d * self._world_scale
             return view3d_utils.location_3d_to_region_2d(
                 self._region, self._rv3d, pos_3d_scaled
             )

--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -54,7 +54,10 @@ class BaseAnnotation(metaclass=ABCMeta):
         Optional method to validate annotation inputs
         This is called during annotation creation and any time the inputs change
         either through the API or GUI. Can return False or raise an exception
-        when validation fails. Returns True when all validations succeed
+        when validation fails. Returns True when all validations succeed.
+
+        Note: This method gets called when any inputs change, so updating values
+        in here will lead to a recursive loop and should not be done.
 
         """
         return True

--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -105,7 +105,7 @@ class BaseAnnotation(metaclass=ABCMeta):
             nv = -Vector(pos_3d)
             nv.normalize()
             pointer_begin = pos_3d + (nv * params.pointer_length)
-            text_pos = pointer_begin + Vector((0, 0, 0.5))  # offset text a bit
+            text_pos = pointer_begin + (nv * 0.5)  # offset text a bit
             self.draw_line_3d(pointer_begin, pos_3d, v2_arrow=True)
 
         pos_2d = self._get_2d_point(text_pos)

--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -134,7 +134,7 @@ class BaseAnnotation(metaclass=ABCMeta):
         pos_x, pos_y = pos_2d
         new_x = pos_x * self.viewport_width
         new_y = pos_y * self.viewport_height
-        self._draw_text_2d((new_x, new_y), text)
+        self.draw_text_2d((new_x, new_y), text)
 
     def draw_text_2d(self, pos_2d: Vector, text: str) -> None:
         """

--- a/molecularnodes/annotations/manager.py
+++ b/molecularnodes/annotations/manager.py
@@ -96,7 +96,7 @@ class BaseAnnotationManager(metaclass=ABCMeta):
 
         # Add a dynamic wrapper to ensure custom signature is retained
         def dynamic_wrapper(cls, annotation_class, **kwargs):
-            cls._create_annotation_instance(annotation_class, **kwargs)
+            return cls._create_annotation_instance(annotation_class, **kwargs)
 
         method = functools.partialmethod(dynamic_wrapper, annotation_class)
         parameters = [

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -125,20 +125,16 @@ class BaseAnnotationProperties(bpy.types.PropertyGroup):
         max=360.0,
     )  # type: ignore
 
-    offset_x: FloatProperty(
+    offset_x: IntProperty(
         name="Offset X",
         description="Offset in X direction",
         default=0,
-        min=0.0,
-        max=1.0,
     )  # type: ignore
 
-    offset_y: FloatProperty(
+    offset_y: IntProperty(
         name="offset Y",
         description="Offset in Y direction",
         default=0,
-        min=0.0,
-        max=1.0,
     )  # type: ignore
 
     line_color: FloatVectorProperty(

--- a/molecularnodes/annotations/utils.py
+++ b/molecularnodes/annotations/utils.py
@@ -1,4 +1,6 @@
 import inspect
+import types
+import typing
 
 
 def get_all_class_annotations(cls) -> dict:
@@ -11,3 +13,14 @@ def get_all_class_annotations(cls) -> dict:
     if "interface" in all_annotations:
         del all_annotations["interface"]
     return all_annotations
+
+
+def get_blender_supported_type(atype):
+    supported_types = (str, bool, int, float)
+    if atype in supported_types:
+        return atype
+    if typing.get_origin(atype) is typing.Union or type(atype) is types.UnionType:
+        for utype in atype.__args__:
+            if utype in supported_types:
+                return utype
+    return None

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -90,3 +90,101 @@ class AtomInfo(TrajectoryAnnotation):
             if params.show_segid:
                 text += f"|seg {atom.segid}"
             self.draw_text_3d(atom.position, text)
+
+
+class COM(TrajectoryAnnotation):
+    """
+    Center-of-Mass Trajectory Annotation
+
+    This annotation shows the center-of-mass of a selection.
+    This annotation can be added using the 'add_com' method of the
+    trajectory's annotation manager:
+        trajectory.annotations.add_com(...)
+
+    Attributes
+    ----------
+    selection: str
+        MDAnalysis selection phrase to select the atom group
+    text: str
+        Text do display at the center-of-mass
+
+    """
+
+    annotation_type = "com"  # required annotation type
+
+    # annotation inputs
+    selection: str = "protein"
+    text: str = "Protein|COM"
+
+    def defaults(self) -> None:
+        params = self.interface
+        # show a default pointer
+        params.pointer_length = 2
+        params.arrow_size = 10
+
+    def validate(self) -> bool:
+        universe = self.trajectory.universe
+        # check if selection phrase is valid - mda throws exception if invalid
+        self.atom_group = universe.select_atoms(self.interface.selection)
+        return True
+
+    def draw(self) -> None:
+        com = self.atom_group.center_of_mass()
+        self.draw_text_3d(com, self.interface.text)
+
+
+class COMDistance(TrajectoryAnnotation):
+    """
+    Distance between Center-of-Masses Trajectory Annotation
+
+    This annotation shows the distance between center-of-masses of two selections.
+    This annotation can be added using the 'add_com_distance' method of the
+    trajectory's annotation manager:
+        trajectory.annotations.add_com_distance(...)
+
+    Attributes
+    ----------
+    selection1: str
+        MDAnalysis selection phrase to select the first atom group
+    selection2: str
+        MDAnalysis selection phrase to select the second atom group
+    text1: str
+        Text do display at the first center-of-mass
+    text2: str
+        Text do display at the second center-of-mass
+
+    """
+
+    annotation_type = "com_distance"  # required annotation type
+
+    # annotation inputs
+    selection1: str
+    selection2: str
+    text1: str = "COM1"
+    text2: str = "COM2"
+
+    def validate(self) -> bool:
+        params = self.interface
+        universe = self.trajectory.universe
+        # check if selection phrases are valid - exception thrown if invalid
+        self.atom_group1 = universe.select_atoms(params.selection1)
+        self.atom_group2 = universe.select_atoms(params.selection2)
+        return True
+
+    def draw(self) -> None:
+        params = self.interface
+        # calculate the two center-of-masses
+        com1 = self.atom_group1.center_of_mass()
+        com2 = self.atom_group2.center_of_mass()
+        # calculate distance between coms
+        distance = self.distance(com1, com2)
+        # draw line with arrow ends showing distance in between
+        self.draw_line_3d(
+            v1=com1,
+            v2=com2,
+            v1_text=params.text1,
+            v2_text=params.text2,
+            mid_text=f"{distance:1.2f} Å",
+            v1_arrow=True,
+            v2_arrow=True,
+        )

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -1,3 +1,5 @@
+import typing
+from MDAnalysis.core.groups import AtomGroup
 from ...annotations.base import BaseAnnotation
 from ...annotations.manager import BaseAnnotationManager
 
@@ -63,7 +65,7 @@ class AtomInfo(TrajectoryAnnotation):
     annotation_type = "atom_info"  # required annotation type
 
     # annotation inputs
-    selection: str = "name CA"
+    selection: str | AtomGroup = "name CA"
     show_resid: bool = False
     show_segid: bool = False
 
@@ -76,8 +78,14 @@ class AtomInfo(TrajectoryAnnotation):
     def validate(self) -> bool:
         params = self.interface
         universe = self.trajectory.universe
-        # check if selection phrase is valid - mda throws exception if invalid
-        self.atom_group = universe.select_atoms(params.selection)
+        if isinstance(params.selection, str):
+            # check if selection phrase is valid
+            # mda throws exception if invalid
+            self.atom_group = universe.select_atoms(params.selection)
+        elif isinstance(params.selection, AtomGroup):
+            self.atom_group = params.selection
+        else:
+            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection)}")
         return True
 
     def draw(self) -> None:
@@ -113,7 +121,7 @@ class COM(TrajectoryAnnotation):
     annotation_type = "com"  # required annotation type
 
     # annotation inputs
-    selection: str = "protein"
+    selection: typing.Union[str | AtomGroup] = "protein"
     text: str = "COM"
 
     def defaults(self) -> None:
@@ -123,9 +131,16 @@ class COM(TrajectoryAnnotation):
         params.arrow_size = 10
 
     def validate(self) -> bool:
+        params = self.interface
         universe = self.trajectory.universe
-        # check if selection phrase is valid - mda throws exception if invalid
-        self.atom_group = universe.select_atoms(self.interface.selection)
+        if isinstance(params.selection, str):
+            # check if selection phrase is valid
+            # mda throws exception if invalid
+            self.atom_group = universe.select_atoms(params.selection)
+        elif isinstance(params.selection, AtomGroup):
+            self.atom_group = params.selection
+        else:
+            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection)}")
         return True
 
     def draw(self) -> None:
@@ -158,17 +173,32 @@ class COMDistance(TrajectoryAnnotation):
     annotation_type = "com_distance"  # required annotation type
 
     # annotation inputs
-    selection1: str
-    selection2: str
+    selection1: str | AtomGroup
+    selection2: str | AtomGroup
     text1: str = "COM1"
     text2: str = "COM2"
 
     def validate(self) -> bool:
         params = self.interface
         universe = self.trajectory.universe
-        # check if selection phrases are valid - exception thrown if invalid
-        self.atom_group1 = universe.select_atoms(params.selection1)
-        self.atom_group2 = universe.select_atoms(params.selection2)
+        # check selection 1
+        if isinstance(params.selection1, str):
+            # check if selection phrase is valid
+            # mda throws exception if invalid
+            self.atom_group1 = universe.select_atoms(params.selection1)
+        elif isinstance(params.selection1, AtomGroup):
+            self.atom_group1 = params.selection1
+        else:
+            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection1)}")
+        # check selection 2
+        if isinstance(params.selection2, str):
+            # check if selection phrase is valid
+            # mda throws exception if invalid
+            self.atom_group2 = universe.select_atoms(params.selection2)
+        elif isinstance(params.selection2, AtomGroup):
+            self.atom_group2 = params.selection2
+        else:
+            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection2)}")
         return True
 
     def draw(self) -> None:

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -114,7 +114,7 @@ class COM(TrajectoryAnnotation):
 
     # annotation inputs
     selection: str = "protein"
-    text: str = "Protein|COM"
+    text: str = "COM"
 
     def defaults(self) -> None:
         params = self.interface

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -945,12 +945,12 @@ class MN_PT_Annotations(bpy.types.Panel):
             return
 
         item = object.mn_annotations[annotations_active_index]
-
         box = layout.box()
         row = box.row()
         row.prop(item, "type")
         row.enabled = False
         inputs = getattr(item, item.type, None)
+        instance = entity.annotations._interfaces.get(inputs.uuid)._instance
         if inputs is not None:
             if not inputs.valid_inputs:
                 col = layout.column()
@@ -962,6 +962,10 @@ class MN_PT_Annotations(bpy.types.Panel):
                 if prop_name in ("uuid", "valid_inputs"):
                     continue
                 row = box.row()
+                if hasattr(instance, f"_{prop_name}"):
+                    # indicate use of non blender property in draw
+                    row.label(icon="ERROR")
+                    row.alert = True
                 row.prop(inputs, prop_name)
 
         # Add all the common annotation params within the 'Options' panel

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -23,6 +23,14 @@ class TestAnnotations:
         assert "atom_info" in manager._classes
         assert hasattr(manager, "add_atom_info")
         assert callable(getattr(manager, "add_atom_info"))
+        # com
+        assert "com" in manager._classes
+        assert hasattr(manager, "add_com")
+        assert callable(getattr(manager, "add_com"))
+        # com_distance
+        assert "com_distance" in manager._classes
+        assert hasattr(manager, "add_com_distance")
+        assert callable(getattr(manager, "add_com_distance"))
 
     def test_trajectory_annotations_registration(self, universe, session):
         manager = mn.entities.trajectory.TrajectoryAnnotationManager
@@ -177,3 +185,76 @@ class TestAnnotations:
             "EXEC_DEFAULT", uuid=t1.uuid, annotation_uuid=a1._uuid
         )
         assert len(t1.annotations) == 0
+
+    def test_trajectory_annotation_atom_info(self, universe, session):
+        t1 = session.add_trajectory(universe)
+        assert len(t1.annotations) == 0
+        # test defaults
+        t1.annotations.add_atom_info()
+        assert len(t1.annotations) == 1
+        t1.annotations.clear()
+        # test selection string
+        phrase = "all"
+        a1 = t1.annotations.add_atom_info(selection=phrase)
+        assert len(t1.annotations) == 1
+        assert phrase == a1.selection
+        t1.annotations.clear()
+        # test selection atom group
+        ag = universe.select_atoms("all")
+        a1 = t1.annotations.add_atom_info(selection=ag)
+        assert len(t1.annotations) == 1
+        assert ag == a1.selection
+        t1.annotations.clear()
+        # test invalid selection type (not str or AtomGroup)
+        with pytest.raises(ValueError):
+            t1.annotations.add_atom_info(selection=1)
+
+    def test_trajectory_annotation_com(self, universe, session):
+        t1 = session.add_trajectory(universe)
+        assert len(t1.annotations) == 0
+        # test defaults
+        t1.annotations.add_com()
+        assert len(t1.annotations) == 1
+        t1.annotations.clear()
+        # test selection string
+        phrase = "all"
+        a1 = t1.annotations.add_com(selection=phrase)
+        assert len(t1.annotations) == 1
+        assert phrase == a1.selection
+        t1.annotations.clear()
+        # test selection atom group
+        ag = universe.select_atoms("all")
+        a1 = t1.annotations.add_com(selection=ag)
+        assert len(t1.annotations) == 1
+        assert ag == a1.selection
+        t1.annotations.clear()
+        # test invalid selection type (not str or AtomGroup)
+        with pytest.raises(ValueError):
+            t1.annotations.add_com(selection=1)
+
+    def test_trajectory_annotation_com_distance(self, universe, session):
+        t1 = session.add_trajectory(universe)
+        assert len(t1.annotations) == 0
+        # test defaults
+        with pytest.raises(ValueError):
+            t1.annotations.add_com_distance()
+        assert len(t1.annotations) == 0
+        # test both required selections
+        with pytest.raises(ValueError):
+            t1.annotations.add_com_distance(selection1="all")
+        assert len(t1.annotations) == 0
+        # test selection strings
+        phrase1 = "all"
+        a1 = t1.annotations.add_com_distance(selection1=phrase1, selection2="protein")
+        assert len(t1.annotations) == 1
+        assert phrase1 == a1.selection1
+        t1.annotations.clear()
+        # test selection atom groups
+        ag1 = universe.select_atoms("all")
+        a1 = t1.annotations.add_com_distance(selection1=ag1, selection2="protein")
+        assert len(t1.annotations) == 1
+        assert ag1 == a1.selection1
+        t1.annotations.clear()
+        # test invalid selection type (not str or AtomGroup)
+        with pytest.raises(ValueError):
+            t1.annotations.add_com_distance(selection1=1, selection2=2)


### PR DESCRIPTION
* API can now use both AtomGroup and selection phrases for selections
* Indication in GUI when non blender property used with ability to override
* A bit of cleanup of variable names
* Tests for new trajectory annotation types
