### PR TITLE
Restore any existing in-memory session after re-enabling the extension

### DIFF
--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -199,8 +199,9 @@ class MNSession:
                 e.annotations._draw_handler_remove()
 
     def add_draw_handlers(self) -> None:
+        self.prune()
         for e in self.entities.values():
-            if hasattr(e, "annotations"):
+            if hasattr(e, "annotations") and e.annotations.visible:
                 e.annotations._draw_handler_add()
 
     def stashpath(self, filepath) -> str:

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -696,7 +696,10 @@ class MN_PT_Entities(bpy.types.Panel):
         if entity is None:
             return
         row = layout.row()
-        row.prop(entity.object.mn, "entity_type")
+        try:
+            row.prop(entity.object.mn, "entity_type")
+        except LinkedObjectError:
+            pass
         row.enabled = False
 
 


### PR DESCRIPTION
Fixes #1097 

---

Hi Brady, a note about the odd looking run once timer:
During the `register` and `unregister`, we are under a restricted context and don't have full access to the scene, objects and other `bpy.data` attributes.

Here is an example of such error:

```
  File ".../python3.11/site-packages/databpy/object.py", line 220, in object
    obj = bpy.data.objects[self._object_name]
          ^^^^^^^^^^^^^^^^
AttributeError: '_RestrictData' object has no attribute 'objects'
```

 The recommended approach is to use a one off timer which runs on the ui thread. For us here, the timer value doesn't matter - we have everything ready. Thanks