### PR TITLE
WIP, ENH: support small molecule renders

### DIFF
--- a/molecularnodes/entities/trajectory/base.py
+++ b/molecularnodes/entities/trajectory/base.py
@@ -113,6 +113,11 @@ class Trajectory(MolecularEntity):
 
     @property
     def atoms(self) -> mda.AtomGroup:
+        try:
+            self.universe.atoms.resnames
+        except mda.exceptions.NoDataError:
+            self.universe.add_TopologyAttr('resnames')
+            self.universe.residues.resnames = "N/A"
         return self.universe.atoms
 
     @property

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -333,6 +333,13 @@ class TestTrajectory:
         v4 = t1.get_view()
         assert v4 != v1 and v4 != v2 and v4 != v3
 
+    def test_gh_985(self):
+        # ensure that we can create a Trajectory
+        # from the SMILES representation of a simple molecule
+        ethanol_smiles = "CCO"
+        u = mda.Universe.from_smiles(ethanol_smiles)
+        traj = mn.Trajectory(u)
+
 
 @pytest.mark.parametrize("toplogy", ["pent/prot_ion.tpr", "pent/TOPOL2.pdb"])
 def test_martini(snapshot_custom: NumpySnapshotExtension, toplogy):


### PR DESCRIPTION
* Fixes gh-985

* Add a "N/A" resname to MDAnalysis Universes so that we may support render workflows with small molecules for which there is no clear resname (i.e., when consuming an MDAnalysis Universe generated from a short SMILES string)