### PR TITLE
BUG, BLD: package annotation font

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,10 @@ where = ["."]
 exclude = ["molecularnodes.nodes._generation*"]
 
 [tool.setuptools.package-data]
-molecularnodes = ["assets/*", "assets/template/*", "**/*.py"]
+molecularnodes = ["assets/*",
+                  "assets/template/*",
+                  "**/*.py",
+                  "annotations/fonts/*"]
 
 
 [tool.ruff.lint]


### PR DESCRIPTION
* The annotation font assets are not being packaged for `MolecularNodes` wheel builds at the moment (same goes for `python -m pip install -v .` locally, which, after all, just builds a wheel and installs it). This patch explicitly adds the font assets to packaging/wheel builds, such that `pip install -v .` again enables proper rendering of annotations on this branch and the related parts of gh-981 are addressed.

* What hasn't been done here yet, but probably should, is the addition of i.e., a wheel build CI job that would be sensitive to missing packaged asset(s). Could just copy the structure of those from upstream projects if needed.

* Also nice would be erroring out rather than silently running to the end with no font available when trying to render a canvas in this fontless situation. I know there are sometimes issues with propagated Blender errors up to MN though.