### PR TITLE
Add depth support for annotation text

### DIFF
--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -101,20 +101,7 @@ class BaseAnnotation(metaclass=ABCMeta):
             Text to display. '|' as multi-line separator
 
         """
-        params = self.interface
-        text_pos = pos_3d
-        if params.pointer_length > 0:
-            # draw a pointer to the 3D position
-            nv = -Vector(pos_3d)
-            nv.normalize()
-            pointer_begin = pos_3d + (nv * params.pointer_length)
-            text_pos = pointer_begin + (nv * 0.5)  # offset text a bit
-            self.draw_line_3d(pointer_begin, pos_3d, v2_arrow=True)
-
-        pos_2d = self._get_2d_point(text_pos)
-        if pos_2d is None:
-            return
-        self.draw_text_2d(pos_2d, text)
+        self._draw_text(pos_3d, text, is3d=True)
 
     def draw_text_2d_norm(self, pos_2d: Vector, text: str) -> None:
         """
@@ -137,7 +124,7 @@ class BaseAnnotation(metaclass=ABCMeta):
         pos_x, pos_y = pos_2d
         new_x = pos_x * self.viewport_width
         new_y = pos_y * self.viewport_height
-        self.draw_text_2d((new_x, new_y), text)
+        self._draw_text((new_x, new_y), text, is3d=False)
 
     def draw_text_2d(self, pos_2d: Vector, text: str) -> None:
         """
@@ -152,8 +139,28 @@ class BaseAnnotation(metaclass=ABCMeta):
             Text to display. '|' as multi-line separator
 
         """
-        if pos_2d is None:
+        self._draw_text(pos_2d, text, is3d=False)
+
+    def _draw_text(self, pos: Vector, text: str, is3d: bool = False) -> None:
+        """Internal: Draw text 3D or 2D"""
+        if pos is None:
             return
+        pos_2d = pos
+        if is3d:
+            text_pos = pos
+            params = self.interface
+            # check if pointer is required
+            if params.pointer_length > 0:
+                # draw a pointer to the 3D position
+                nv = -Vector(pos)
+                nv.normalize()
+                pointer_begin = pos + (nv * params.pointer_length)
+                text_pos = pointer_begin + (nv * 0.5)  # offset text a bit
+                self._draw_line(pointer_begin, pos, v2_arrow=True, is3d=True)
+            pos_2d = self._get_2d_point(text_pos)
+            if pos_2d is None:
+                return
+        # draw text at 2D position
         font_id = 0
         scale = 1
         right_alignment_gap = 12
@@ -163,8 +170,19 @@ class BaseAnnotation(metaclass=ABCMeta):
         pos_x += params.offset_x
         pos_y += params.offset_y
         rgba = params.text_color
+        text_size = params.text_size
+        # adjust the text size if depth enabled
+        if is3d and params.text_depth:
+            view_matrix = self._rv3d.view_matrix
+            if self._rv3d.is_perspective:  # perspective
+                dist = (view_matrix @ (Vector(pos) * self._world_scale)).length
+            else:  # orthographic
+                dist = -(view_matrix @ (Vector(pos) * self._world_scale)).z
+            # reduction factor
+            r_factor = 1.0 - ((dist - self._min_dist) / self._dist_range)
+            text_size *= r_factor
         # set the text size
-        blf.size(font_id, params.text_size)
+        blf.size(font_id, text_size)
         # height of one line - for use in multiline text
         _, max_th = blf.dimensions(font_id, "Tp")  # uses high/low letters
         # split lines
@@ -230,11 +248,9 @@ class BaseAnnotation(metaclass=ABCMeta):
             Whether to display an arrow at v2
 
         """
-        if v1 is None or v2 is None:
-            return
-        v1_2d = self._get_2d_point(v1)
-        v2_2d = self._get_2d_point(v2)
-        self.draw_line_2d(v1_2d, v2_2d, v1_text, v2_text, mid_text, v1_arrow, v2_arrow)
+        self._draw_line(
+            v1, v2, v1_text, v2_text, mid_text, v1_arrow, v2_arrow, is3d=True
+        )
 
     def draw_line_2d(
         self,
@@ -273,16 +289,9 @@ class BaseAnnotation(metaclass=ABCMeta):
             Whether to display an arrow at v2
 
         """
-        if v1 is None or v2 is None:
-            return
-        self._draw_arrow_line_2d(v1, v2, v1_arrow, v2_arrow)
-        if v1_text is not None:
-            self.draw_text_2d(v1, v1_text)
-        if v2_text is not None:
-            self.draw_text_2d(v2, v2_text)
-        if mid_text is not None:
-            mid = (v1 + v2) / 2
-            self.draw_text_2d(mid, mid_text)
+        self._draw_line(
+            v1, v2, v1_text, v2_text, mid_text, v1_arrow, v2_arrow, is3d=False
+        )
 
     def distance(self, v1: Vector, v2: Vector) -> float:
         """
@@ -303,28 +312,59 @@ class BaseAnnotation(metaclass=ABCMeta):
         """
         return (Vector(v2) - Vector(v1)).length
 
