### PR TITLE
Fix for empty material creation in 5.0

### DIFF
--- a/molecularnodes/nodes/material.py
+++ b/molecularnodes/nodes/material.py
@@ -445,7 +445,7 @@ def create_material(
     except KeyError:
         output = tree.nodes.new("ShaderNodeOutputMaterial")
         bsdf = tree.nodes.new("ShaderNodeBsdfPrincipled")
-        bsdf.location -= (200, 0)
+        bsdf.location = (-200, 0)
         tree.links.new(bsdf.outputs["BSDF"], output.inputs["Surface"])
 
     for input_socket in bsdf.inputs:


### PR DESCRIPTION
Fixes #979 

Workflow: https://github.com/BradyAJohnston/MolecularNodes/actions/runs/17750491611/job/50444329907#step:5:776

It seems that creating a new material via `bpy.data.materials.new()` no longer starts with a BSDF and output node.

```py
        mat = bpy.data.materials.new(name)
        mat.use_nodes = True
        bsdf = mat.node_tree.nodes.get("Principled BSDF")
    
>       for input_socket in bsdf.inputs:
                            ^^^^^^^^^^^
E       AttributeError: 'NoneType' object has no attribute 'inputs'
```

Materials created no longer require `use_nodes = True` and a new material created through `bpy.data.materials.new()` no longer starts with an output or BSDF node and is completely empty.