### PR TITLE
Add support to override common annotation params

### DIFF
--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -53,16 +53,24 @@ def create_annotation_type_inputs(
                 update=_create_update_callback(update_callback, attr),
             )
         elif hasattr(stype, "__name__") and stype.__name__ == "tuple":
+            subtype = "NONE"
             if str(stype) == "tuple[float, float]":
                 size = 2
                 default = (0.0, 0.0)
             elif str(stype) == "tuple[float, float, float]":
                 size = 3
                 default = (0.0, 0.0, 0.0)
+            elif str(stype) == "tuple[float, float, float, float]":
+                size = 4
+                default = (0.0, 0.0, 0.0, 0.0)
+                if "color" in attr.lower():
+                    default = (1.0, 1.0, 1.0, 1.0)
+                    subtype = "COLOR"
             else:
                 continue
             prop = FloatVectorProperty(
                 size=size,
+                subtype=subtype,
                 default=getattr(annotation_class, attr, default),
                 update=_create_update_callback(update_callback, attr),
             )

--- a/molecularnodes/annotations/utils.py
+++ b/molecularnodes/annotations/utils.py
@@ -25,6 +25,7 @@ def get_blender_supported_type(atype):
         float,
         tuple[float, float],
         tuple[float, float, float],
+        tuple[float, float, float, float],
     )
     if atype in supported_types:
         return atype


### PR DESCRIPTION
* Add support for color tuple in annotation inputs

Hi @BradyAJohnston , @yuxuanzhuang , this PR adds support to override common annotation params when write annotation code. This does not change any existing functionality, but will allow advanced annotations that can have different font sizes, colors etc within the same annotation type. Users will also be able to create inputs that will automatically show up in the GUI as well to control any of these. This can come in quite handy for a complex annotations that have a lot of detail to show / draw. Thanks