-    def _draw_arrow_line_2d(
+    def _draw_line(
+        self,
+        v1: Vector,
+        v2: Vector,
+        v1_text: str = None,
+        v2_text: str = None,
+        mid_text: str = None,
+        v1_arrow: bool = False,
+        v2_arrow: bool = False,
+        is3d: bool = False,
+    ) -> None:
+        """Internal: Draw line 3D or 2D"""
+        if v1 is None or v2 is None:
+            return
+        self._draw_arrow_line(v1, v2, v1_arrow, v2_arrow, is3d=is3d)
+        if v1_text is not None:
+            self._draw_text(v1, v1_text, is3d=is3d)
+        if v2_text is not None:
+            self._draw_text(v2, v2_text, is3d=is3d)
+        if mid_text is not None:
+            mid = (v1 + v2) / 2
+            self._draw_text(mid, mid_text, is3d=is3d)
+
+    def _draw_arrow_line(
         self,
         v1: Vector,
         v2: Vector,
         v1_arrow: bool = False,
         v2_arrow: bool = False,
+        is3d: bool = False,
     ) -> None:
         """Internal: Draw a line between two 2D points with arrows"""
         if v1 is None or v2 is None:
             return
+        v1_2d = v1
+        v2_2d = v2
+        if is3d:
+            v1_2d = self._get_2d_point(v1)
+            v2_2d = self._get_2d_point(v2)
+            if v1_2d is None or v2_2d is None:
+                return
         # actual line
-        self._draw_line_2d(v1, v2)
+        self._draw_line_2d(v1_2d, v2_2d)
         if v1_arrow:
             # v1 arrow lines
-            va, vb = self._get_arrow_end_points(v1, v2)
-            self._draw_line_2d(v1, va)
-            self._draw_line_2d(v1, vb)
+            va, vb = self._get_arrow_end_points(v1_2d, v2_2d)
+            self._draw_line_2d(v1_2d, va)
+            self._draw_line_2d(v1_2d, vb)
         if v2_arrow:
             # v2 arrow lines
-            va, vb = self._get_arrow_end_points(v2, v1)
-            self._draw_line_2d(v2, va)
-            self._draw_line_2d(v2, vb)
+            va, vb = self._get_arrow_end_points(v2_2d, v1_2d)
+            self._draw_line_2d(v2_2d, va)
+            self._draw_line_2d(v2_2d, vb)
 
     def _get_arrow_end_points(self, v1, v2: Vector) -> tuple:
         """Internal: Get arrow end point positions"""
@@ -381,10 +421,15 @@ class BaseAnnotation(metaclass=ABCMeta):
         self,
         region: bpy.types.Region | None,
         rv3d: bpy.types.RegionView3D | None,
+        min_dist: float,
+        max_dist: float,
     ) -> None:
         """Internal: Set the 3D viewport region and region data"""
         self._region = region
         self._rv3d = rv3d
+        self._min_dist = min_dist
+        self._max_dist = max_dist
+        self._dist_range = max_dist - min_dist
 
     def _get_2d_point(self, pos_3d: Vector) -> Vector | None:
         """Internal: Get the 2D point in region corresponding to 3D position"""

--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -178,8 +178,17 @@ class BaseAnnotation(metaclass=ABCMeta):
                 dist = (view_matrix @ (Vector(pos) * self._world_scale)).length
             else:  # orthographic
                 dist = -(view_matrix @ (Vector(pos) * self._world_scale)).z
-            # reduction factor
-            r_factor = 1.0 - ((dist - self._min_dist) / self._dist_range)
+            # adjust distance range based on falloff factor
+            dist_range = self._dist_range * params.text_falloff
+            r_factor = 0  # reduction factor
+            if dist_range > 0:  # to avoid div by 0
+                offset = dist - self._min_dist
+                # clamp to within range
+                if offset < 0:
+                    offset = 0
+                elif offset > dist_range:
+                    offset = dist_range
+                r_factor = 1.0 - (offset / dist_range)
             text_size *= r_factor
         # set the text size
         blf.size(font_id, text_size)

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -148,9 +148,17 @@ class BaseAnnotationProperties(bpy.types.PropertyGroup):
     )  # type: ignore
 
     text_depth: BoolProperty(
-        name="Text depth",
+        name="Text Depth",
         description="Adjust text size to show depth",
         default=False,
+    )  # type: ignore
+
+    text_falloff: FloatProperty(
+        name="Text Falloff",
+        description="Text size falloff factor",
+        default=1.0,
+        min=0.0,
+        max=1.0,
     )  # type: ignore
 
     offset_x: IntProperty(

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -147,6 +147,12 @@ class BaseAnnotationProperties(bpy.types.PropertyGroup):
         max=360.0,
     )  # type: ignore
 
+    text_depth: BoolProperty(
+        name="Text depth",
+        description="Adjust text size to show depth",
+        default=False,
+    )  # type: ignore
+
     offset_x: IntProperty(
         name="Offset X",
         description="Offset in X direction",

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -980,7 +980,10 @@ class MN_PT_Annotations(bpy.types.Panel):
                     continue
                 if prop.type == "POINTER":
                     continue
-                panel.prop(item, prop.identifier)
+                row = panel.row()
+                row.prop(item, prop.identifier)
+                if prop.identifier == "text_falloff":
+                    row.enabled = item.text_depth
 
         row = box.row()
 


### PR DESCRIPTION
Hi @BradyAJohnston and @yuxuanzhuang , this PR adds support for text depth in annotations. This is currently disabled by default and the option is available at an annotation level. So, there is no change of functionality by default with respect to the previous PR. There is some code refactoring, but it is useful refactoring.

If the text depth option is enabled (at annotation level), the size of the text varies depending on its  position from the virtual viewport camera, creating a perception of depth. Without this, everything is of the same size and could look pretty flat. Currently only the text size is impacted with this option, but we could also include the alpha and even add a clip param to control how much gets displayed - especially in the case of any dense text.

Here is a short video that shows the difference with this option enabled and disabled:

https://github.com/user-attachments/assets/375b1aac-9ae9-4e7f-b96f-b14571931367

This is also not an expensive computation. Only the object bounding box coords are used to get the min and max viewport distance and the reduction factor is determined based on it. If you think this looks better, we could make this the default later after more testing.