### PR TITLE
Reattach object annotation properties during re-register

### DIFF
--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -30,6 +30,7 @@ all_classes = (
 )
 
 _is_registered = False
+_mn_annotations = None
 
 
 def _test_register():
@@ -43,6 +44,7 @@ def _test_register():
 
 def register():
     global _is_registered
+    global _mn_annotations
 
     if _is_registered:
         return
@@ -74,6 +76,10 @@ def register():
     # bpy.types.Object.mn_annotations is dynamically created and updated based
     # on different annotation types. It has to be a top level property to avoid
     # AttributeError: '_PropertyDeferred' object has no attribute '...'
+    if _mn_annotations is not None:
+        # if the extension is being re-registered and the modules are already
+        # loaded, reuse the saved value
+        bpy.types.Object.mn_annotations = _mn_annotations
     register_templates_menu()
 
     _is_registered = True
@@ -81,6 +87,7 @@ def register():
 
 def unregister():
     global _is_registered
+    global _mn_annotations
 
     for op in all_classes:
         try:
@@ -101,6 +108,7 @@ def unregister():
     del bpy.types.Scene.mn  # type: ignore
     del bpy.types.Object.mn  # type: ignore
     del bpy.types.Object.mn_trajectory_selections  # type: ignore
+    _mn_annotations = bpy.types.Object.mn_annotations
     del bpy.types.Object.mn_annotations  # type: ignore
     unregister_templates_menu()
 


### PR DESCRIPTION
Fixes #1092 

Hi Brady, this is the simpler option mentioned at the end of PR #1095 . It definitely works for the end user case of enabling/disabling the extension multiple times. Maybe we go with this simpler option? We anyway know the root cause of the issue and we could go the path of PR #1095 if we run into any other issues. If you agree, we could use this PR and close the other one. Thanks
