### PR TITLE
Fix origin value in density info annotation for centered case

### DIFF
--- a/molecularnodes/entities/density/annotations.py
+++ b/molecularnodes/entities/density/annotations.py
@@ -112,7 +112,11 @@ class DensityInfo(DensityAnnotation):
                 else:
                     text = text + f"|ISO Value: {iso_value:.2f}"
         if params.show_origin:
-            text = text + f"|Origin: {np.round(grid.origin, 2)}"
+            if grid.metadata["center"]:
+                origin = -np.array(grid.grid.shape) * 0.5 * grid.delta
+            else:
+                origin = grid.origin
+            text = text + f"|Origin: {np.round(origin, 2)}"
         if params.show_delta:
             text = text + f"|Delta: {np.round(grid.delta, 2)}"
         if params.show_shape:


### PR DESCRIPTION
This PR fixes the origin value that is shown in the density info annotation for centered case, which was earlier showing the same value from the grid and not the transformed origin.

Here is a screenshot that shows the corrected values for the two cases after the fix:
<img width="1237" height="864" alt="density-info-origin" src="https://github.com/user-attachments/assets/db87ce70-553b-4cca-9efe-041997c2e3d1" />
