### PR TITLE
Change CI runner from self-hosted to macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   docs:
     name: Build Documentation
     needs: [lint, build]
-    runs-on: self-hosted
+    runs-on: macos-latest
     permissions: write-all
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Might be able to render docs which requires GPU for rendering images / animations using `bpy` for EEVEE / GPU Cycles rendering.