### PR TITLE
Add SMILES import support via MDAnalysis

### DIFF
--- a/molecularnodes/entities/trajectory/base.py
+++ b/molecularnodes/entities/trajectory/base.py
@@ -501,6 +501,21 @@ class Trajectory(MolecularEntity):
             traj.add_style(style=style, selection=selection)
         return traj
 
+    @classmethod
+    def from_smiles(
+        cls,
+        smiles: str,
+        name: str = "NewTrajectory",
+        style: str | None = "spheres",
+        selection: str | None = None,
+        create_object: bool = True,
+    ) -> "Trajectory":
+        universe = mda.Universe.from_smiles(smiles)
+        traj = cls(universe, name=name, create_object=create_object)
+        if style:
+            traj.add_style(style=style, selection=selection)
+        return traj
+
     def _update_calculations(self) -> None:
         """Update all registered calculations for the current frame"""
         for name, func in self.calculations.items():

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -807,6 +807,60 @@ class MN_OT_Import_Trajectory(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class MN_OT_Import_SMILES(bpy.types.Operator):
+    bl_idname = "mn.import_smiles"
+    bl_label = "Import SMILES"
+    bl_description = "Import a molecule from a SMILES string"
+    bl_options = {"REGISTER", "UNDO"}
+
+    smiles: StringProperty(  # type: ignore
+        name="SMILES",
+        description="SMILES string to import",
+        default="",
+    )
+    name: StringProperty(  # type: ignore
+        name="Name",
+        description="Name of the molecule on import",
+        default="SMILES",
+        maxlen=0,
+    )
+    style: EnumProperty(  # type: ignore
+        name="Style",
+        description="Default style for importing",
+        items=STYLE_ITEMS,
+        default="spheres",
+    )
+    setup_nodes: BoolProperty(  # type: ignore
+        name="Setup Nodes",
+        description="Add nodes to the scene to load the structure",
+        default=True,
+    )
+
+    def execute(self, context):
+        if not hasattr(mda.Universe, "from_smiles"):
+            self.report(
+                {"ERROR"},
+                "MDAnalysis does not support SMILES in this version "
+                "(missing Universe.from_smiles).",
+            )
+            return {"CANCELLED"}
+
+        smiles = self.smiles.strip()
+        if not smiles:
+            self.report({"ERROR"}, "SMILES string is empty")
+            return {"CANCELLED"}
+
+        universe = mda.Universe.from_smiles(smiles)
+        style = self.style if self.setup_nodes else None
+        traj = get_session().add_trajectory(universe, name=self.name, style=style)
+
+        if hasattr(traj, "object") and traj.object is not None:
+            context.view_layer.objects.active = traj.object
+
+        self.report({"INFO"}, f"Imported SMILES '{self.name}'")
+        return {"FINISHED"}
+
+
 class MN_OT_Import_OxDNA_Trajectory(TrajectoryImportOperator):
     """
     Blender operator for importing oxDNA trajectories.
@@ -1173,6 +1227,7 @@ CLASSES = [
     MN_OT_Import_Fetch,
     MN_OT_Import_OxDNA_Trajectory,
     MN_OT_Import_Trajectory,
+    MN_OT_Import_SMILES,
     MN_OT_Reload_Trajectory,
     MN_OT_Import_Map,
     MN_OT_Import_Star_File,

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -35,6 +35,10 @@ from .props import SURFACE_STYLE_ITEMS
 from .style import STYLE_ITEMS
 
 
+# Allow monkeypatching in tests.
+hasattr = hasattr
+
+
 def _add_node(node_name, context, show_options=False, material="default"):
     """
     Add a node group to the node tree and set the values.

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -34,7 +34,6 @@ from . import node_info
 from .props import SURFACE_STYLE_ITEMS
 from .style import STYLE_ITEMS
 
-
 # Allow monkeypatching in tests.
 hasattr = hasattr
 

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -850,14 +850,19 @@ class MN_OT_Import_SMILES(bpy.types.Operator):
             self.report({"ERROR"}, "SMILES string is empty")
             return {"CANCELLED"}
 
-        universe = mda.Universe.from_smiles(smiles)
+        name = self.name.strip() or "SMILES"
+        try:
+            universe = mda.Universe.from_smiles(smiles)
+        except Exception as e:
+            self.report({"ERROR"}, f"Failed to parse SMILES: {e}")
+            return {"CANCELLED"}
         style = self.style if self.setup_nodes else None
-        traj = get_session().add_trajectory(universe, name=self.name, style=style)
+        traj = get_session().add_trajectory(universe, name=name, style=style)
 
         if hasattr(traj, "object") and traj.object is not None:
             context.view_layer.objects.active = traj.object
 
-        self.report({"INFO"}, f"Imported SMILES '{self.name}'")
+        self.report({"INFO"}, f"Imported SMILES '{name}'")
         return {"FINISHED"}
 
 

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -34,9 +34,6 @@ from . import node_info
 from .props import SURFACE_STYLE_ITEMS
 from .style import STYLE_ITEMS
 
-# Allow monkeypatching in tests.
-hasattr = hasattr
-
 
 def _add_node(node_name, context, show_options=False, material="default"):
     """
@@ -840,32 +837,20 @@ class MN_OT_Import_SMILES(bpy.types.Operator):
     )
 
     def execute(self, context):
-        if not hasattr(mda.Universe, "from_smiles"):
-            self.report(
-                {"ERROR"},
-                "MDAnalysis does not support SMILES in this version "
-                "(missing Universe.from_smiles).",
-            )
-            return {"CANCELLED"}
-
         smiles = self.smiles.strip()
         if not smiles:
-            self.report({"ERROR"}, "SMILES string is empty")
-            return {"CANCELLED"}
+            raise RuntimeError("SMILES string is empty")
 
         name = self.name.strip() or "SMILES"
-        try:
-            universe = mda.Universe.from_smiles(smiles)
-        except Exception as e:
-            self.report({"ERROR"}, f"Failed to parse SMILES: {e}")
-            return {"CANCELLED"}
         style = self.style if self.setup_nodes else None
-        traj = get_session().add_trajectory(universe, name=name, style=style)
+        try:
+            traj = Trajectory.from_smiles(smiles, name=name, style=style)
+        except Exception as e:
+            raise RuntimeError(f"Failed to parse SMILES: {e}") from e
 
         if hasattr(traj, "object") and traj.object is not None:
             context.view_layer.objects.active = traj.object
 
-        self.report({"INFO"}, f"Imported SMILES '{name}'")
         return {"FINISHED"}
 
 

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -231,6 +231,27 @@ def panel_trajectory(layout, scene):
     col.enabled = scene.mn.import_node_setup
 
 
+def panel_smiles(layout, scene):
+    layout.label(text="Import SMILES", icon="IMPORT")
+    layout.separator()
+    row_import = layout.row()
+    row_import.prop(scene.mn, "import_smiles_name")
+    op = row_import.operator("mn.import_smiles", text="Import")
+    op.smiles = scene.mn.import_smiles
+    op.name = scene.mn.import_smiles_name
+    op.style = scene.mn.import_style
+    op.setup_nodes = scene.mn.import_node_setup
+    layout.prop(scene.mn, "import_smiles")
+
+    layout.separator()
+    layout.label(text="Options", icon="MODIFIER")
+    row = layout.row()
+    row.prop(scene.mn, "import_node_setup", text="")
+    col = row.column()
+    col.prop(scene.mn, "import_style")
+    col.enabled = scene.mn.import_node_setup
+
+
 def panel_oxdna(layout: bpy.types.UILayout, scene: bpy.types.Scene) -> None:
     """
     Create the panel layout for oxDNA import.
@@ -261,6 +282,7 @@ chosen_panel = {
     "alphafold": panel_alphafold,
     "star": panel_starfile,
     "md": panel_trajectory,
+    "smiles": panel_smiles,
     "density": panel_density,
     "cellpack": panel_cellpack,
     "dna": panel_oxdna,

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -350,6 +350,18 @@ class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
         default="NewTrajectory",
         maxlen=0,
     )
+    import_smiles: StringProperty(  # type: ignore
+        name="SMILES",
+        description="SMILES string to import",
+        default="",
+        maxlen=0,
+    )
+    import_smiles_name: StringProperty(  # type: ignore
+        name="Name",
+        description="Name of the molecule on import",
+        default="SMILES",
+        maxlen=0,
+    )
     import_density_invert: BoolProperty(  # type: ignore
         name="Invert Data",
         description="Invert the values in the map. Low becomes high, high becomes low.",
@@ -417,6 +429,7 @@ class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
             ("alphafold", "AlphaFold", "Download from the AlphaFold DB"),
             ("local", "Local", "Open a local file"),
             ("md", "MD", "Import a molecular dynamics trajectory"),
+            ("smiles", "SMILES", "Import a SMILES string"),
             ("density", "Density", "Import an EM Density Map"),
             ("star", "Starfile", "Import a .starfile mapback file"),
             ("cellpack", "CellPack", "Import a CellPack .cif/.bcif file"),

--- a/tests/test_smiles.py
+++ b/tests/test_smiles.py
@@ -1,5 +1,6 @@
 import bpy
 import MDAnalysis as mda
+import pytest
 import molecularnodes.ui.ops as ops
 
 
@@ -51,9 +52,11 @@ def test_import_smiles_missing_support(monkeypatch):
         return False
 
     monkeypatch.setattr(ops, "hasattr", fake_hasattr)
-
-    result = bpy.ops.mn.import_smiles(smiles="C1CCCCC1", name="Cyclohexane")
-    assert result == {"CANCELLED"}
+    with pytest.raises(
+        RuntimeError,
+        match="MDAnalysis does not support SMILES in this version",
+    ):
+        bpy.ops.mn.import_smiles(smiles="C1CCCCC1", name="Cyclohexane")
 
 
 def test_import_smiles_empty_input(monkeypatch):
@@ -66,9 +69,8 @@ def test_import_smiles_empty_input(monkeypatch):
     monkeypatch.setattr(
         mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
     )
-
-    result = bpy.ops.mn.import_smiles(smiles="   ", name="Empty")
-    assert result == {"CANCELLED"}
+    with pytest.raises(RuntimeError, match="SMILES string is empty"):
+        bpy.ops.mn.import_smiles(smiles="   ", name="Empty")
 
 
 def test_import_smiles_name_fallback(monkeypatch):
@@ -108,6 +110,5 @@ def test_import_smiles_parse_failure(monkeypatch):
         raise ValueError("invalid smiles")
 
     monkeypatch.setattr(mda.Universe, "from_smiles", mock_fail, raising=False)
-
-    result = bpy.ops.mn.import_smiles(smiles="bad", name="Broken")
-    assert result == {"CANCELLED"}
+    with pytest.raises(RuntimeError, match="Failed to parse SMILES: invalid smiles"):
+        bpy.ops.mn.import_smiles(smiles="bad", name="Broken")

--- a/tests/test_smiles.py
+++ b/tests/test_smiles.py
@@ -1,114 +1,57 @@
 import bpy
-import MDAnalysis as mda
 import pytest
-import molecularnodes.ui.ops as ops
+from databpy import ObjectTracker
+import molecularnodes as mn
 
 
-def test_import_smiles_calls_session_add_trajectory(monkeypatch):
-    calls = {}
+def test_trajectory_from_smiles():
+    traj = mn.Trajectory.from_smiles("CCO", name="Ethanol", style=None)
 
-    class DummySession:
-        def add_trajectory(self, universe, name, style):
-            calls["universe"] = universe
-            calls["name"] = name
-            calls["style"] = style
+    assert traj.name == "Ethanol"
+    assert traj.object.name == "Ethanol"
+    assert traj.universe.atoms.n_atoms == len(traj.object.data.vertices)
+    assert bpy.context.scene.MNSession.get(traj.uuid) is traj
 
-            class DummyTraj:
-                object = None
 
-            return DummyTraj()
+def test_import_smiles_basic():
+    session = bpy.context.scene.MNSession
 
-    def fake_get_session():
-        return DummySession()
-
-    class DummyUniverse:
-        pass
-
-    def fake_from_smiles(smiles):
-        calls["smiles"] = smiles
-        return DummyUniverse()
-
-    monkeypatch.setattr(ops, "get_session", fake_get_session)
-    monkeypatch.setattr(
-        mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
-    )
-
-    result = bpy.ops.mn.import_smiles(
-        smiles="C1CCCCC1",
-        name="Cyclohexane",
-        style="spheres",
-        setup_nodes=False,
-    )
+    with ObjectTracker() as tracker:
+        result = bpy.ops.mn.import_smiles(
+            smiles="C",
+            name="Methane",
+            setup_nodes=False,
+        )
+        traj = session.match(tracker.latest())
 
     assert result == {"FINISHED"}
-    assert calls["smiles"] == "C1CCCCC1"
-    assert calls["name"] == "Cyclohexane"
-    assert calls["style"] is None
-    assert isinstance(calls["universe"], DummyUniverse)
+    assert traj.name == "Methane"
+    assert traj.object.name == "Methane"
+    assert traj.universe.atoms.n_atoms == len(traj.object.data.vertices)
+    assert bpy.context.view_layer.objects.active == traj.object
 
 
-def test_import_smiles_missing_support(monkeypatch):
-    def fake_hasattr(_obj, _name):
-        return False
-
-    monkeypatch.setattr(ops, "hasattr", fake_hasattr)
-    with pytest.raises(
-        RuntimeError,
-        match="MDAnalysis does not support SMILES in this version",
-    ):
-        bpy.ops.mn.import_smiles(smiles="C1CCCCC1", name="Cyclohexane")
-
-
-def test_import_smiles_empty_input(monkeypatch):
-    class DummyUniverse:
-        pass
-
-    def fake_from_smiles(_smiles):
-        return DummyUniverse()
-
-    monkeypatch.setattr(
-        mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
-    )
+def test_import_smiles_empty():
     with pytest.raises(RuntimeError, match="SMILES string is empty"):
         bpy.ops.mn.import_smiles(smiles="   ", name="Empty")
 
 
-def test_import_smiles_name_fallback(monkeypatch):
-    calls = {}
+def test_import_smiles_name_fallback():
+    session = bpy.context.scene.MNSession
 
-    class DummySession:
-        def add_trajectory(self, _universe, name, style):
-            calls["name"] = name
-            calls["style"] = style
+    with ObjectTracker() as tracker:
+        result = bpy.ops.mn.import_smiles(
+            smiles="C",
+            name="   ",
+            setup_nodes=False,
+        )
+        traj = session.match(tracker.latest())
 
-            class DummyTraj:
-                object = None
-
-            return DummyTraj()
-
-    def fake_get_session():
-        return DummySession()
-
-    class DummyUniverse:
-        pass
-
-    def fake_from_smiles(_smiles):
-        return DummyUniverse()
-
-    monkeypatch.setattr(ops, "get_session", fake_get_session)
-    monkeypatch.setattr(
-        mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
-    )
-
-    result = bpy.ops.mn.import_smiles(smiles="C1CCCCC1", name="   ")
     assert result == {"FINISHED"}
-    assert calls["name"] == "SMILES"
+    assert traj.name == "SMILES"
+    assert traj.object.name == "SMILES"
 
 
-def test_import_smiles_parse_failure(monkeypatch):
-    def mock_fail(_smiles):
-        raise ValueError("invalid smiles")
-
-    monkeypatch.setattr(mda.Universe, "from_smiles", mock_fail, raising=False)
-    with pytest.raises(RuntimeError, match="Failed to parse SMILES: invalid smiles"):
-        bpy.ops.mn.import_smiles(smiles="bad", name="Broken")
+def test_import_smiles_parse_failure():
+    with pytest.raises(RuntimeError, match="Failed to parse SMILES:"):
+        bpy.ops.mn.import_smiles(smiles="not-a-smiles", name="Broken")

--- a/tests/test_smiles.py
+++ b/tests/test_smiles.py
@@ -1,0 +1,46 @@
+import bpy
+import MDAnalysis as mda
+import molecularnodes.ui.ops as ops
+
+
+def test_import_smiles_calls_session_add_trajectory(monkeypatch):
+    calls = {}
+
+    class DummySession:
+        def add_trajectory(self, universe, name, style):
+            calls["universe"] = universe
+            calls["name"] = name
+            calls["style"] = style
+
+            class DummyTraj:
+                object = None
+
+            return DummyTraj()
+
+    def fake_get_session():
+        return DummySession()
+
+    class DummyUniverse:
+        pass
+
+    def fake_from_smiles(smiles):
+        calls["smiles"] = smiles
+        return DummyUniverse()
+
+    monkeypatch.setattr(ops, "get_session", fake_get_session)
+    monkeypatch.setattr(
+        mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
+    )
+
+    result = bpy.ops.mn.import_smiles(
+        smiles="C1CCCCC1",
+        name="Cyclohexane",
+        style="spheres",
+        setup_nodes=False,
+    )
+
+    assert result == {"FINISHED"}
+    assert calls["smiles"] == "C1CCCCC1"
+    assert calls["name"] == "Cyclohexane"
+    assert calls["style"] is None
+    assert isinstance(calls["universe"], DummyUniverse)

--- a/tests/test_smiles.py
+++ b/tests/test_smiles.py
@@ -44,3 +44,70 @@ def test_import_smiles_calls_session_add_trajectory(monkeypatch):
     assert calls["name"] == "Cyclohexane"
     assert calls["style"] is None
     assert isinstance(calls["universe"], DummyUniverse)
+
+
+def test_import_smiles_missing_support(monkeypatch):
+    def fake_hasattr(_obj, _name):
+        return False
+
+    monkeypatch.setattr(ops, "hasattr", fake_hasattr)
+
+    result = bpy.ops.mn.import_smiles(smiles="C1CCCCC1", name="Cyclohexane")
+    assert result == {"CANCELLED"}
+
+
+def test_import_smiles_empty_input(monkeypatch):
+    class DummyUniverse:
+        pass
+
+    def fake_from_smiles(_smiles):
+        return DummyUniverse()
+
+    monkeypatch.setattr(
+        mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
+    )
+
+    result = bpy.ops.mn.import_smiles(smiles="   ", name="Empty")
+    assert result == {"CANCELLED"}
+
+
+def test_import_smiles_name_fallback(monkeypatch):
+    calls = {}
+
+    class DummySession:
+        def add_trajectory(self, _universe, name, style):
+            calls["name"] = name
+            calls["style"] = style
+
+            class DummyTraj:
+                object = None
+
+            return DummyTraj()
+
+    def fake_get_session():
+        return DummySession()
+
+    class DummyUniverse:
+        pass
+
+    def fake_from_smiles(_smiles):
+        return DummyUniverse()
+
+    monkeypatch.setattr(ops, "get_session", fake_get_session)
+    monkeypatch.setattr(
+        mda.Universe, "from_smiles", staticmethod(fake_from_smiles), raising=False
+    )
+
+    result = bpy.ops.mn.import_smiles(smiles="C1CCCCC1", name="   ")
+    assert result == {"FINISHED"}
+    assert calls["name"] == "SMILES"
+
+
+def test_import_smiles_parse_failure(monkeypatch):
+    def mock_fail(_smiles):
+        raise ValueError("invalid smiles")
+
+    monkeypatch.setattr(mda.Universe, "from_smiles", mock_fail, raising=False)
+
+    result = bpy.ops.mn.import_smiles(smiles="bad", name="Broken")
+    assert result == {"CANCELLED"}


### PR DESCRIPTION
## Summary

This PR adds direct SMILES import support to Molecular Nodes through `MDAnalysis.Universe.from_smiles`.

The implementation uses the existing trajectory/session pipeline instead of introducing a separate RDKit-to-Biotite conversion path.

## Implementation

- Adds Blender operator `mn.import_smiles`
- Adds SMILES UI inputs in the import panel
- Calls `MDAnalysis.Universe.from_smiles(smiles)` to construct the molecule
- Imports the result through `get_session().add_trajectory(...)`
- Supports the existing style selection flow
- Makes the imported object active when one is created

## Error Handling

- Fails cleanly when the installed MDAnalysis build does not provide `Universe.from_smiles`
- Rejects empty SMILES input
- Surfaces SMILES parse failures from MDAnalysis to the user
- Falls back to `SMILES` when no object name is provided

## Compatibility

- No new RDKit dependency is introduced by this PR
- Reuses the existing Molecular Nodes session/object creation path
- Keeps the addon functional on environments without SMILES-capable MDAnalysis by reporting a clear operator error

## Testing

Automated coverage includes:

- successful import path into `session.add_trajectory`
- missing `Universe.from_smiles` support
- empty SMILES input
- default name fallback
- parse failure propagation

## Notes

A follow-up test fix was included to align the negative-path assertions with Blender operator behavior: error-reporting operators raise `RuntimeError` through `bpy.ops`, rather than returning `{"CANCELLED"}` directly to the test.