### PR TITLE
Annotation line meshes

### DIFF
--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -573,6 +573,20 @@ class BaseAnnotation(metaclass=ABCMeta):
         """Internal: Draw line 3D or 2D"""
         if v1 is None or v2 is None:
             return
+
+        if is3d and self.geometry is not None:
+            geometry = self.geometry
+            i = len(geometry["vertices"])
+            # add the ends of line as vertices
+            geometry["vertices"].append(Vector(v1) * self._world_scale)
+            geometry["vertices"].append(Vector(v2) * self._world_scale)
+            # add an edge
+            geometry["edges"].append((i, i + 1))
+            params = _get_params(self.interface, overrides)
+            # add resolved params to be added as attributes
+            geometry["color"].append(params.mesh_color)
+            geometry["thickness"].append(params.mesh_thickness)
+
         self._draw_arrow_line(
             v1, v2, v1_arrow, v2_arrow, is3d=is3d, overrides=overrides
         )
@@ -639,6 +653,9 @@ class BaseAnnotation(metaclass=ABCMeta):
         if v1 is None or v2 is None:
             return
         params = _get_params(self.interface, overrides)
+        if params.line_mesh and not params.line_overlay:
+            # only draw overlays when enabled in mesh mode
+            return
         rgba = params.line_color
         line_width = params.line_width * self._scale
         if self._render_mode:

--- a/molecularnodes/annotations/interface.py
+++ b/molecularnodes/annotations/interface.py
@@ -1,3 +1,4 @@
+import bpy
 import numpy as np
 
 
@@ -15,6 +16,7 @@ class AnnotationInterface:
     # py annotations of common params for code complete
     # these are bound dynamically along with any annotation inputs
     visible: bool
+    text_font: str
     text_color: np.ndarray | list | tuple
     text_font: str
     text_size: int
@@ -29,6 +31,11 @@ class AnnotationInterface:
     line_width: float
     arrow_size: int
     pointer_length: int
+    line_mesh: bool
+    line_overlay: bool
+    mesh_color: np.ndarray | list | tuple
+    mesh_thickness: float
+    mesh_material: str | bpy.types.Material
 
     def __init__(self, instance):
         self._instance = instance

