### PR TITLE
Fix: Filepath cross-platform

### DIFF
--- a/molecularnodes/entities/trajectory/base.py
+++ b/molecularnodes/entities/trajectory/base.py
@@ -655,9 +655,9 @@ class Trajectory(MolecularEntity):
                 )
 
                 if topology_filename is not None:
-                    state["_universe_topology"] = topology_filename
+                    state["_universe_topology"] = str(topology_filename)
                 if trajectory_filename is not None:
-                    state["_universe_trajectory"] = trajectory_filename
+                    state["_universe_trajectory"] = str(trajectory_filename)
 
             except AttributeError as e:
                 logger.warning(


### PR DESCRIPTION
Ensure filepaths are pickled as a string for cross-platform loading.

Fixes #859 

