### PR TITLE
Add AI Policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,6 +1,6 @@
 # 🤖 MolecularNodes AI-generated contributions policy 🤖
 
-* Version: **1.1 (2026-02-17)**
+* Version: **1.0 (2026-03-02)**
 * License: **[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)** (Copied as a template from [MDAnalysis AI Policy](https://github.com/MDAnalysis/mdanalysis/blob/develop/AI_POLICY.md))
 
 This document defines the [Molecular Node's](https://github.com/BradyAJohnston/MolecularNodes/) policy regarding AI-generated content.


### PR DESCRIPTION
Adds an AI_POLICY.md

This is mostly a reposting of the [MDAnalysis AI Policy](https://github.com/MDAnalysis/mdanalysis/blob/develop/AI_POLICY.md) with some select changes to reflect that MN is not a full organisation and currently just a single repo.