### PR TITLE
Expose any annotations draw handler errors to GUI and API

### DIFF
--- a/molecularnodes/annotations/manager.py
+++ b/molecularnodes/annotations/manager.py
@@ -342,6 +342,8 @@ class BaseAnnotationManager(metaclass=ABCMeta):
         setattr(annotation_instance, "_invalid_inputs", [])
         # dict of invalid input messages
         setattr(annotation_instance, "_invalid_input_messages", {})
+        # draw error string if any
+        setattr(annotation_instance, "_draw_error", None)
         # call the validate method in the annotation class if specified for
         # any annotation specific custom validation
         if hasattr(annotation_instance, "validate") and callable(
@@ -601,8 +603,9 @@ class BaseAnnotationManager(metaclass=ABCMeta):
             # handle exceptions to allow other annotations to be drawn
             try:
                 interface._instance.draw()
-            except Exception:
-                pass
+                interface._instance._draw_error = None
+            except Exception as e:
+                interface._instance._draw_error = str(e)
         # check and return geometry if present
         if get_geometry and geometry != empty_geometry:
             return geometry

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -1044,6 +1044,11 @@ class MN_PT_Annotations(bpy.types.Panel):
         inputs = getattr(item, entity_annotation_type, None)
         instance = entity.annotations._interfaces.get(inputs.uuid)._instance
         if inputs is not None:
+            if instance._draw_error is not None:
+                row = box.row()
+                row.alert = True
+                row.label(text=instance._draw_error, icon="ERROR")
+
             for prop_name in inputs.__annotations__.keys():
                 if prop_name == "uuid":
                     continue


### PR DESCRIPTION
This is a follow up to PR #1068.

Currently, any errors that happen in any of our annotation's `draw` methods don't show up anywhere. Given the `draw` method is called from Blender's viewport draw handler, any errors don't show up in Notebook cells (for API stuff) or even in Blender's console (even when launched from command line). This makes debugging any errors in the annotation draw code hard. This would be a problem for others who write custom annotation code in the future as well. Similar to PR #1068, this PR exposes any such errors back to the GUI, which makes it invaluable for debuggability.

Here is an example of an artificially induced error in draw code showing up in the GUI:

<img width="503" height="382" alt="draw-handler-error-in-gui" src="https://github.com/user-attachments/assets/8c7624d5-2c65-42d8-8dde-b2d67b9c5b25" />