--- a/molecularnodes/annotations/node_tree.py
+++ b/molecularnodes/annotations/node_tree.py
@@ -1,0 +1,102 @@
+import bpy
+
+
+def annotations_node_tree():
+    node_group = bpy.data.node_groups.new(type="GeometryNodeTree", name="Annotations")
+    node_group.is_modifier = True
+
+    # Output Socket Geometry
+    node_group.interface.new_socket(
+        name="Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+    )
+
+    # Input Socket Geometry
+    node_group.interface.new_socket(
+        name="Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+    )
+
+    # initialize nodes
+    # node Group Input
+    group_input = node_group.nodes.new("NodeGroupInput")
+    group_input.name = "Group Input"
+
+    # node Group Output
+    group_output = node_group.nodes.new("NodeGroupOutput")
+    group_output.name = "Group Output"
+
+    # node Mesh to Curve
+    mesh_to_curve = node_group.nodes.new("GeometryNodeMeshToCurve")
+    mesh_to_curve.name = "Mesh to Curve"
+
+    # node Set Curve Radius
+    set_curve_radius = node_group.nodes.new("GeometryNodeSetCurveRadius")
+    set_curve_radius.name = "Set Curve Radius"
+
+    # node Thickness Attribute
+    thickness_attribute = node_group.nodes.new("GeometryNodeInputNamedAttribute")
+    thickness_attribute.name = "Thickness Attribute"
+    thickness_attribute.inputs["Name"].default_value = "thickness"
+
+    # node Curve Circle
+    curve_circle = node_group.nodes.new("GeometryNodeCurvePrimitiveCircle")
+    curve_circle.name = "Curve Circle"
+    curve_circle.inputs["Resolution"].default_value = 32
+    curve_circle.inputs["Radius"].default_value = 0.001
+
+    # node Curve to Mesh
+    curve_to_mesh = node_group.nodes.new("GeometryNodeCurveToMesh")
+    curve_to_mesh.name = "Curve to Mesh"
+    curve_to_mesh.inputs["Fill Caps"].default_value = True
+
+    # node Set Material
+    set_material = node_group.nodes.new("GeometryNodeSetMaterial")
+    set_material.name = "Set Material"
+    if "MN Default" in bpy.data.materials:
+        set_material.inputs["Material"].default_value = bpy.data.materials["MN Default"]
+
+    # Set locations
+    group_input.location = (-340.0, 0.0)
+    group_output.location = (560.0, 0.0)
+    mesh_to_curve.location = (-160.0, 0.0)
+    set_curve_radius.location = (20.0, 0.0)
+    thickness_attribute.location = (-160.0, -120.0)
+    curve_circle.location = (20.0, -140.0)
+    curve_to_mesh.location = (200.0, 0.0)
+    set_material.location = (380.0, 0.0)
+
+    # Set dimensions
+    group_input.width, group_input.height = 140.0, 100.0
+    group_output.width, group_output.height = 140.0, 100.0
+    mesh_to_curve.width, mesh_to_curve.height = 140.0, 100.0
+    set_curve_radius.width, set_curve_radius.height = 140.0, 100.0
+    thickness_attribute.width, thickness_attribute.height = 140.0, 100.0
+    curve_circle.width, curve_circle.height = 140.0, 100.0
+    curve_to_mesh.width, curve_to_mesh.height = 140.0, 100.0
+    set_material.width, set_material.height = 140.0, 100.0
+
+    # initialize links
+    # set_material.Geometry -> group_output.Geometry
+    node_group.links.new(
+        set_material.outputs["Geometry"], group_output.inputs["Geometry"]
+    )
+    # group_input.Geometry -> mesh_to_curve.Mesh
+    node_group.links.new(group_input.outputs["Geometry"], mesh_to_curve.inputs["Mesh"])
+    # mesh_to_curve.Curve -> set_curve_radius.Curve
+    node_group.links.new(
+        mesh_to_curve.outputs["Curve"], set_curve_radius.inputs["Curve"]
+    )
+    # thickness_attribute.Attribute -> set_curve_radius.Radius
+    node_group.links.new(
+        thickness_attribute.outputs["Attribute"], set_curve_radius.inputs["Radius"]
+    )
+    # set_curve_radius.Curve -> curve_to_mesh.Curve
+    node_group.links.new(
+        set_curve_radius.outputs["Curve"], curve_to_mesh.inputs["Curve"]
+    )
+    # curve_circle.Curve -> curve_to_mesh.Profile Curve
+    node_group.links.new(
+        curve_circle.outputs["Curve"], curve_to_mesh.inputs["Profile Curve"]
+    )
+    # curve_to_mesh.Mesh -> set_material.Geometry
+    node_group.links.new(curve_to_mesh.outputs["Mesh"], set_material.inputs["Geometry"])
+    return node_group

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -256,6 +256,7 @@ class CanonicalDihedrals(TrajectoryAnnotation):
     def defaults(self) -> None:
         params = self.interface
         params.arrow_size = 8
+        params.mesh_thickness = 0.1
 
     def validate(self) -> bool:
         params = self.interface

--- a/molecularnodes/entities/trajectory/base.py
+++ b/molecularnodes/entities/trajectory/base.py
@@ -630,6 +630,8 @@ class Trajectory(MolecularEntity):
         self._update_positions(frame)
         self._update_selections()
         self._update_calculations()
+        # update annotation object
+        self.annotations._update_annotation_object()
 
     def _position_at_frame(self, frame: int) -> np.ndarray:
         "Return the atom positions at the given universe frame number"

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -1020,17 +1020,38 @@ class MN_PT_Annotations(bpy.types.Panel):
         header.label(text="Options")
 
         if panel:
+            line_mesh_props = [
+                "line_overlay",
+                "mesh_color",
+                "mesh_thickness",
+                "mesh_material",
+            ]
             for prop in item.bl_rna.properties:
                 if not prop.is_runtime:
                     continue
                 if prop.identifier in ("label", "type", "visible"):
                     continue
-                if prop.type == "POINTER":
+                if prop.type == "POINTER" and prop.identifier != "mesh_material":
                     continue
-                row = panel.row()
-                row.prop(item, prop.identifier)
-                if prop.identifier == "text_falloff":
-                    row.enabled = item.text_depth
+                if prop.identifier not in line_mesh_props:
+                    if prop.identifier == "line_mesh":
+                        # create a new panel for line mesh props
+                        mesh_header, mesh_panel = panel.panel(
+                            "line_mesh", default_closed=False
+                        )
+                        mesh_header.prop(item, prop.identifier)
+                    else:
+                        # all other properties
+                        row = panel.row()
+                        row.prop(item, prop.identifier)
+                        if prop.identifier == "text_falloff":
+                            row.enabled = item.text_depth
+                else:
+                    if mesh_panel:
+                        # line mesh props
+                        row = mesh_panel.row()
+                        row.prop(item, prop.identifier)
+                        row.enabled = item.line_mesh
 
         row = box.row()
 

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -303,6 +303,11 @@ class MolecularNodesSceneProperties(PropertyGroup):
     )
 
 
+def _update_annotations_visibility(self, context):
+    entity = context.scene.MNSession.get(self.id_data.uuid)
+    entity.annotations._update_annotation_object()
+
+
 class MolecularNodesObjectProperties(PropertyGroup):
     styles_active_index: IntProperty(default=-1)  # type: ignore
     annotations_active_index: IntProperty(default=-1)  # type: ignore
@@ -312,6 +317,7 @@ class MolecularNodesObjectProperties(PropertyGroup):
         name="Visible",
         description="Visibility of all annotations",
         default=True,
+        update=_update_annotations_visibility,
     )
 
     biological_assemblies: StringProperty(  # type: ignore


### PR DESCRIPTION
Hi Brady, this PR adds support for showing annotation lines as 3d meshes as described in this [comment](https://github.com/BradyAJohnston/MolecularNodes/issues/981#issuecomment-3314601217) of issue #981

Here is an example of how this looks:

https://github.com/user-attachments/assets/d956a441-5591-4129-97d1-20681b139e4c

This is still a draft PR. Though material shows up in the GUI and API, it is not implemented yet (I might need your help here) and tests and documentation updates are not done yet. Creating this to unblock Adam and Tyler to see if this helps.