### PR TITLE
Annotations: Pass input name in validation callback

### DIFF
--- a/docs/api/annotations.qmd
+++ b/docs/api/annotations.qmd
@@ -439,7 +439,7 @@ class CustomAnnotation(mn.entities.trajectory.TrajectoryAnnotation):
         params.text_size = 20
 
     # optional validate method
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         # validate any input params that change (either through API or GUI)
         # return True if validation succeeds else False or raise an Exception
         params = self.interface

--- a/molecularnodes/annotations/base.py
+++ b/molecularnodes/annotations/base.py
@@ -87,7 +87,7 @@ class BaseAnnotation(metaclass=ABCMeta):
         self._image = None
         self._image_scale = 1
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         """
         Optional method to validate annotation inputs
         This is called during annotation creation and any time the inputs change
@@ -96,6 +96,12 @@ class BaseAnnotation(metaclass=ABCMeta):
 
         Note: This method gets called when any inputs change, so updating values
         in here will lead to a recursive loop and should not be done.
+
+        Parameters
+        ----------
+        input_name: str or None, required
+            The input name update that trigged this validation callback.
+            When no specific input name is available, None is passed.
 
         """
         return True

--- a/molecularnodes/annotations/manager.py
+++ b/molecularnodes/annotations/manager.py
@@ -42,7 +42,7 @@ def _validate_annotation_update(self, context, attr):
     if hasattr(instance, nbattr):
         delattr(instance, nbattr)
     try:
-        if not instance.validate():
+        if not instance.validate(attr):
             raise ValueError(f"Invalid input {attr}")
     except Exception as exception:
         self.valid_inputs = False
@@ -349,7 +349,7 @@ class BaseAnnotationManager(metaclass=ABCMeta):
                 if value is not None:
                     setattr(interface.__class__, attr, value)
             # validate
-            if not annotation_instance.validate():
+            if not annotation_instance.validate(None):
                 raise ValueError("Invalid annotation inputs")
         # only after all validations pass start doing real stuff like creating
         # properties and adding to the interface list

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -125,7 +125,7 @@ def create_property_interface(
             # not a supported blender type property
             # set a non blender property and validate
             setattr(instance, nbattr, value)
-            instance.validate()
+            instance.validate(nbattr)
             if instance._ready:
                 # update annotation object
                 entity.annotations._update_annotation_object()

--- a/molecularnodes/entities/annotations.py
+++ b/molecularnodes/entities/annotations.py
@@ -20,11 +20,12 @@ class Label2D(BaseAnnotation):
     text: str
     location: tuple[float, float] = (0.5, 0.5)
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        x, y = params.location
-        if (not 0 <= x <= 1) or (not 0 <= y <= 1):
-            raise ValueError("Normalized coordinates should lie between 0 and 1")
+        if input_name in (None, "location"):
+            x, y = params.location
+            if (not 0 <= x <= 1) or (not 0 <= y <= 1):
+                raise ValueError("Normalized coordinates should lie between 0 and 1")
         return True
 
     def draw(self) -> None:

--- a/molecularnodes/entities/density/annotations.py
+++ b/molecularnodes/entities/density/annotations.py
@@ -88,11 +88,12 @@ class DensityInfo(DensityAnnotation):
         params = self.interface
         params.text_align = "left"
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        x, y = params.location
-        if (not 0 <= x <= 1) or (not 0 <= y <= 1):
-            raise ValueError("Normalized coordinates should lie between 0 and 1")
+        if input_name in (None, "location"):
+            x, y = params.location
+            if (not 0 <= x <= 1) or (not 0 <= y <= 1):
+                raise ValueError("Normalized coordinates should lie between 0 and 1")
         return True
 
     def draw(self) -> None:

--- a/molecularnodes/entities/molecule/annotations.py
+++ b/molecularnodes/entities/molecule/annotations.py
@@ -75,11 +75,12 @@ class MoleculeInfo(MoleculeAnnotation):
         params = self.interface
         params.text_align = "left"
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        x, y = params.location
-        if (not 0 <= x <= 1) or (not 0 <= y <= 1):
-            raise ValueError("Normalized coordinates should lie between 0 and 1")
+        if input_name == "location":
+            x, y = params.location
+            if (not 0 <= x <= 1) or (not 0 <= y <= 1):
+                raise ValueError("Normalized coordinates should lie between 0 and 1")
         return True
 
     def draw(self) -> None:

--- a/molecularnodes/entities/trajectory/annotations.py
+++ b/molecularnodes/entities/trajectory/annotations.py
@@ -93,17 +93,18 @@ class AtomInfo(TrajectoryAnnotation):
         params.text_size = 16
         params.text_color = (1, 1, 1, 1)
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        universe = self.trajectory.universe
-        if isinstance(params.selection, str):
-            # check if selection phrase is valid
-            # mda throws exception if invalid
-            self.atom_group = universe.select_atoms(params.selection)
-        elif isinstance(params.selection, AtomGroup):
-            self.atom_group = params.selection
-        else:
-            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection)}")
+        if input_name in (None, "selection"):
+            if isinstance(params.selection, str):
+                # check if selection phrase is valid
+                # mda throws exception if invalid
+                universe = self.trajectory.universe
+                self.atom_group = universe.select_atoms(params.selection)
+            elif isinstance(params.selection, AtomGroup):
+                self.atom_group = params.selection
+            else:
+                raise ValueError(f"Need str or AtomGroup. Got {type(params.selection)}")
         return True
 
     def draw(self) -> None:
