### PR TITLE
Fix: Use world-scale box dimensions when PBC correction is applied to averaged frames.

### DIFF
--- a/molecularnodes/entities/trajectory/helpers.py
+++ b/molecularnodes/entities/trajectory/helpers.py
@@ -221,7 +221,9 @@ class FrameManager:
         """
         if self.trajectory.correct_periodic and self.trajectory._is_orthorhombic:
             return correct_periodic_positions(
-                pos1, pos2, self.trajectory.universe.dimensions[:3]
+                pos1,
+                pos2,
+                self.trajectory.universe.dimensions[:3] * self.trajectory.world_scale,
             )
         else:
             return pos2


### PR DESCRIPTION
This PR addresses a problem with PBC correction being applied to trajectory frames that were being averaged (specifically, the problem is not present for interpolated frames).

The box dimensions were not scaled by the `world_scale`, making them too large by a factor of 100. This means that the PBC correction was pretty much never applied.

Fixes #1124