### PR TITLE
Fix for bpy reporting test failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,11 @@ jobs:
       - uses: actions/checkout@v4
       # - uses: quarto-dev/quarto-actions/setup@v2
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
         
       - name: Install Packages
         run: |
@@ -30,7 +31,7 @@ jobs:
         timeout-minutes: 3
         continue-on-error: true
         run: |
-          uv run generate.py
+          uv run docs/generate.py
       - name: Pre-render Scripts
         run: |
           cd docs
@@ -60,7 +61,7 @@ jobs:
       # deploy ----
 
       - name: Create Github Deployment
-        uses: bobheadxi/deployments@v0.4.3
+        uses: bobheadxi/deployments@v1
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: deployment
         with:
@@ -88,8 +89,9 @@ jobs:
 
       - name: Update Github Deployment
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: bobheadxi/deployments@v0.4.3
+        uses: bobheadxi/deployments@v1
         with:
+          env: ${{ steps.deployment.outputs.deployment_id }}
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
@@ -98,7 +100,7 @@ jobs:
           logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           
       - name: Deploy Release Documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.event_name == 'release'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,16 +27,23 @@ jobs:
           uv sync --all-extras
       
       - name: Pre-render Scripts
+        timeout-minutes: 3
+        continue-on-error: true
+        run: |
+          uv run generate.py
+      - name: Pre-render Scripts
         run: |
           cd docs
-          uv run generate.py
           uv run quartodoc build
           uv run quartodoc interlinks
           cd ..
       
-      - name: Render Docs
+      - name: Biotite Setup CCD
         run: |
           uv run python -m biotite.setup_ccd
+        
+      - name: Quarto Render Docs
+        run: |
           uv run quarto render docs
   
       - name: Configure pull release name

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
       # deploy ----
 
       - name: Create Github Deployment
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@v0.4.3
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: deployment
         with:
@@ -89,9 +89,8 @@ jobs:
 
       - name: Update Github Deployment
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@v0.4.3
         with:
-          env: ${{ steps.deployment.outputs.deployment_id }}
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,9 +55,42 @@ jobs:
                 uv sync --all-extras
             - name: Run Tests "not density"
               run: |
-                uv run pytest -n auto -k "not density"
+                uv run pytest -n auto -k "not density" --junitxml=test-results-1.xml || echo "TEST_RESULT_1=$?" >> $GITHUB_ENV
                 
             - name: Run Tests "density"
               run: |
-                uv run pytest -k density
+                uv run pytest -k density --junitxml=test-results-2.xml || echo "TEST_RESULT_2=$?" >> $GITHUB_ENV
+                
+            - name: Check Test Results
+              run: |
+                # Check if test result files exist and contain failures
+                FAILED=false
+                
+                if [ -f "test-results-1.xml" ]; then
+                  if grep -q 'failures="[^0]' test-results-1.xml || grep -q 'errors="[^0]' test-results-1.xml; then
+                    echo "Tests 'not density' had failures"
+                    FAILED=true
+                  fi
+                else
+                  echo "Test results file 1 not found, assuming failure"
+                  FAILED=true
+                fi
+                
+                if [ -f "test-results-2.xml" ]; then
+                  if grep -q 'failures="[^0]' test-results-2.xml || grep -q 'errors="[^0]' test-results-2.xml; then
+                    echo "Tests 'density' had failures"
+                    FAILED=true
+                  fi
+                else
+                  echo "Test results file 2 not found, assuming failure"
+                  FAILED=true
+                fi
+                
+                if [ "$FAILED" = true ]; then
+                  echo "Tests failed"
+                  exit 1
+                else
+                  echo "All tests passed successfully"
+                  exit 0
+                fi
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
             fail-fast: false
             matrix:
               version: ["4.5"]
-              os: [ubuntu-latest, macos-latest, windows-latest]
+              os: [ubuntu-latest, macos-latest]
         steps:
             - uses: actions/checkout@v4
             - name: Install uv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,12 +54,14 @@ jobs:
               run: |
                 uv sync --all-extras
             - name: Run Tests "not density"
+              timeout-minutes: 10
               run: |
-                uv run pytest -n auto -k "not density" --junitxml=test-results-1.xml || echo "TEST_RESULT_1=$?" >> $GITHUB_ENV
+                timeout 600 uv run pytest -n auto -k "not density" --junitxml=test-results-1.xml || echo "TEST_RESULT_1=$?" >> $GITHUB_ENV
                 
-            - name: Run Tests "density"
+            - name: Run Tests "density" 
+              timeout-minutes: 5
               run: |
