### PR TITLE
Hide inactive node inputs from 3d viewport styles panel

### DIFF
--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -883,6 +883,8 @@ class MN_PT_Styles(bpy.types.Panel):
                 input = style_node.inputs[item.identifier]
                 if not hasattr(input, "default_value"):
                     continue
+                if input.is_inactive:
+                    continue
                 row = None
                 if item.parent.name and item.parent.name in panels:
                     panel = panels[item.parent.name]


### PR DESCRIPTION
The Styles panel in the 3D viewport n-panel currently shows all the style node inputs - even the ones that are [inactive](https://docs.blender.org/api/current/bpy.types.NodeSocket.html#bpy.types.NodeSocket.is_inactive). This makes them inconsistent with what is seen in the Geometry Node itself. For example, the `Subdivisions` input is not relevant (and hence inactive and doesn't show in the GN inputs) for the `Point` Geometry. This PR adds a simple check to ensure they are consistent.

Before:
<img width="505" height="358" alt="node-input-inactive-before" src="https://github.com/user-attachments/assets/f364c7c4-f1bc-4b01-8dba-d646c8710880" />

After:
<img width="505" height="358" alt="node-input-inactive-after" src="https://github.com/user-attachments/assets/d4f471e5-c1e0-4ddf-a9e4-1ead013ed03f" />
