### PR TITLE
Fix entity type discrepancies

### DIFF
--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -12,13 +12,16 @@ from ..nodes.geometry import (
 )
 
 
-# create a EntityType enum with strings for values, "md", "md-oxdna", "molecule", "star"
+# create a EntityType enum
+# These should match the entity_type EnumProperty in props.py
 class EntityType(Enum):
     MD = "md"
     MD_OXDNA = "md-oxdna"
     MOLECULE = "molecule"
     ENSEMBLE = "ensemble"
     DENSITY = "density"
+    ENSEMBLE_STAR = "ensemble-star"
+    ENSEMBLE_CELLPACK = "ensemble-cellpack"
 
 
 class MolecularEntity(

--- a/molecularnodes/entities/ensemble/cellpack.py
+++ b/molecularnodes/entities/ensemble/cellpack.py
@@ -8,13 +8,14 @@ from ... import blender as bl
 from ... import color
 from ...nodes import nodes
 from ..utilities import create_object
-from .base import Ensemble
+from .base import Ensemble, EntityType
 from .reader import CellPackReader
 
 
 class CellPack(Ensemble):
     def __init__(self, file_path):
         super().__init__(file_path)
+        self._entity_type = EntityType.ENSEMBLE_CELLPACK
         self.file_type = self._file_type()
         self.file = CellPackReader(file_path)
         self.file.get_molecules()
@@ -22,6 +23,7 @@ class CellPack(Ensemble):
         self.color_entity = {}
         self._color_palette_path = Path(file_path).parent / "color_palette.json"
         self.object = self._create_data_object(name=f"{Path(file_path).name}")
+        self.object.mn.entity_type = self._entity_type.value
         self._create_object_instances(name=self.object.name, node_setup=False)
         self._setup_node_tree(fraction=0.1)
         # self._setup_colors()
@@ -80,6 +82,7 @@ class CellPack(Ensemble):
                 name=mol_id,
                 collection=collection,
             )
+            obj.mn.entity_type = self._entity_type.value
 
             if len(self.color_entity) > 0:
                 self._assign_colors(obj, array)

--- a/molecularnodes/entities/ensemble/star.py
+++ b/molecularnodes/entities/ensemble/star.py
@@ -11,7 +11,7 @@ from PIL import Image
 from scipy.spatial.transform import Rotation
 from ... import blender as bl
 from ...nodes import nodes
-from .base import Ensemble
+from .base import Ensemble, EntityType
 
 
 class EnsembleDataFrame:
@@ -152,6 +152,7 @@ class StarFile(Ensemble):
         super().__init__(file_path)
         self.type: str = "starfile"
         self.current_image: int = -1
+        self._entity_type = EntityType.ENSEMBLE_STAR
 
     @classmethod
     def from_starfile(cls, file_path: Union[str, Path]) -> "StarFile":
@@ -281,8 +282,8 @@ class StarFile(Ensemble):
         self.object = databpy.create_object(
             self.df.coordinates_scaled * world_scale, collection=bl.coll.mn(), name=name
         )
+        self.object.mn.entity_type = self._entity_type.value
         self.df.store_data_on_object(self.object)
-        self.object.mn["entity_type"] = "star"  # type: ignore
 
         if node_setup:
             nodes.create_starting_nodes_starfile(self.object)

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -86,6 +86,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
             name=name,
             collection=bl.coll.mn(),
         )
+        self.object.mn.entity_type = self._entity_type.value
         if self._reader is not None:
             self._store_object_custom_properties(self.object, self._reader)
         self._setup_frames_collection()
@@ -218,7 +219,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
             code=code, format=format, database=database
         )
         mol = cls.load(file_path, name=code, remove_solvent=remove_solvent)
-        mol.object.mn["entity_type"] = "molecule"
         mol._code = code
 
         return mol

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -330,12 +330,16 @@ class MolecularNodesObjectProperties(PropertyGroup):
         name="Entity Type",
         description="How the file was imported, dictating how MN interacts with it",
         items=(
+            ("None", "None", "Not an MN entity"),
             ("molecule", "Molecule", "A single molecule"),
             ("ensemble", "Ensemble", "A collection of molecules"),
-            ("density", "Density", "An electron density map"),
+            ("density", "Density", "A density grid"),
             ("md", "Trajectory", "A molecular dynamics trajectory"),
             ("md-oxdna", "oxDNA Trajectory", "A oxDNA molecular dynamics trajectory "),
+            ("ensemble-star", "Star Ensemble", "A starfile ensemble"),
+            ("ensemble-cellpack", "CellPack Ensemble", "A CellPack model ensemble"),
         ),
