### PR TITLE
Fix: Additional checks in render_pre_handler

### DIFF
--- a/molecularnodes/annotations/utils.py
+++ b/molecularnodes/annotations/utils.py
@@ -1,10 +1,13 @@
 import inspect
 import types
 import typing
+from typing import TYPE_CHECKING
 import bpy
 from PIL import Image
-from ..entities.trajectory import TrajectoryAnnotationManager
-from ..session import MNSession
+
+if TYPE_CHECKING:
+    from ..entities.trajectory import TrajectoryAnnotationManager
+    from ..session import MNSession
 
 
 def get_all_class_annotations(cls) -> dict:

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -1,10 +1,13 @@
+from typing import TYPE_CHECKING
 import bpy
 import numpy as np
 from bpy.app.handlers import persistent
 from PIL import Image
 from .annotations.utils import render_annotations
 from .scene.compositor import annotations_image
-from .session import MNSession
+
+if TYPE_CHECKING:
+    from .session import MNSession
 
 
 # this update function requires a self and context input, as funcitons with these inputs

--- a/uv.lock
+++ b/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "molecularnodes"
-version = "4.5.6"
+version = "4.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
Doesn't really fix issues with crashing during rendering but will reduce the number of users who encounter it. We return early if there aren't any entities or annotations on those entities so unless a user is using annotations directly they shouldn't encounter any issues.
