### PR TITLE
Docs: Add table of supported annotation input types

### DIFF
--- a/docs/api/annotations.qmd
+++ b/docs/api/annotations.qmd
@@ -518,9 +518,7 @@ Text, lines and meshes drawn in custom annotations can be controlled by the same
 
 Here is an example within a custom annotation that draws two 3D circles, the first with a hardcoded color value and the second with a custom input color:
 
-```{python}
-#| eval: false
-
+```python
     ...
     # custom line color input
     line_color_input: tuple[float, float, float, float] = (1, 1, 1, 1)


### PR DESCRIPTION
This PR adds a simple table to the docs that lists the currently supported annotation input types and their corresponding representation in Blender GUI. This was missing item in the docs:

This looks as follows in the Custom Annotations section of the Annotations API doc:

<img width="785" height="688" alt="image" src="https://github.com/user-attachments/assets/9d1112f2-c8bf-4954-9b5c-c964a939ad09" />

