### PR TITLE
Fix Blender __slots__ warnings

### DIFF
--- a/molecularnodes/annotations/manager.py
+++ b/molecularnodes/annotations/manager.py
@@ -190,8 +190,9 @@ class BaseAnnotationManager(metaclass=ABCMeta):
     @classmethod
     def _update_annotation_props(cls, annotation_class: BaseAnnotation):
         """Update annotation properties attached to Object"""
+        attributes = {"__slots__": []}
         AnnotationProperties = type(
-            "AnnotationProperties", (BaseAnnotationProperties,), {}
+            "AnnotationProperties", (BaseAnnotationProperties,), attributes
         )
         # Add each annotation type inputs as a pointer to a separate property group
         for annotation_type, annotation_class in BaseAnnotationManager._classes.items():
@@ -208,8 +209,6 @@ class BaseAnnotationManager(metaclass=ABCMeta):
             AnnotationProperties.__annotations__[annotation_type] = (
                 bpy.props.PointerProperty(type=AnnotationInputs)
             )
-        # add slots to declare annotation type attributes
-        AnnotationProperties.__slots__ = []
         # Re-register the new AnnotationProperties class
         bpy.utils.register_class(AnnotationProperties)
         # Re-assign the annotation properties to Object - old data is retained

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -156,6 +156,8 @@ def _update_annotation_object(self, context):
 class BaseAnnotationProperties(bpy.types.PropertyGroup):
     """Base annotation properties"""
 
+    __slots__ = []
+
     # annotation name (label)
     label: StringProperty()  # type: ignore
 

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -6,7 +6,6 @@ from bpy.props import (  # type: ignore
     IntProperty,
     StringProperty,
 )
-from bpy.types import PropertyGroup  # type: ignore
 from databpy.object import LinkedObjectError
 from ..blender.utils import set_object_visibility
 from ..handlers import _update_entities
@@ -78,7 +77,7 @@ class EntityProperties(bpy.types.PropertyGroup):
     )  # type: ignore
 
 
-class MolecularNodesSceneProperties(PropertyGroup):
+class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
     __slots__ = []
     entities: CollectionProperty(name="Entities", type=EntityProperties)  # type: ignore
     entities_active_index: IntProperty(
@@ -303,7 +302,7 @@ def _update_annotations_visibility(self, context):
         entity.annotations._update_annotation_object()
 
 
-class MolecularNodesObjectProperties(PropertyGroup):
+class MolecularNodesObjectProperties(bpy.types.PropertyGroup):
     __slots__ = []
     styles_active_index: IntProperty(default=-1)  # type: ignore
     annotations_active_index: IntProperty(default=-1)  # type: ignore


### PR DESCRIPTION
Blender shows a lot of the following warnings when run in debug mode (`--debug-all`):

```
register_class(...): warning, AnnotationInputs: is expected to contain a "__slots__" member to prevent arbitrary assignments.
register_class(...): warning, AnnotationProperties: is expected to contain a "__slots__" member to prevent arbitrary assignments.
```

In addition, there are single warnings for the following:

```
register_class(...): warning, EntityProperties: is expected to contain a "__slots__" member to prevent arbitrary assignments.
register_class(...): warning, MolecularNodesObjectProperties: is expected to contain a "__slots__" member to prevent arbitrary assignments.
register_class(...): warning, MolecularNodesSceneProperties: is expected to contain a "__slots__" member to prevent arbitrary assignments.
register_class(...): warning, TrajectorySelectionItem: is expected to contain a "__slots__" member to prevent arbitrary assignments.
```

This PR adds the `__slots__` member for `AnnotationInputs`, `AnnotationProperties` and `EntityProperties` classes as I added them and am sure there are no dynamic attributes added at runtime for those and adding this seems sensible based on what I read about preventing arbitrary assignments and conserving memory. The last three, I am not sure, but since they are single warnings, maybe we could ignore.