### PR TITLE
Fix multi-file trajectory path handling during save/load

### DIFF
--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -26,26 +26,48 @@ def trim(dictionary: dict):
 
 def _make_trajectory_paths_relative(trajectories: Dict[str, Trajectory]) -> None:
     for key, traj in trajectories.items():
+        trajectory = traj.universe.trajectory
+
+        if hasattr(trajectory, "filenames"):
+            traj_files = list(trajectory.filenames)
+        else:
+            traj_files = [trajectory.filename]
+
         # skip streaming trajectories
-        if traj.universe.trajectory.filename.startswith("imd://"):
+        if any(f.startswith("imd://") for f in traj_files):
             continue
-        # save linked universe frame
+
+        # save frame
         uframe = traj.uframe
-        traj.universe.load_new(_make_path_relative(traj.universe.trajectory.filename))
-        # restore linked universe frame
+
+        new_paths = [_make_path_relative(f) for f in traj_files]
+        traj.universe.load_new(new_paths)
+
+        # restore frame
         traj.uframe = uframe
         traj._save_filepaths_on_object()
 
 
 def _make_trajectory_paths_absolute(trajectories: Dict[str, Trajectory]) -> None:
     for key, traj in trajectories.items():
+        trajectory = traj.universe.trajectory
+
+        if hasattr(trajectory, "filenames"):
+            traj_files = list(trajectory.filenames)
+        else:
+            traj_files = [trajectory.filename]
+
         # skip streaming trajectories
-        if traj.universe.trajectory.filename.startswith("imd://"):
+        if any(f.startswith("imd://") for f in traj_files):
             continue
-        # save linked universe frame
+
+        # save frame
         uframe = traj.uframe
-        traj.universe.load_new(_make_path_absolute(traj.universe.trajectory.filename))
-        # restore linked universe frame
+
+        new_paths = [_make_path_absolute(f) for f in traj_files]
+        traj.universe.load_new(new_paths)
+
+        # restore frame
         traj.uframe = uframe
         traj._save_filepaths_on_object()
 

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -41,7 +41,9 @@ def _make_trajectory_paths_relative(trajectories: Dict[str, Trajectory]) -> None
         uframe = traj.uframe
 
         new_paths = [_make_path_relative(f) for f in traj_files]
-        traj.universe.load_new(new_paths)
+        traj.universe.load_new(
+        new_paths if len(new_paths) > 1 else new_paths[0]
+        )
 
         # restore frame
         traj.uframe = uframe
@@ -65,7 +67,9 @@ def _make_trajectory_paths_absolute(trajectories: Dict[str, Trajectory]) -> None
         uframe = traj.uframe
 
         new_paths = [_make_path_absolute(f) for f in traj_files]
-        traj.universe.load_new(new_paths)
+        traj.universe.load_new(
+        new_paths if len(new_paths) > 1 else new_paths[0]
+        )
 
         # restore frame
         traj.uframe = uframe

--- a/molecularnodes/session.py
+++ b/molecularnodes/session.py
@@ -41,9 +41,7 @@ def _make_trajectory_paths_relative(trajectories: Dict[str, Trajectory]) -> None
         uframe = traj.uframe
 
         new_paths = [_make_path_relative(f) for f in traj_files]
-        traj.universe.load_new(
-        new_paths if len(new_paths) > 1 else new_paths[0]
-        )
+        traj.universe.load_new(new_paths if len(new_paths) > 1 else new_paths[0])
 
         # restore frame
         traj.uframe = uframe
@@ -67,9 +65,7 @@ def _make_trajectory_paths_absolute(trajectories: Dict[str, Trajectory]) -> None
         uframe = traj.uframe
 
         new_paths = [_make_path_absolute(f) for f in traj_files]
-        traj.universe.load_new(
-        new_paths if len(new_paths) > 1 else new_paths[0]
-        )
+        traj.universe.load_new(new_paths if len(new_paths) > 1 else new_paths[0])
 
         # restore frame
         traj.uframe = uframe


### PR DESCRIPTION
Fixes issue where only a single trajectory file path was handled during save/load relativization.

### Changes
- Added support for multiple trajectory files using `.filenames`
- Applied path conversion to all trajectory files instead of just one
- Maintained backward compatibility for single-file trajectories
- Ensured correct handling when reloading via `load_new`

### Notes
- No change to GUI behavior
- Improves API completeness for multi-file trajectories