### PR TITLE
Density Annotations and additions

### DIFF
--- a/molecularnodes/annotations/interface.py
+++ b/molecularnodes/annotations/interface.py
@@ -16,9 +16,13 @@ class AnnotationInterface:
     # these are bound dynamically along with any annotation inputs
     visible: bool
     text_color: np.ndarray | list | tuple
+    text_font: str
     text_size: int
     text_align: str
     text_rotation: float
+    text_vspacing: float
+    text_depth: bool
+    text_falloff: float
     offset_x: float
     offset_y: float
     line_color: np.ndarray | list | tuple

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -142,6 +142,13 @@ class BaseAnnotationProperties(bpy.types.PropertyGroup):
         default=True,
     )  # type: ignore
 
+    text_font: StringProperty(  # type: ignore
+        name="Text Font",
+        description="Custom font to use for the text",
+        subtype="FILE_PATH",
+        maxlen=0,
+    )
+
     text_color: FloatVectorProperty(
         name="Text Color",
         description="Font color",
@@ -176,6 +183,14 @@ class BaseAnnotationProperties(bpy.types.PropertyGroup):
         default=0.0,
         min=0.0,
         max=360.0,
+    )  # type: ignore
+
+    text_vspacing: FloatProperty(
+        name="Text Vertical Spacing",
+        description="Vertical Spacing in multiline text",
+        default=1.35,
+        min=1.0,
+        max=4.0,
     )  # type: ignore
 
     text_depth: BoolProperty(

--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -37,7 +37,9 @@ class MolecularEntity(
 
     @property
     def node_group(self) -> bpy.types.GeometryNodeTree:
-        return self.object.modifiers["MolecularNodes"].node_group
+        if "MolecularNodes" in self.object.modifiers:
+            return self.object.modifiers["MolecularNodes"].node_group
+        return None
 
     @property
     def tree(self) -> bpy.types.GeometryNodeTree:

--- a/molecularnodes/entities/density/annotations.py
+++ b/molecularnodes/entities/density/annotations.py
@@ -1,6 +1,9 @@
+import os
+import numpy as np
 from ...annotations.base import BaseAnnotation
 from ...annotations.manager import BaseAnnotationManager
 from ..annotations import Label2D, Label3D
+from ..base import EntityType
 
 
 class DensityAnnotation(BaseAnnotation):
@@ -34,11 +37,132 @@ class DensityAnnotationManager(BaseAnnotationManager):
 
     """
 
+    _entity_type = EntityType.DENSITY
     _classes = {}  # Entity class specific annotation classes
 
     def __init__(self, entity):
         super().__init__(entity)
         self._interfaces = {}  # Entity instance specific annotation interfaces
+
+
+class DensityInfo(DensityAnnotation):
+    """
+    Density Info Annotation
+
+    Attributes
+    ----------
+    location: tuple[float, float]
+        Normalized coordinates (0.0 - 1.0) of the postion in viewport / render
+
+    show_filename: bool
+        Whether or not to show the grid filename
+
+    show_threshold: bool
+        Whether or not to show the current threshold value
+
+    show_origin: bool
+        Whether or not to show the grid origin
+
+    show_delta: bool
+        Whether or not to show the grid delta
+
+    show_shape: bool
+        Whether or not to show the grid shape
+
+    custom_text: str
+        Any custom text to add at the end of the annotation
+
+    """
+
+    annotation_type = "density_info"
+
+    location: tuple[float, float] = (0.025, 0.05)
+    show_filename: bool = True
+    show_threshold: bool = True
+    show_origin: bool = True
+    show_delta: bool = True
+    show_shape: bool = True
+    custom_text: str = ""
+
+    def defaults(self) -> None:
+        params = self.interface
+        params.text_align = "left"
+
+    def validate(self) -> bool:
+        params = self.interface
+        x, y = params.location
+        if (not 0 <= x <= 1) or (not 0 <= y <= 1):
+            raise ValueError("Normalized coordinates should lie between 0 and 1")
+        return True
+
+    def draw(self) -> None:
+        params = self.interface
+        grid = self.density.grid
+        text = ""
+        if params.show_filename:
+            filename = os.path.basename(grid.metadata["filepath"])
+            text = f"Filename: {filename}"
+        if params.show_threshold:
+            if self.density.node_group:
+                threshold = self.density.styles[0].threshold
+                text = text + f"|Threshold: {threshold:.2f}"
+        if params.show_origin:
+            text = text + f"|Origin: {np.round(grid.origin, 2)}"
+        if params.show_delta:
+            text = text + f"|Delta: {np.round(grid.delta, 2)}"
+        if params.show_shape:
+            text = text + f"|Shape: {np.round(grid.grid.shape, 2)}"
+        if params.custom_text != "":
+            text = text + "|" + params.custom_text
+        # Draw text at normalized coordinates wrt viewport / render
+        self.draw_text_2d_norm(params.location, text)
+
+
+class DensityGridAxes(DensityAnnotation):
+    """
+    Density Grid Axes Annotation
+
+    Attributes
+    ----------
+    show_length: bool
+        Whether or not to show the length of the grid axes
+
+    units: str
+        Units to use for length. Default: Å
+
+    """
+
+    annotation_type = "grid_axes"
+
+    show_length: bool = False
+    units: str = "Å"
+
+    def defaults(self) -> None:
+        params = self.interface
+        params.text_depth = False
+        params.arrow_size = 10
+        params.text_color = (1.0, 1.0, 1.0, 0.5)
+        params.line_color = (1.0, 1.0, 1.0, 0.5)
+
+    def draw(self) -> None:
+        params = self.interface
+        grid = self.density.grid
+        if grid.origin.size != 3:
+            return
+        origin = grid.origin.copy()
+        if grid.metadata["center"]:
+            origin += -np.array(grid.grid.shape) * 0.5 * grid.delta
+        axes = ["X", "Y", "Z"]
+        for i in range(3):
+            length = grid.grid.shape[i] * grid.delta[i]
+            mid_text = None
+            if params.show_length:
+                mid_text = f"{length:.2f} {params.units}"
+            end = origin.copy()
+            end[i] += length
+            self.draw_line_3d(
+                v1=origin, v2=end, mid_text=mid_text, v2_text=axes[i], v2_arrow=True
+            )
 
 
 class Label2D(DensityAnnotation, Label2D):

--- a/molecularnodes/entities/density/grids.py
+++ b/molecularnodes/entities/density/grids.py
@@ -62,6 +62,7 @@ class Grids(Density):
         if name and name != "":
             self.name = name
 
+        # TODO: setup_nodes is unused. Using it causes pytest failures
         node_density = self.create_starting_node_tree(style=style)
         # set the active index for UI to the added style
         self.object.mn.styles_active_index = self.tree.nodes.find(node_density.name)
@@ -142,7 +143,12 @@ class Grids(Density):
         if file.endswith((".map", ".map.gz", ".map.bz2")):
             file_format = "mrc"
 
-        gobj = Grid(file, file_format=file_format)
+        metadata = {
+            "filepath": file,
+            "invert": invert,
+            "center": center,
+        }
+        gobj = Grid(file, file_format=file_format, metadata=metadata)
         if invert:
             gobj.grid = np.max(gobj.grid) - gobj.grid
         self.grid = gobj

--- a/molecularnodes/entities/molecule/annotations.py
+++ b/molecularnodes/entities/molecule/annotations.py
@@ -1,6 +1,8 @@
+from biotite.structure import AtomArrayStack
 from ...annotations.base import BaseAnnotation
 from ...annotations.manager import BaseAnnotationManager
 from ..annotations import Label2D, Label3D
+from ..base import EntityType
 
 
 class MoleculeAnnotation(BaseAnnotation):
@@ -34,11 +36,68 @@ class MoleculeAnnotationManager(BaseAnnotationManager):
 
     """
 
+    _entity_type = EntityType.MOLECULE
     _classes = {}  # Entity class specific annotation classes
 
     def __init__(self, entity):
         super().__init__(entity)
         self._interfaces = {}  # Entity instance specific annotation interfaces
+
+
+class MoleculeInfo(MoleculeAnnotation):
+    """
+    Molecule Info Annotation
+
+    Attributes
+    ----------
+    location: tuple[float, float]
+        Normalized coordinates (0.0 - 1.0) of the postion in viewport / render
+
+    show_models: bool
+        Whether or not to show the number of models in the molecule
+
+    show_atoms: bool
+        Whether or not to show the number of atoms in the molecule
+
+    custom_text: str
+        Any custom text to add at the end of the annotation
+
+    """
+
+    annotation_type = "molecule_info"
+
+    location: tuple[float, float] = (0.025, 0.05)
+    show_models: bool = True
+    show_atoms: bool = True
+    custom_text: str = ""
+
+    def defaults(self) -> None:
+        params = self.interface
+        params.text_align = "left"
+
+    def validate(self) -> bool:
+        params = self.interface
+        x, y = params.location
+        if (not 0 <= x <= 1) or (not 0 <= y <= 1):
+            raise ValueError("Normalized coordinates should lie between 0 and 1")
+        return True
+
+    def draw(self) -> None:
+        params = self.interface
+        molecule = self.molecule
+        text = ""
+        if params.show_models:
+            text = f"Models: {molecule.n_models}"
+        if params.show_atoms:
+            array = molecule.array
+            if isinstance(array, AtomArrayStack):
+                text = text + f"|Atoms[0]: {len(array[0])}"
+            else:
+                text = text + f"|Atoms: {len(array)}"
+        if params.custom_text != "":
+            text = text + "|" + params.custom_text
+        # Draw text at normalized coordinates wrt viewport / render
+        self.draw_text_2d_norm(params.location, text)
 
 
 class Label2D(MoleculeAnnotation, Label2D):

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -5,6 +5,7 @@ from MDAnalysis.core.groups import AtomGroup
 from ...annotations.base import BaseAnnotation
 from ...annotations.manager import BaseAnnotationManager
 from ..annotations import Label2D, Label3D
+from ..base import EntityType
 
 
 class TrajectoryAnnotation(BaseAnnotation):
@@ -38,6 +39,7 @@ class TrajectoryAnnotationManager(BaseAnnotationManager):
 
     """
 
+    _entity_type = EntityType.MD
     _classes = {}  # Entity class specific annotation classes
 
     def __init__(self, entity):
@@ -180,6 +182,10 @@ class COMDistance(TrajectoryAnnotation):
     selection2: str | AtomGroup
     text1: str = "COM1"
     text2: str = "COM2"
+
+    def defaults(self) -> None:
+        params = self.interface
+        params.arrow_size = 10
 
     def validate(self) -> bool:
         params = self.interface

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -896,8 +896,9 @@ def _register_temp_annotation_add_op(entity):
     for cls in entity.annotations._classes.values():
         AnnotationTypeInputs = create_annotation_type_inputs(cls)
         register(AnnotationTypeInputs)
-        attributes["__annotations__"][cls.annotation_type] = bpy.props.PointerProperty(
-            type=AnnotationTypeInputs
+        entity_annotation_type = f"{entity._entity_type.value}_{cls.annotation_type}"
+        attributes["__annotations__"][entity_annotation_type] = (
+            bpy.props.PointerProperty(type=AnnotationTypeInputs)
         )
     AnnotationProps = type("AnnotationProps", (bpy.types.PropertyGroup,), attributes)
     register(AnnotationProps)
@@ -913,7 +914,8 @@ def _register_temp_annotation_add_op(entity):
         def draw(self, context):
             layout = self.layout
             layout.prop(self.props, "type")
-            inputs = getattr(self.props, self.props.type, None)
+            entity_annotation_type = f"{entity._entity_type.value}_{self.props.type}"
+            inputs = getattr(self.props, entity_annotation_type, None)
             if inputs is not None:
                 for prop_name in inputs.__annotations__.keys():
                     if prop_name in ("uuid", "valid_inputs"):
@@ -928,7 +930,8 @@ def _register_temp_annotation_add_op(entity):
                 return {"CANCELLED"}
             annotation_class = entity.annotations._classes[self.props.type]
             api_inputs = {}
-            ui_inputs = getattr(self.props, self.props.type, None)
+            entity_annotation_type = f"{entity._entity_type.value}_{self.props.type}"
+            ui_inputs = getattr(self.props, entity_annotation_type, None)
             if ui_inputs is not None:
                 for prop_name in ui_inputs.__annotations__.keys():
                     if prop_name in ui_inputs:

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -782,6 +782,8 @@ class MN_PT_Styles(bpy.types.Panel):
         uuid = scene.mn.entities[entities_active_index].name
         entity = scene.MNSession.get(uuid)
         node_group = entity.node_group
+        if node_group is None:
+            return
         styles_active_index = entity.object.mn.styles_active_index
         valid_selection = False
         style_nodes = get_final_style_nodes(node_group)
@@ -953,7 +955,8 @@ class MN_PT_Annotations(bpy.types.Panel):
         row = box.row()
         row.prop(item, "type")
         row.enabled = False
-        inputs = getattr(item, item.type, None)
+        entity_annotation_type = f"{entity._entity_type.value}_{item.type}"
+        inputs = getattr(item, entity_annotation_type, None)
         instance = entity.annotations._interfaces.get(inputs.uuid)._instance
         if inputs is not None:
             if not inputs.valid_inputs:


### PR DESCRIPTION
* Add density info and density grid axes annotations
* Add custom font configuration for text (works for both viewport and renders)
* Add molecule info annotation
* Separate annotation types per entity (to avoid any name collisions)
* Add vertical spacing support for multiline text
* Tests for new molecule and density annotations