### PR TITLE
Fixes 933

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "PyYAML",
 ]
 maintainers = [{ name = "Brady Johnston", email = "brady.johnston@me.com" }]
-requires-python = "~=3.11"
+requires-python = "~=3.11.0"
 
 [project.urls]
 Homepage = "https://bradyajohnston.github.io/MolecularNodes"


### PR DESCRIPTION
Fixes #933 

Makes python version in `pyproject.toml` more specific to 3.11.X rather than ~3.11