### PR TITLE
Show individual annotation input errors with details in GUI

### DIFF
--- a/molecularnodes/annotations/manager.py
+++ b/molecularnodes/annotations/manager.py
@@ -45,9 +45,13 @@ def _validate_annotation_update(self, context, attr):
         if not instance.validate(attr):
             raise ValueError(f"Invalid input {attr}")
     except Exception as exception:
-        self.valid_inputs = False
+        if attr not in instance._invalid_inputs:
+            instance._invalid_inputs.append(attr)
+            instance._invalid_input_messages[attr] = str(exception)
         raise exception
-    self.valid_inputs = True
+    if attr in instance._invalid_inputs:
+        instance._invalid_inputs.remove(attr)
+        instance._invalid_input_messages[attr]
     if instance._ready:
         # update annotation object
         entity.annotations._update_annotation_object()
@@ -334,6 +338,10 @@ class BaseAnnotationManager(metaclass=ABCMeta):
         setattr(annotation_instance, "interface", interface)
         # instance is ready only after all the property interfaces are created
         setattr(annotation_instance, "_ready", False)
+        # array of invalid inputs
+        setattr(annotation_instance, "_invalid_inputs", [])
+        # dict of invalid input messages
+        setattr(annotation_instance, "_invalid_input_messages", {})
         # call the validate method in the annotation class if specified for
         # any annotation specific custom validation
         if hasattr(annotation_instance, "validate") and callable(
@@ -385,14 +393,6 @@ class BaseAnnotationManager(metaclass=ABCMeta):
         inputs = getattr(prop, entity_annotation_type, None)
         if inputs is not None:
             inputs.uuid = uuid  # add annotation uuid for lookup in update callback
-            # link to the valid inputs property for use in draw handler
-            prop_interface = create_property_interface(
-                self._entity,
-                uuid,
-                "valid_inputs",
-                annotation_type=entity_annotation_type,
-            )
-            setattr(interface.__class__, "_valid_inputs", prop_interface)
             # all annotation inputs as defined in class
             for attr, atype in py_annotations.items():
                 # name is a special case that is already added above
@@ -580,7 +580,7 @@ class BaseAnnotationManager(metaclass=ABCMeta):
             if not interface.visible:
                 continue
             # annotations input validity
-            if not getattr(interface, "_valid_inputs", True):
+            if interface._instance._invalid_inputs:
                 continue
             interface._instance.geometry = None
             if get_geometry:

--- a/molecularnodes/annotations/props.py
+++ b/molecularnodes/annotations/props.py
@@ -92,8 +92,6 @@ def create_annotation_type_inputs(
         attributes["__annotations__"][attr] = prop
     # add the uuid to the annotation for lookup during update callback
     attributes["__annotations__"]["uuid"] = StringProperty()
-    # add a boolean to indicate if validations succeeded
-    attributes["__annotations__"]["valid_inputs"] = BoolProperty(default=True)
     # add slots to declare attributes
     attributes["__slots__"] = []
     # create and return new AnnotationInputs class

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -949,7 +949,7 @@ def _register_temp_annotation_add_op(entity):
             inputs = getattr(self.props, entity_annotation_type, None)
             if inputs is not None:
                 for prop_name in inputs.__annotations__.keys():
-                    if prop_name in ("uuid", "valid_inputs"):
+                    if prop_name == "uuid":
                         continue
                     layout.prop(inputs, prop_name)
 

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -1044,14 +1044,8 @@ class MN_PT_Annotations(bpy.types.Panel):
         inputs = getattr(item, entity_annotation_type, None)
         instance = entity.annotations._interfaces.get(inputs.uuid)._instance
         if inputs is not None:
-            if not inputs.valid_inputs:
-                col = layout.column()
-                box = col.box()
-                box.label(text="Invalid inputs", icon="ERROR")
-                box.alert = True
-
             for prop_name in inputs.__annotations__.keys():
-                if prop_name in ("uuid", "valid_inputs"):
+                if prop_name == "uuid":
                     continue
                 row = box.row()
                 nbattr = f"_custom_{prop_name}"  # non blender property
@@ -1059,7 +1053,16 @@ class MN_PT_Annotations(bpy.types.Panel):
                     # indicate use of non blender property in draw
                     row.label(icon="ERROR")
                     row.alert = True
-                row.prop(inputs, prop_name)
+                if prop_name not in instance._invalid_inputs:
+                    row.prop(inputs, prop_name)
+                else:
+                    row.alert = True
+                    row.prop(inputs, prop_name)
+                    row = box.row()
+                    row.alert = True
+                    row.label(
+                        text=instance._invalid_input_messages[prop_name], icon="ERROR"
+                    )
 
         # Add all the common annotation params within the 'Options' panel
         header, panel = box.panel("annotation_options", default_closed=True)


### PR DESCRIPTION
Previously, any annotation input validations just showed a generic error with no details in the GUI. This PR shows which input caused validation failure along with the error details.

Before|After
:---|:---
<img width="503" height="382" alt="annotation-input-error-before" src="https://github.com/user-attachments/assets/cd8c2e36-25a9-494d-8275-9af222210411" />|<img width="503" height="382" alt="annotation-input-error-after" src="https://github.com/user-attachments/assets/9f19eaff-8a29-4866-94e0-50e472e52376" />

Multiple errors are also supported as shown below:
<img width="503" height="382" alt="annotation-input-errors-multiple" src="https://github.com/user-attachments/assets/b05eb247-601d-496c-a784-b3cf3c8fb886" />
