### PR TITLE
Fix pickling/unpickling of annotation manager

### DIFF
--- a/molecularnodes/annotations/manager.py
+++ b/molecularnodes/annotations/manager.py
@@ -118,6 +118,18 @@ class BaseAnnotationManager(metaclass=ABCMeta):
         """Return annotation names"""
         return [i.name for i in self._interfaces.values()]
 
+    def __getstate__(self):
+        """Get state for pickling this object"""
+        state = self.__dict__.copy()
+        # Remove reference to Scene before pickling
+        del state["_scene"]
+        return state
+
+    def __setstate__(self, state):
+        """Set state when unpickling this object"""
+        self.__dict__.update(state)
+        self._scene = None
+
     @classmethod
     def register(cls, annotation_class) -> None:
         """


### PR DESCRIPTION
The following error (which shows up as a warning) is seen in the test logs:

```
tests/test_trajectory.py::TestTrajectory::test_save_persistance
  /home/runner/work/MolecularNodes/blender/5.1/python/lib/python3.11/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning: Exception ignored in: <function ReaderBase.__del__ at 0x7f267848a5c0>
  
  Traceback (most recent call last):
    File "/home/runner/work/MolecularNodes/blender/5.1/python/lib/python3.11/site-packages/MDAnalysis/coordinates/base.py", line 1531, in __del__
      for aux in self.aux_list:
                 ^^^^^^^^^^^^^
    File "/home/runner/work/MolecularNodes/blender/5.1/python/lib/python3.11/site-packages/MDAnalysis/coordinates/base.py", line 1175, in aux_list
      return self._auxs.keys()
             ^^^^^^^^^^
  AttributeError: 'XTCReader' object has no attribute '_auxs'
```

When the output capture is enabled, it shows the following root cause:

```
molecularnodes/session.py", line 320, in _pickle
    get_session().pickle(filepath)
molecularnodes/session.py", line 168, in pickle
    pk.dump(self, f)
TypeError: cannot pickle 'Scene' object
```

This leads to errors when unpickling as well. This PR removes the scene object used in the annotation manager from getting pickled and addresses the error and the related warning as well. Thanks