### PR TITLE
Add updating/periodic for style selection phrases in n-panel

### DIFF
--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -335,16 +335,16 @@ def ui_from_node(
 
 
 def selection_string_input(layout: bpy.types.UILayout, item: TrajectorySelectionItem):
-    col = layout.column(align=False)
-    col.prop(item, "string")
+    row = layout.row(align=True)
+    row.prop(item, "string")
 
     # disable editing for immutable selections
     # disable modifying updating and periodic
     if item.from_atomgroup:
-        col.enabled = False
+        row.enabled = False
 
     if item.message != "":
-        box = col.box()
+        box = layout.box()
         box.label(text="Invalid Selection", icon="ERROR")
         box.label(text=item.message)
         box.alert = True
@@ -352,6 +352,8 @@ def selection_string_input(layout: bpy.types.UILayout, item: TrajectorySelection
         op.url = (
             "https://docs.mdanalysis.org/stable/documentation_pages/selections.html"
         )
+
+    return row
 
 
 def layout_trajectory_playback(
@@ -738,24 +740,6 @@ class MN_PT_trajectory(bpy.types.Panel):
         traj = scene.MNSession.get(uuid)
 
         layout_trajectory_playback(layout, traj, panel=False)
-        return
-
-        object = traj.object
-        props = object.mn
-
-        if traj._entity_type == EntityType.MD_STREAMING:
-            return
-
-        label = "This trajectory has " + str(props.n_frames) + " frames"
-        layout.label(text=label)
-        layout.prop(props, "update_with_scene")
-        row = layout.row()
-        row.prop(props, "frame")
-        row.enabled = not props.update_with_scene
-        col = layout.column(align=True)
-        col.prop(props, "average")
-        col.prop(props, "subframes")
-        col.prop(props, "offset")
 
 
 class MN_PT_trajectory_dssp(bpy.types.Panel):
@@ -909,7 +893,9 @@ def panel_selection_node(
     assert isinstance(sel_node, bpy.types.GeometryNodeInputNamedAttribute)
     attr_name = sel_node.inputs[0].default_value
     item: TrajectorySelectionItem = entity.selections.ui_items[attr_name]
-    selection_string_input(layout, item)
+    row = selection_string_input(layout, item)
+    row.prop(item, "updating", icon_only=True, icon="FILE_REFRESH")
+    row.prop(item, "periodic", icon_only=True, icon="CUBE")
 
 
 class MN_PT_Styles(bpy.types.Panel):
@@ -979,8 +965,8 @@ class MN_PT_Styles(bpy.types.Panel):
             row = col.row()
             op = row.operator("mn.remove_style", icon="REMOVE", text="")
             if valid_selection:
-                op.uuid: str = uuid
-                op.style_node_index: int = styles_active_index
+                op.uuid = uuid
+                op.style_node_index = styles_active_index
             else:
                 row.enabled = False
 
@@ -991,8 +977,8 @@ class MN_PT_Styles(bpy.types.Panel):
 
         col = layout.column()
         panel_selection_node(col, style_node, entity)
-        row = col.row()
-        row.label(text="Style")
+        row = col.split(factor=0.25)
+        row.label(text="Style:")
         op = row.operator_menu_enum(
             operator="mn.node_swap_style_menu",
             property="node_items",


### PR DESCRIPTION
* Fix style selection dropdown split
* Remove dead code
* Fix Pylance warnings in file

---

While testing PR #1103 , it wasn't ideal that the updating/periodic settings for the style selection phrase is at a different place. This PR brings them into the n-panel. There is also some minor cleanup. Thanks

Before:

| normal | error |
|---|---|
|<img width="375" height="320" alt="style-up-before-normal" src="https://github.com/user-attachments/assets/dfe8cdb0-7c69-414e-b4db-3fae75ab48e7" />|<img width="375" height="320" alt="style-up-before-error" src="https://github.com/user-attachments/assets/ce2e6870-335b-410b-bf5b-46afb21aec98" />|

After:

| normal | error |
|---|---|
|<img width="375" height="320" alt="style-up-after-normal" src="https://github.com/user-attachments/assets/f0614270-06f6-4bac-b754-27d2f241cf35" />|<img width="375" height="320" alt="style-up-after-error" src="https://github.com/user-attachments/assets/57c0c91f-b2a9-428e-a33a-e2747010e543" />|

The disabled case when the selection is an `AtomGroup`:
<img width="375" height="320" alt="style-up-after-disabled" src="https://github.com/user-attachments/assets/2454bc93-18a8-4644-9e23-5cbff685e4c8" />