-                uv run pytest -k density --junitxml=test-results-2.xml || echo "TEST_RESULT_2=$?" >> $GITHUB_ENV
+                timeout 300 uv run pytest -k density --junitxml=test-results-2.xml || echo "TEST_RESULT_2=$?" >> $GITHUB_ENV
                 
             - name: Check Test Results
               run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,12 +54,14 @@ jobs:
               run: |
                 uv sync --all-extras
             - name: Run Tests "not density"
-              timeout-minutes: 10
+              timeout-minutes: 5
+              continue-on-error: true
               run: |
                 uv run pytest -n auto -k "not density" --junitxml=test-results-1.xml || echo "TEST_RESULT_1=$?" >> $GITHUB_ENV
                 
             - name: Run Tests "density" 
-              timeout-minutes: 5
+              timeout-minutes: 3
+              continue-on-error: true
               run: |
                 uv run pytest -k density --junitxml=test-results-2.xml || echo "TEST_RESULT_2=$?" >> $GITHUB_ENV
                 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,12 @@ jobs:
             - name: Run Tests "not density"
               timeout-minutes: 10
               run: |
-                timeout 600 uv run pytest -n auto -k "not density" --junitxml=test-results-1.xml || echo "TEST_RESULT_1=$?" >> $GITHUB_ENV
+                uv run pytest -n auto -k "not density" --junitxml=test-results-1.xml || echo "TEST_RESULT_1=$?" >> $GITHUB_ENV
                 
             - name: Run Tests "density" 
               timeout-minutes: 5
               run: |
-                timeout 300 uv run pytest -k density --junitxml=test-results-2.xml || echo "TEST_RESULT_2=$?" >> $GITHUB_ENV
+                uv run pytest -k density --junitxml=test-results-2.xml || echo "TEST_RESULT_2=$?" >> $GITHUB_ENV
                 
             - name: Check Test Results
               run: |

--- a/docs/data_table.qmd
+++ b/docs/data_table.qmd
@@ -7,7 +7,7 @@ fig-align: center
 
 The different lookup tables that are used to conver strings to integers in Molecular Nodes.
 
-Code for this can be found on the [GitHub Page](https://github.com/BradyAJohnston/MolecularNodes/blob/main/molecularnodes/data.py)
+Code for this can be found on the [GitHub Page](https://github.com/BradyAJohnston/MolecularNodes/blob/main/molecularnodes/assets/data.py)
 
 ### Residue Names
 
@@ -54,6 +54,7 @@ Code for this can be found on the [GitHub Page](https://github.com/BradyAJohnsto
 | C | `41::Int` |
 | G | `42::Int` |
 | U | `43::Int` |
+| T | `43::Int` |
 
 
 ### Atom Names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "mrcfile",
     "starfile",
     "PyYAML",
-    "nodepad>=0.2.0",
 ]
 maintainers = [{ name = "Brady Johnston", email = "brady.johnston@me.com" }]
 requires-python = "~=3.11.0"
@@ -23,7 +22,7 @@ Documentation = "https://bradyajohnston.github.io/MolecularNodes"
 [project.optional-dependencies]
 bpy = ["bpy>=4.5.2, <5.0.0"]
 jupyter = ["jupyter", "IPython"]
-dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython"]
+dev = ["pytest", "pytest-cov", "syrupy", "scipy", "fake-bpy-module", "IPython", "nodepad>=0.2.0"]
 test = ["pytest", "pytest-cov", "syrupy", "scipy", "IPython", "pytest-xdist", "MDAnalysisTests>=2.7.0", "MDAnalysisData"]
 docs = ["quartodoc", "tomlkit", "nodepad", "jupyter", "IPython", "jupyter-cache", "MDAnalysisTests>=2.7.0", "MDAnalysisData"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,6 @@ dependencies = [
     { name = "databpy" },
     { name = "mdanalysis" },
     { name = "mrcfile" },
-    { name = "nodepad" },
     { name = "pyyaml" },
     { name = "starfile" },
 ]
@@ -1227,6 +1226,7 @@ bpy = [
 dev = [
     { name = "fake-bpy-module" },
     { name = "ipython" },
+    { name = "nodepad" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "scipy" },
@@ -1276,7 +1276,7 @@ requires-dist = [
     { name = "mdanalysistests", marker = "extra == 'docs'", specifier = ">=2.7.0" },
     { name = "mdanalysistests", marker = "extra == 'test'", specifier = ">=2.7.0" },
     { name = "mrcfile" },
-    { name = "nodepad", specifier = ">=0.2.0" },
+    { name = "nodepad", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "nodepad", marker = "extra == 'docs'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'test'" },


### PR DESCRIPTION
This was previously a problem with bpy <4.4, seems to have become a problem again with bpy 4.5. Even though all pytest tests pass, bpy cleanup reports an error and such an exit code of 1 and and the GHA reports a failure even though tests pass.

- **move nodepad to optional**
- **a fix for bpy tests**