@@ -147,17 +148,18 @@ class COM(TrajectoryAnnotation):
         # show a default pointer
         params.line_pointer_length = 2
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        universe = self.trajectory.universe
-        if isinstance(params.selection, str):
-            # check if selection phrase is valid
-            # mda throws exception if invalid
-            self.atom_group = universe.select_atoms(params.selection)
-        elif isinstance(params.selection, AtomGroup):
-            self.atom_group = params.selection
-        else:
-            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection)}")
+        if input_name in (None, "selection"):
+            if isinstance(params.selection, str):
+                # check if selection phrase is valid
+                # mda throws exception if invalid
+                universe = self.trajectory.universe
+                self.atom_group = universe.select_atoms(params.selection)
+            elif isinstance(params.selection, AtomGroup):
+                self.atom_group = params.selection
+            else:
+                raise ValueError(f"Need str or AtomGroup. Got {type(params.selection)}")
         return True
 
     def draw(self) -> None:
@@ -199,27 +201,33 @@ class COMDistance(TrajectoryAnnotation):
         params = self.interface
         params.line_arrow_size = 0.1
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
         universe = self.trajectory.universe
-        # check selection 1
-        if isinstance(params.selection1, str):
-            # check if selection phrase is valid
-            # mda throws exception if invalid
-            self.atom_group1 = universe.select_atoms(params.selection1)
-        elif isinstance(params.selection1, AtomGroup):
-            self.atom_group1 = params.selection1
-        else:
-            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection1)}")
-        # check selection 2
-        if isinstance(params.selection2, str):
-            # check if selection phrase is valid
-            # mda throws exception if invalid
-            self.atom_group2 = universe.select_atoms(params.selection2)
-        elif isinstance(params.selection2, AtomGroup):
-            self.atom_group2 = params.selection2
-        else:
-            raise ValueError(f"Need str or AtomGroup. Got {type(params.selection2)}")
+        if input_name in (None, "selection1"):
+            # check selection 1
+            if isinstance(params.selection1, str):
+                # check if selection phrase is valid
+                # mda throws exception if invalid
+                self.atom_group1 = universe.select_atoms(params.selection1)
+            elif isinstance(params.selection1, AtomGroup):
+                self.atom_group1 = params.selection1
+            else:
+                raise ValueError(
+                    f"Need str or AtomGroup. Got {type(params.selection1)}"
+                )
+        if input_name in (None, "selection2"):
+            # check selection 2
+            if isinstance(params.selection2, str):
+                # check if selection phrase is valid
+                # mda throws exception if invalid
+                self.atom_group2 = universe.select_atoms(params.selection2)
+            elif isinstance(params.selection2, AtomGroup):
+                self.atom_group2 = params.selection2
+            else:
+                raise ValueError(
+                    f"Need str or AtomGroup. Got {type(params.selection2)}"
+                )
         return True
 
     def draw(self) -> None:
@@ -269,11 +277,12 @@ class CanonicalDihedrals(TrajectoryAnnotation):
         params.line_arrow_size = 10.0
         params.mesh_thickness = 0.1
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        universe = self.trajectory.universe
-        # verify residue in universe - raises exception if invalid
-        self.residue = universe.residues[params.resid - 1]
+        if input_name in (None, "resid"):
+            universe = self.trajectory.universe
+            # verify residue in universe - raises exception if invalid
+            self.residue = universe.residues[params.resid - 1]
         return True
 
     def _get_start_dv(self, dihedral: list) -> Vector:
@@ -376,11 +385,12 @@ class UniverseInfo(TrajectoryAnnotation):
         params = self.interface
         params.text_align = "left"
 
-    def validate(self) -> bool:
+    def validate(self, input_name: str = None) -> bool:
         params = self.interface
-        x, y = params.location
-        if (not 0 <= x <= 1) or (not 0 <= y <= 1):
-            raise ValueError("Normalized coordinates should lie between 0 and 1")
+        if input_name in (None, "location"):
+            x, y = params.location
+            if (not 0 <= x <= 1) or (not 0 <= y <= 1):
+                raise ValueError("Normalized coordinates should lie between 0 and 1")
         return True
 
     def draw(self) -> None:


### PR DESCRIPTION
This PR passes in the actual input (when available) that triggers a validation callback for annotations. This not only helps with fine grained validation checks, it is also especially useful for a variety of different use cases later. For example, for streaming charts (let us say for distance between to selections), on the change of selection values can reset the plot values and not other inputs like labels, chart size, location etc.