### PR TITLE
Fix: Import of oxDNA base properties not set

### DIFF
--- a/molecularnodes/entities/trajectory/oxdna.py
+++ b/molecularnodes/entities/trajectory/oxdna.py
@@ -426,6 +426,7 @@ class OXDNA(Trajectory):
             Name of the new object, by default "NewUniverseObject"
         """
         super()._create_object(name=name)
+        self.set_frame(0)
         nodes.create_starting_node_tree(self.object, style="oxdna", color=None)
 
     def set_frame(self, frame: int) -> None:


### PR DESCRIPTION
The oxDNA properties for the base are set on `set_frame()` and currently aren't used on initial import. This just uses `set_frame()` on import so it is set up properly.