+        default="None",
     )
 
     code: StringProperty(  # type: ignore

--- a/tests/test_cellpack.py
+++ b/tests/test_cellpack.py
@@ -42,6 +42,8 @@ def test_load_cellpack(snapshot, format):
     file_path = data_dir / f"cellpack/square1.{format}"
 
     ens = mn.entities.ensemble.load_cellpack(file_path, node_setup=False, fraction=0.1)
+    assert ens._entity_type == mn.entities.base.EntityType.ENSEMBLE_CELLPACK
+    assert ens.object.mn.entity_type == ens._entity_type.value
 
     assert ens.name == Path(file_path).name
     assert snapshot == str(ens.object["chain_ids"])

--- a/tests/test_dna.py
+++ b/tests/test_dna.py
@@ -123,6 +123,8 @@ class TestOXDNAReading:
         traj.create_object()
 
         assert isinstance(session.get(traj.uuid), oxdna.OXDNA)
+        assert traj._entity_type == mn.entities.base.EntityType.MD_OXDNA
+        assert traj.object.mn.entity_type == traj._entity_type.value
 
     def test_reload_lost_connection(self, snapshot, file_holl_top, file_holl_dat):
         session = mn.session.get_session()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -43,6 +43,8 @@ def test_style_1(snapshot_custom: NumpySnapshotExtension, assembly, code, style)
 )
 def test_download_format(code, format):
     mol = mn.Molecule.fetch(code, format=format, cache=data_dir)
+    assert mol._entity_type == mn.entities.base.EntityType.MOLECULE
+    assert mol.object.mn.entity_type == mol._entity_type.value
     with db.ObjectTracker() as o:
         bpy.ops.mn.import_fetch(code=code, file_format=format, cache_dir=str(data_dir))
         mol2 = bpy.context.scene.MNSession.match(o.latest())
@@ -126,6 +128,8 @@ def test_rcsb_nmr(snapshot_custom):
 
 def test_load_small_mol(snapshot_custom):
     mol = mn.Molecule.load(data_dir / "ASN.cif")
+    assert mol._entity_type == mn.entities.base.EntityType.MOLECULE
+    assert mol.object.mn.entity_type == mol._entity_type.value
     for att in ["position", "bond_type"]:
         assert snapshot_custom == mol.named_attribute(att).tolist()
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -43,6 +43,8 @@ def test_op_fetch_alphafold(tmpdir):
             database="alphafold",
         )
         mol = scene.MNSession.match(o.latest())
+        assert mol._entity_type == mn.entities.base.EntityType.MOLECULE
+        assert mol.object.mn.entity_type == mol._entity_type.value
 
     assert mol.name == "Q7Z434"
 
@@ -58,6 +60,8 @@ def test_op_local(snapshot_custom, code, file_format):
     with ObjectTracker() as o:
         bpy.ops.mn.import_local(filepath=str(path), node_setup=False)
         mol = session.match(o.latest())
+        assert mol._entity_type == mn.entities.base.EntityType.MOLECULE
+        assert mol.object.mn.entity_type == mol._entity_type.value
 
     with ObjectTracker() as o:
         bpy.ops.mn.import_local(filepath=str(path), centre=True, centre_type="centroid")
@@ -83,6 +87,8 @@ def test_op_api_mda(snapshot_custom: NumpySnapshotExtension):
 
     traj_op = bpy.context.scene.MNSession.match(obj_1)
     assert traj_op.name == name
+    assert traj_op._entity_type == mn.entities.base.EntityType.MD
+    assert traj_op.object.mn.entity_type == traj_op._entity_type.value
 
     traj_func = mn.entities.trajectory.load(topo, traj, name="test", style="ribbon")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -41,8 +41,10 @@ def universe():
 
 def test_add_trajectory(session, universe):
     # add Universe as trajectory
-    session.add_trajectory(universe, name="u1")
+    t1 = session.add_trajectory(universe, name="u1")
     assert "u1" in bpy.data.objects
+    assert t1._entity_type == mn.entities.base.EntityType.MD
+    assert t1.object.mn.entity_type == t1._entity_type.value
     # add AtomGroup as trajectory
     ag = universe.select_atoms("name CA")
     session.add_trajectory(ag, name="ag1")

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -39,6 +39,8 @@ def test_starfile_attributes(type):
 def test_load_starfiles():
     file = data_dir / "starfile/clathrin.star"
     _ensemble = mn.entities.ensemble.load_starfile(file)
+    assert _ensemble._entity_type == mn.entities.base.EntityType.ENSEMBLE_STAR
+    assert _ensemble.object.mn.entity_type == _ensemble._entity_type.value
 
 
 def test_categorical_attributes():


### PR DESCRIPTION
* Add new entity types for star and cellpack entities
* Add a None entity type that is default for blender objects
* Ensure entity's type and object's mn.entity_type match for all cases
* Show a read-only entity type in the 3D viewport panel under entities
* Add tests to match entity's type and corresponding object mn.entity_type for all cases that add entities to scene

This PR should address issues outlined in issue #930 