### PR TITLE
Reregister annotations if extension is re-enabled after being loaded

### DIFF
--- a/molecularnodes/annotations/__init__.py
+++ b/molecularnodes/annotations/__init__.py
@@ -1,4 +1,16 @@
+import importlib
+import sys
 from . import base, interface, manager
+from .utils import get_all_subclasses
+
+
+def _reregister_annotations():
+    subclasses = get_all_subclasses(manager.BaseAnnotationManager)
+    # reload required annotation modules
+    importlib.reload(sys.modules[manager.__name__])
+    for cls in subclasses:
+        importlib.reload(sys.modules[cls.__module__])
+
 
 __all__ = [
     "base",

--- a/molecularnodes/annotations/utils.py
+++ b/molecularnodes/annotations/utils.py
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
     from ..session import MNSession
 
 
+def get_all_subclasses(cls):
+    """Get all subclasses"""
+    subclasses = set(cls.__subclasses__())
+    for s in cls.__subclasses__():
+        subclasses.update(get_all_subclasses(s))
+    return subclasses
+
+
 def get_all_class_annotations(cls) -> dict:
     """Get all the annotations from the class including base classes"""
     all_annotations = {}

--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -15,6 +15,7 @@ import bpy
 from bpy.app.handlers import frame_change_pre, load_post, render_pre, save_post
 from bpy.props import CollectionProperty, PointerProperty
 from .. import session
+from ..annotations import _reregister_annotations
 from ..handlers import render_pre_handler, update_entities
 from ..templates import register_templates_menu, unregister_templates_menu
 from ..utils import add_current_module_to_path
@@ -30,6 +31,7 @@ all_classes = (
 )
 
 _is_registered = False
+_is_loaded = False
 
 
 def _test_register():
@@ -43,6 +45,7 @@ def _test_register():
 
 def register():
     global _is_registered
+    global _is_loaded
 
     if _is_registered:
         return
@@ -74,9 +77,12 @@ def register():
     # bpy.types.Object.mn_annotations is dynamically created and updated based
     # on different annotation types. It has to be a top level property to avoid
     # AttributeError: '_PropertyDeferred' object has no attribute '...'
+    if _is_loaded:
+        _reregister_annotations()
     register_templates_menu()
 
     _is_registered = True
+    _is_loaded = True
 
 
 def unregister():


### PR DESCRIPTION
Fixes #1092 

This PR re-registers the annotations by reloading only the relevant annotation modules when the extension is re-enabled (i.e., `register` of extension being called again) after it has already been loaded earlier (after a previous `register` and `unregister`). Thanks