### PR TITLE
Fix annotations

### DIFF
--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -35,6 +35,7 @@ class MolecularEntity(
     metaclass=ABCMeta,
 ):
     update_with_scene = BoolObjectMNProperty("update_with_scene")
+    _entity_type: EntityType = None  # Overridden by derived classes
 
     def __init__(self) -> None:
         super().__init__(obj=None)
@@ -99,3 +100,18 @@ class MolecularEntity(
 
         """
         return blender_utils.get_bounding_box(self.object)
+
+    def _get_annotation_entity_type(self) -> str:
+        """
+        Internal: Get entity type string for annotations.
+
+        Subentities that derive from other entities can set this
+        to the parent entity type to re-use annotations of the parent.
+        By default, this returns the string value of the Entity type.
+
+        Eg: OXDNA and StreamingTrajectory that derive from Trajectory entity
+        can return EntityType.MD.value to re-use the annotations from
+        the parent Trajectory entity.
+
+        """
+        return self._entity_type.value

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -385,7 +385,7 @@ class UniverseInfo(TrajectoryAnnotation):
         params = self.interface
         u = self.trajectory.universe
         text = ""
-        if params.show_frame:
+        if params.show_frame and u.trajectory.n_frames is not None:
             text = f"Frame : {u.trajectory.frame} / {u.trajectory.n_frames - 1}"
         if params.show_topology and isinstance(u.filename, (str, Path)):
             text = text + "|Topology : " + os.path.basename(u.filename)

--- a/molecularnodes/entities/trajectory/imd.py
+++ b/molecularnodes/entities/trajectory/imd.py
@@ -144,3 +144,7 @@ class StreamingTrajectory(Trajectory):
             traj.add_style(style=style, selection=selection)
 
         return traj
+
+    def _get_annotation_entity_type(self) -> str:
+        "Interna: Re-use the annotations for Trajectory entity"
+        return EntityType.MD.value

--- a/molecularnodes/entities/trajectory/oxdna.py
+++ b/molecularnodes/entities/trajectory/oxdna.py
@@ -445,3 +445,7 @@ class OXDNA(Trajectory):
                 )
             except KeyError as e:
                 print(e)
+
+    def _get_annotation_entity_type(self) -> str:
+        "Interna: Re-use the annotations for Trajectory entity"
+        return EntityType.MD.value

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -922,7 +922,9 @@ def _register_temp_annotation_add_op(entity):
     for cls in entity.annotations._classes.values():
         AnnotationTypeInputs = create_annotation_type_inputs(cls)
         register(AnnotationTypeInputs)
-        entity_annotation_type = f"{entity._mn_entity_type}_{cls.annotation_type}"
+        entity_annotation_type = (
+            f"{entity._get_annotation_entity_type()}_{cls.annotation_type}"
+        )
         attributes["__annotations__"][entity_annotation_type] = (
             bpy.props.PointerProperty(type=AnnotationTypeInputs)
         )
@@ -940,7 +942,9 @@ def _register_temp_annotation_add_op(entity):
         def draw(self, context):
             layout = self.layout
             layout.prop(self.props, "type")
-            entity_annotation_type = f"{entity._mn_entity_type}_{self.props.type}"
+            entity_annotation_type = (
+                f"{entity._get_annotation_entity_type()}_{self.props.type}"
+            )
             inputs = getattr(self.props, entity_annotation_type, None)
             if inputs is not None:
                 for prop_name in inputs.__annotations__.keys():
@@ -956,7 +960,9 @@ def _register_temp_annotation_add_op(entity):
                 return {"CANCELLED"}
             annotation_class = entity.annotations._classes[self.props.type]
             api_inputs = {}
-            entity_annotation_type = f"{entity._mn_entity_type}_{self.props.type}"
+            entity_annotation_type = (
+                f"{entity._get_annotation_entity_type()}_{self.props.type}"
+            )
             ui_inputs = getattr(self.props, entity_annotation_type, None)
             if ui_inputs is not None:
                 for prop_name in ui_inputs.__annotations__.keys():

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -1007,7 +1007,7 @@ class MN_PT_Annotations(bpy.types.Panel):
         row = box.row()
         row.prop(item, "type")
         row.enabled = False
-        entity_annotation_type = f"{entity._mn_entity_type}_{item.type}"
+        entity_annotation_type = f"{entity._get_annotation_entity_type()}_{item.type}"
         inputs = getattr(item, entity_annotation_type, None)
         instance = entity.annotations._interfaces.get(inputs.uuid)._instance
         if inputs is not None:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -235,7 +235,7 @@ class TestAnnotations:
         with pytest.raises(ValueError):
             t1.annotations._remove_annotation_by_uuid("InvalidUUID")
 
-    def test_annotation_ops(self, universe):
+    def test_annotation_ops_md(self, universe):
         t1 = mn.Trajectory(universe)
         assert len(t1.annotations) == 0
         # add annotation operator
@@ -248,6 +248,34 @@ class TestAnnotations:
             "EXEC_DEFAULT", uuid=t1.uuid, annotation_uuid=a1._uuid
         )
         assert len(t1.annotations) == 0
+
+    def test_annotation_ops_molecule(self):
+        mol = mn.Molecule.load(data_dir / "1cd3.cif")
+        assert len(mol.annotations) == 0
+        # add annotation operator
+        # first annotation type due to no invoke - must have no required inputs
+        bpy.ops.mn.add_annotation("EXEC_DEFAULT", uuid=mol.uuid)
+        assert len(mol.annotations) == 1
+        a1 = mol.annotations[0]
+        # remove annotation operator
+        bpy.ops.mn.remove_annotation(
+            "EXEC_DEFAULT", uuid=mol.uuid, annotation_uuid=a1._uuid
+        )
+        assert len(mol.annotations) == 0
+
+    def test_annotation_ops_density(self, density_file):
+        d1 = mn.entities.density.load(density_file)
+        assert len(d1.annotations) == 0
+        # add annotation operator
+        # first annotation type due to no invoke - must have no required inputs
+        bpy.ops.mn.add_annotation("EXEC_DEFAULT", uuid=d1.uuid)
+        assert len(d1.annotations) == 1
+        a1 = d1.annotations[0]
+        # remove annotation operator
+        bpy.ops.mn.remove_annotation(
+            "EXEC_DEFAULT", uuid=d1.uuid, annotation_uuid=a1._uuid
+        )
+        assert len(d1.annotations) == 0
 
     def test_trajectory_annotation_atom_info(self, universe):
         t1 = mn.Trajectory(universe)


### PR DESCRIPTION
* Use the correct entity type string for accessing annotation inputs
* Support annotations for derived entities like OXDNA and StreamingTrajectory
* Add new tests to add annotation (from UI) for Molecule and Density EntityType

---

Hi Brady, this should fix the issue described in #1039 and a few other related issues.

I have added a couple of new tests (earlier, only add op for Trajectory was in tests) to test for the UI add operator for Molecule and Density entity as well - this would have caught the issue earlier.

Both `OXDNA` and `StreamingTrajectory` that derive from `Trajectory` entity should now be able to re-use the annotations for Trajectory. I have not added `OXDNA` in the poll because the annotations aren't of much use - the topology doesn't have the required attributes like masses (for center-of-mass calculation), names (for selections based on names) etc. I haven't gotten a chance to read about and setup Streaming Trajectories yet. It would be great if you can give this a try if you already have a setup. It would be pretty cool to see if the annotations like com distance etc update in real time. I only added a basic `n_frames` check in the `universe_info` annotation to not error out, but I believe the rest should work as is, though I couldn't verify. Thanks