### PR TITLE
Small molecule CAS (amongst others) importer

### DIFF
--- a/molecularnodes/blender_manifest.toml
+++ b/molecularnodes/blender_manifest.toml
@@ -24,7 +24,6 @@ copyright = [
 ]
 
 wheels = [
-	"./wheels/asttokens-3.0.1-py3-none-any.whl",
 	"./wheels/biotite-1.6.0-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/biotite-1.6.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
 	"./wheels/biotite-1.6.0-cp313-cp313-win_amd64.whl",
@@ -37,17 +36,12 @@ wheels = [
 	"./wheels/contourpy-1.3.3-cp313-cp313-win_amd64.whl",
 	"./wheels/cycler-0.12.1-py3-none-any.whl",
 	"./wheels/databpy-0.7.0-py3-none-any.whl",
-	"./wheels/decorator-5.2.1-py3-none-any.whl",
-	"./wheels/executing-2.2.1-py2.py3-none-any.whl",
 	"./wheels/filelock-3.25.2-py3-none-any.whl",
 	"./wheels/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl",
 	"./wheels/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
 	"./wheels/fonttools-4.62.1-cp313-cp313-win_amd64.whl",
 	"./wheels/griddataformats-1.1.0-py3-none-any.whl",
 	"./wheels/imdclient-0.2.3-py3-none-any.whl",
-	"./wheels/ipython-9.11.0-py3-none-any.whl",
-	"./wheels/ipython_pygments_lexers-1.1.1-py3-none-any.whl",
-	"./wheels/jedi-0.19.2-py2.py3-none-any.whl",
 	"./wheels/joblib-1.5.3-py3-none-any.whl",
 	"./wheels/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl",
 	"./wheels/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
@@ -55,7 +49,6 @@ wheels = [
 	"./wheels/matplotlib-3.10.8-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
 	"./wheels/matplotlib-3.10.8-cp313-cp313-win_amd64.whl",
-	"./wheels/matplotlib_inline-0.2.1-py3-none-any.whl",
 	"./wheels/mda_xdrlib-0.2.0-py3-none-any.whl",
 	"./wheels/mdanalysis-2.10.0-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/mdanalysis-2.10.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
@@ -70,15 +63,9 @@ wheels = [
 	"./wheels/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
 	"./wheels/pandas-2.3.3-cp313-cp313-win_amd64.whl",
-	"./wheels/parso-0.8.6-py2.py3-none-any.whl",
-	"./wheels/pexpect-4.9.0-py2.py3-none-any.whl",
 	"./wheels/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
 	"./wheels/pillow-12.1.1-cp313-cp313-win_amd64.whl",
-	"./wheels/prompt_toolkit-3.0.52-py3-none-any.whl",
-	"./wheels/ptyprocess-0.7.0-py2.py3-none-any.whl",
-	"./wheels/pure_eval-0.2.3-py3-none-any.whl",
-	"./wheels/pygments-2.19.2-py3-none-any.whl",
 	"./wheels/pyparsing-3.3.2-py3-none-any.whl",
 	"./wheels/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
 	"./wheels/pytz-2026.1.post1-py2.py3-none-any.whl",
@@ -89,17 +76,13 @@ wheels = [
 	"./wheels/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
 	"./wheels/scipy-1.17.1-cp313-cp313-win_amd64.whl",
 	"./wheels/six-1.17.0-py2.py3-none-any.whl",
-	"./wheels/stack_data-0.6.3-py3-none-any.whl",
 	"./wheels/starfile-0.5.13-py3-none-any.whl",
 	"./wheels/threadpoolctl-3.6.0-py3-none-any.whl",
 	"./wheels/tqdm-4.67.3-py3-none-any.whl",
-	"./wheels/traitlets-5.14.3-py3-none-any.whl",
 	"./wheels/typing_extensions-4.15.0-py3-none-any.whl",
 	"./wheels/tzdata-2025.3-py2.py3-none-any.whl",
-	"./wheels/wcwidth-0.6.0-py3-none-any.whl",
 ]
 
 [permissions]
 network = "Downloading structural data from the PDB and AFPDB"
 files = "Importing data files from disk and caching downloads"
-

--- a/molecularnodes/download.py
+++ b/molecularnodes/download.py
@@ -170,20 +170,25 @@ class StructureDownloader:
         code : str
             The CAS code of the structure to download.
 
+        Example of the API call structure:
+        https://cactus.nci.nih.gov/chemical/structure/aspirin/file?format=sdf
+        Base API: https://cactus.nci.nih.gov/chemical/structure/{code}/{representation}
+
+        Code can be CAS number, name, SMILES string, amongst other possibilities.
+        - The API will handle the code given on its own, we aren't doing anything to on our end.
+        - We are simply providing to the API a "code".
+
+        Representation can be SMILES, SDF, CIF, amongst MANY other options (see API docs)
+        - The current implementation is getting the SDF representation and turning it into a file to be loaded into MolecularNodes.
+
         Returns
         -------
         Path or io.BytesIO or io.StringIO
         """
 
         BASE_API = "https://cactus.nci.nih.gov/chemical/structure"
-        # cas_url = f"{BASE_API}/{code}/smiles"
         cas_url = f"{BASE_API}/{code}/file?format=sdf"
-        # https://cactus.nci.nih.gov/chemical/structure/aspirin/file?format=sdf
-        # r = requests.get(cas_url)
-        # r.raise_for_status()
-        # return r.text
 
-        _is_binary = format in ["bcif"]
         filename = f"{code}.sdf"
 
         if self.cache:
@@ -199,32 +204,17 @@ class StructureDownloader:
         except requests.HTTPError as e:
             raise FileDownloadPDBError(str(e))
 
-        if _is_binary:
-            content = r.content
-            # Check if the content is gzipped
-            if content[:2] == b"\x1f\x8b":  # gzip magic number
-                content = gzip.decompress(content)
-        else:
-            content = r.text
+        content = r.text
 
         if file:
-            mode = "wb+" if _is_binary else "w+"
+            mode = "w+"
             with open(file, mode) as f:
                 f.write(content)
             return Path(file)
         else:
-            if _is_binary:
-                if not isinstance(content, bytes):
-                    raise ValueError(
-                        "Binary content is not bytes, please check your format."
-                    )
-                file = io.BytesIO(content)
-            else:
-                if not isinstance(content, str):
-                    raise ValueError(
-                        "Text content is not str, please check your format."
-                    )
-                file = io.StringIO(content)
+            if not isinstance(content, str):
+                raise ValueError("Text content is not str, please check your format.")
+            file = io.StringIO(content)
 
         return file
 

--- a/molecularnodes/download.py
+++ b/molecularnodes/download.py
@@ -113,6 +113,17 @@ class StructureDownloader:
                     f"Error downloading from AlphaFold database: {str(e)}"
                 )
 
+        """
+        TODO:
+        Somewhere in here we need to add a CAS checker
+
+        Trying to reuse what we have. Download function already does what we need it to do...I think...
+        it just needs to perform the correct actions for the CAS specific pipeline.
+
+        The preceeding FETCH call that leads to download, probably has to be adjusted or cloned
+        to specifically handle CAS codes.
+        """
+
         _is_binary = format in ["bcif"]
         filename = f"{code}.{format}"
 

--- a/molecularnodes/download.py
+++ b/molecularnodes/download.py
@@ -86,6 +86,7 @@ class StructureDownloader:
         >>> path = downloader.download("1abc", format="cif")
         >>> path = downloader.download("pdb_00009bdt", format="bcif")
         """
+
         code = code.strip()
         format = format.strip(".")
         supported_formats = ["cif", "pdb", "bcif"]
@@ -113,17 +114,6 @@ class StructureDownloader:
                     f"Error downloading from AlphaFold database: {str(e)}"
                 )
 
-        """
-        TODO:
-        Somewhere in here we need to add a CAS checker
-
-        Trying to reuse what we have. Download function already does what we need it to do...I think...
-        it just needs to perform the correct actions for the CAS specific pipeline.
-
-        The preceeding FETCH call that leads to download, probably has to be adjusted or cloned
-        to specifically handle CAS codes.
-        """
-
         _is_binary = format in ["bcif"]
         filename = f"{code}.{format}"
 
@@ -136,6 +126,75 @@ class StructureDownloader:
 
         try:
             r = requests.get(self._url(code, format, database))
+            r.raise_for_status()
+        except requests.HTTPError as e:
+            raise FileDownloadPDBError(str(e))
+
+        if _is_binary:
+            content = r.content
+            # Check if the content is gzipped
+            if content[:2] == b"\x1f\x8b":  # gzip magic number
+                content = gzip.decompress(content)
+        else:
+            content = r.text
+
+        if file:
+            mode = "wb+" if _is_binary else "w+"
+            with open(file, mode) as f:
+                f.write(content)
+            return Path(file)
+        else:
+            if _is_binary:
+                if not isinstance(content, bytes):
+                    raise ValueError(
+                        "Binary content is not bytes, please check your format."
+                    )
+                file = io.BytesIO(content)
+            else:
+                if not isinstance(content, str):
+                    raise ValueError(
+                        "Text content is not str, please check your format."
+                    )
+                file = io.StringIO(content)
+
+        return file
+
+    def cas_download(
+        self,
+        code: str,
+    ) -> Path | io.BytesIO | io.StringIO:
+        """Download structure as SDF (Easily fits into existing pipelines).
+
+        Parameters
+        ----------
+        code : str
+            The CAS code of the structure to download.
+
+        Returns
+        -------
+        Path or io.BytesIO or io.StringIO
+        """
+
+        BASE_API = "https://cactus.nci.nih.gov/chemical/structure"
+        # cas_url = f"{BASE_API}/{code}/smiles"
+        cas_url = f"{BASE_API}/{code}/file?format=sdf"
+        # https://cactus.nci.nih.gov/chemical/structure/aspirin/file?format=sdf
+        # r = requests.get(cas_url)
+        # r.raise_for_status()
+        # return r.text
+
+        _is_binary = format in ["bcif"]
+        filename = f"{code}.sdf"
+
+        if self.cache:
+            file = self.cache / filename
+            if file.exists():
+                return file
+        else:
+            file = None
+
+        try:
+            r = requests.get(cas_url)
             r.raise_for_status()
         except requests.HTTPError as e:
             raise FileDownloadPDBError(str(e))

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -223,6 +223,41 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
 
         return mol
 
+    @classmethod
+    def cas_fetch(
+        cls,
+        code: str,
+        format=".bcif",
+        centre: str | None = None,
+        remove_solvent: bool = True,
+        cache: Path | str | None = download.CACHE_DIR,
+        database: str = "rcsb",
+    ) -> "Molecule":
+        """
+        Fetch a molecule from the RCSB database.
+
+        Parameters
+        ----------
+        code : str
+            The PDB ID code of the molecule to fetch.
+        format : str, optional
+            The file format to download. Default is ".bcif".
+        centre : str | None, optional
+            Method to use for centering the molecule. Options are "centroid" (geometric center)
+            or "mass" (center of mass). If None, no centering is performed. Default is None.
+        cache : str, optional
+            Path to cache directory. If None, no caching is performed.
+        remove_solvent : bool, optional
+            Whether to remove solvent from the molecule. Default is True.
+        database : str, optional
+            The database to fetch from. Default is "rcsb".
+
+        Returns
+        -------
+        Molecule
+            A new Molecule instance created from the downloaded data.
+        """
+
     def centre_molecule(self, method: str | None = "centroid"):
         """
         Offset positions to centre the atoms and vertices over either the geometric centroid

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -138,6 +138,28 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
 
         return mol
 
+    # @classmethod
+    # def cas_load(
+    #     cls,
+    #     smiles_string: str,
+    #     name: str,
+    #     remove_solvent: bool = True,
+    # ) -> "Molecule":
+    #     """
+    #     Load a molecules using the SMILES string given.
+
+    #     Parameters
+    #     ----------
+    #     smiles_string : str
+    #         The SMILES string of the molecule to load.
+    #     name : str
+    #         The name to give the molecule object.
+    #     remove_solvent : bool, optional
+    #         Whether to remove solvent from the molecule, by default True.
+    #     """
+    #     u = mda.Universe.from_smiles(smiles_string)
+    #     return Trajectory(u).create_object
+
     @property
     def code(self) -> str | None:
         """
@@ -227,11 +249,9 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
     def cas_fetch(
         cls,
         code: str,
-        format=".bcif",
         centre: str | None = None,
         remove_solvent: bool = True,
         cache: Path | str | None = download.CACHE_DIR,
-        database: str = "rcsb",
     ) -> "Molecule":
         """
         Fetch a molecule from the RCSB database.
@@ -240,8 +260,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         ----------
         code : str
             The PDB ID code of the molecule to fetch.
-        format : str, optional
-            The file format to download. Default is ".bcif".
         centre : str | None, optional
             Method to use for centering the molecule. Options are "centroid" (geometric center)
             or "mass" (center of mass). If None, no centering is performed. Default is None.
@@ -257,6 +275,12 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         Molecule
             A new Molecule instance created from the downloaded data.
         """
+
+        cas_SDF_path = download.StructureDownloader(cache=cache).cas_download(code=code)
+        mol = cls.load(cas_SDF_path, name=code, remove_solvent=remove_solvent)
+        mol._code = code
+
+        return mol
 
     def centre_molecule(self, method: str | None = "centroid"):
         """

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -138,28 +138,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
 
         return mol
 
-    # @classmethod
-    # def cas_load(
-    #     cls,
-    #     smiles_string: str,
-    #     name: str,
-    #     remove_solvent: bool = True,
-    # ) -> "Molecule":
-    #     """
-    #     Load a molecules using the SMILES string given.
-
-    #     Parameters
-    #     ----------
-    #     smiles_string : str
-    #         The SMILES string of the molecule to load.
-    #     name : str
-    #         The name to give the molecule object.
-    #     remove_solvent : bool, optional
-    #         Whether to remove solvent from the molecule, by default True.
-    #     """
-    #     u = mda.Universe.from_smiles(smiles_string)
-    #     return Trajectory(u).create_object
-
     @property
     def code(self) -> str | None:
         """
@@ -250,7 +228,6 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         cls,
         code: str,
         centre: str | None = None,
-        remove_solvent: bool = True,
         cache: Path | str | None = download.CACHE_DIR,
     ) -> "Molecule":
         """
@@ -277,7 +254,7 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         """
 
         cas_SDF_path = download.StructureDownloader(cache=cache).cas_download(code=code)
-        mol = cls.load(cas_SDF_path, name=code, remove_solvent=remove_solvent)
+        mol = cls.load(cas_SDF_path, name=code)
         mol._code = code
 
         return mol

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -231,21 +231,17 @@ class Molecule(MolecularEntity, metaclass=ABCMeta):
         cache: Path | str | None = download.CACHE_DIR,
     ) -> "Molecule":
         """
-        Fetch a molecule from the RCSB database.
+        Fetch a molecule from the NCI NIH database.
 
         Parameters
         ----------
         code : str
-            The PDB ID code of the molecule to fetch.
+            The CAS ID code of the molecule to fetch.
         centre : str | None, optional
             Method to use for centering the molecule. Options are "centroid" (geometric center)
             or "mass" (center of mass). If None, no centering is performed. Default is None.
         cache : str, optional
             Path to cache directory. If None, no caching is performed.
-        remove_solvent : bool, optional
-            Whether to remove solvent from the molecule. Default is True.
-        database : str, optional
-            The database to fetch from. Default is "rcsb".
 
         Returns
         -------

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -34,6 +34,8 @@ from . import node_info
 from .props import SURFACE_STYLE_ITEMS
 from .style import STYLE_ITEMS
 
+""" from posix import remove"""
+
 
 def _add_node(node_name, context, show_options=False, material="default"):
     """
@@ -899,7 +901,6 @@ class MN_OT_Import_CAS(bpy.types.Operator):
             entities.Molecule.cas_fetch(
                 code=self.code,
                 cache=self.cache_dir,
-                database=self.database,
             )
             .add_style(
                 style=self.style if self.node_setup else None,  # type: ignore

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -823,6 +823,101 @@ class MN_OT_Import_OxDNA_Trajectory(TrajectoryImportOperator):
         return {"FINISHED"}
 
 
+class MN_OT_Import_CAS(bpy.types.Operator):
+    """
+    Operator for importing simple molecules from a CAS code database.
+    """
+
+    bl_idname = "mn.import_cas"
+    bl_label = "Import CAS"
+    bl_description = "Import simple molecule from CAS code database"
+    bl_options = {"REGISTER", "UNDO"}
+
+    code: StringProperty(  # type: ignore
+        name="CAS",
+        description="The max 12-character CAS code to download",
+        options={"TEXTEDIT_UPDATE"},
+    )
+
+    node_setup: BoolProperty(  # type: ignore
+        name="Setup Nodes",
+        default=True,
+        description="Create and set up a Geometry Nodes tree on import",
+    )
+
+    style: EnumProperty(  # type: ignore
+        name="Style",
+        description="Default style for importing",
+        items=STYLE_ITEMS,
+        default="spheres",
+    )
+
+    cache_dir: StringProperty(  # type: ignore
+        name="Cache Directory",
+        description="Where to store the structures downloaded from the Protein Data Bank",
+        default=str(CACHE_DIR),
+        subtype="DIR_PATH",
+    )
+
+    del_hydrogen: BoolProperty(  # type: ignore
+        name="Remove Hydrogens",
+        description="Remove the hydrogens from a structure on import",
+        default=False,
+    )
+
+    centre: BoolProperty(  # type: ignore
+        name="Centre",
+        description="Centre the structure on the world origin",
+        default=False,
+    )
+
+    database: StringProperty(  # type: ignore
+        name="CAS Database",
+        description="The NCI NIH CAS database",
+        default="NIH",
+    )
+
+    centre_type: EnumProperty(  # type: ignore
+        name="Method",
+        default="mass",
+        items=(
+            (
+                "mass",
+                "Mass",
+                "Adjust the structure's centre of mass to be at the world origin",
+            ),
+            (
+                "centroid",
+                "Centroid",
+                "Adjust the structure's centroid (centre of geometry) to be at the world origin",
+            ),
+        ),
+    )
+
+    def execute(self, context):
+        mol = (
+            entities.Molecule.cas_fetch(
+                code=self.code,
+                cache=self.cache_dir,
+                database=self.database,
+            )
+            .add_style(
+                style=self.style if self.node_setup else None,  # type: ignore
+            )
+            .centre_molecule(self.centre_type if self.centre else None)
+        )
+
+        message = f"Downloaded {self.code} as {mol.name}"
+        try:
+            bpy.context.view_layer.objects.active = mol.object  # type: ignore
+        except RuntimeError:
+            message += " - MolecularNodes collection is disabled"
+
+        self.report({"INFO"}, message=message)
+
+        return {"FINISHED"}
+
+
 class MN_OT_Add_Style(Operator):
     """
     Operator to add a new style to an entity
@@ -1171,6 +1266,7 @@ CLASSES = [
     MN_OT_Node_Swap,
     MN_OT_Node_Swap_Style_Menu,
     MN_OT_Import_Fetch,
+    MN_OT_Import_CAS,
     MN_OT_Import_OxDNA_Trajectory,
     MN_OT_Import_Trajectory,
     MN_OT_Reload_Trajectory,

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -34,8 +34,6 @@ from . import node_info
 from .props import SURFACE_STYLE_ITEMS
 from .style import STYLE_ITEMS
 
-""" from posix import remove"""
-
 
 def _add_node(node_name, context, show_options=False, material="default"):
     """

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -828,6 +828,14 @@ class MN_OT_Import_OxDNA_Trajectory(TrajectoryImportOperator):
 class MN_OT_Import_CAS(bpy.types.Operator):
     """
     Operator for importing simple molecules from a CAS code database.
+
+    Original implementation idea was to use CAS codes, but the fact is, the NCI NIH
+    API we are calling, will automatically understand CAS codes, common names, SMILES strings,
+    and even other options to give a result.
+
+    Example:
+    --------
+    The common name "aspirin" or the CAS code 50-78-2 can be given and the same result will be obtained.
     """
 
     bl_idname = "mn.import_cas"

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -843,7 +843,7 @@ class MN_OT_Import_CAS(bpy.types.Operator):
 
     code: StringProperty(  # type: ignore
         name="CAS",
-        description="The max 12-character CAS code to download",
+        description="The CAS code to download",
         options={"TEXTEDIT_UPDATE"},
     )
 

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -851,7 +851,7 @@ class MN_OT_Import_CAS(bpy.types.Operator):
         name="Style",
         description="Default style for importing",
         items=STYLE_ITEMS,
-        default="spheres",
+        default="ball_and_stick",
     )
 
     cache_dir: StringProperty(  # type: ignore
@@ -859,12 +859,6 @@ class MN_OT_Import_CAS(bpy.types.Operator):
         description="Where to store the structures downloaded from the Protein Data Bank",
         default=str(CACHE_DIR),
         subtype="DIR_PATH",
-    )
-
-    del_hydrogen: BoolProperty(  # type: ignore
-        name="Remove Hydrogens",
-        description="Remove the hydrogens from a structure on import",
-        default=False,
     )
 
     centre: BoolProperty(  # type: ignore

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -255,6 +255,10 @@ def panel_oxdna(layout: bpy.types.UILayout, scene: bpy.types.Scene) -> None:
     col.prop(scene.mn, "import_oxdna_trajectory")
 
 
+def panel_cas(layout, scene):
+    pass
+
+
 chosen_panel = {
     "pdb": panel_wwpdb,
     "local": panel_local,
@@ -264,6 +268,7 @@ chosen_panel = {
     "density": panel_density,
     "cellpack": panel_cellpack,
     "dna": panel_oxdna,
+    "cas": panel_cas,
 }
 
 

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -267,7 +267,7 @@ def panel_cas(layout, scene):
     op.code = scene.mn.import_code_cas  # type: ignore
     op.database = "NIH"  # type: ignore
     op.node_setup = scene.mn.import_node_setup  # type: ignore
-    op.style = scene.mn.import_style  # type: ignore
+    op.style = scene.mn.import_style_cas  # type: ignore
     op.centre = scene.mn.import_centre  # type: ignore
     op.centre_type = scene.mn.import_centre_type  # type: ignore
 
@@ -286,7 +286,7 @@ def panel_cas(layout, scene):
     row = options.row()
     row.prop(scene.mn, "import_node_setup", text="")
     col = row.column()
-    col.prop(scene.mn, "import_style")
+    col.prop(scene.mn, "import_style_cas")
     col.enabled = scene.mn.import_node_setup
 
     row_centre = options.row()
@@ -295,9 +295,6 @@ def panel_cas(layout, scene):
     col_centre.prop(scene.mn, "import_centre_type", text="")
     col_centre.enabled = scene.mn.import_centre
     options.separator()
-
-    grid = options.grid_flow()
-    grid.prop(scene.mn, "import_del_hydrogen")
 
 
 chosen_panel = {

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -256,7 +256,48 @@ def panel_oxdna(layout: bpy.types.UILayout, scene: bpy.types.Scene) -> None:
 
 
 def panel_cas(layout, scene):
-    pass
+    layout.label(text="Download from NIH CAS Database", icon="IMPORT")
+    layout.separator()
+
+    layout = check_online_access_for_ui(layout)
+
+    row_import = layout.row().split(factor=0.5)
+    row_import.prop(scene.mn, "import_code_cas")
+    op = row_import.operator("mn.import_cas")
+    op.code = scene.mn.import_code_cas  # type: ignore
+    op.database = "NIH"  # type: ignore
+    op.node_setup = scene.mn.import_node_setup  # type: ignore
+    op.style = scene.mn.import_style  # type: ignore
+    op.centre = scene.mn.import_centre  # type: ignore
+    op.centre_type = scene.mn.import_centre_type  # type: ignore
+
+    prefs = addon_preferences()
+    if prefs is not None:
+        op.cache_dir = str(prefs.cache_dir)  # type: ignore
+    else:
+        op.cache_dir = str(bpy.app.tempdir)  # type: ignore
+    layout.separator(factor=0.4)
+
+    layout.separator()
+
+    layout.label(text="Options", icon="MODIFIER")
+    options = layout.column(align=True)
+
+    row = options.row()
+    row.prop(scene.mn, "import_node_setup", text="")
+    col = row.column()
+    col.prop(scene.mn, "import_style")
+    col.enabled = scene.mn.import_node_setup
+
+    row_centre = options.row()
+    row_centre.prop(scene.mn, "import_centre", icon_value=0)
+    col_centre = row_centre.column()
+    col_centre.prop(scene.mn, "import_centre_type", text="")
+    col_centre.enabled = scene.mn.import_centre
+    options.separator()
+
+    grid = options.grid_flow()
+    grid.prop(scene.mn, "import_del_hydrogen")
 
 
 chosen_panel = {

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -421,6 +421,7 @@ class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
             ("star", "Starfile", "Import a .starfile mapback file"),
             ("cellpack", "CellPack", "Import a CellPack .cif/.bcif file"),
             ("dna", "oxDNA", "Import an oxDNA file"),
+            ("cas", "CAS", "Import from the NIH CAS Database"),
         ),
     )
     import_star_file_path: StringProperty(  # type: ignore

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -264,6 +264,13 @@ class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
         maxlen=4,
     )
 
+    import_code_cas: StringProperty(  # type: ignore
+        name="CAS",
+        description="The CAS code to download and import",
+        options={"TEXTEDIT_UPDATE"},
+        maxlen=12,
+    )
+
     is_updating: BoolProperty(  # type: ignore
         name="Updating",
         description="Currently updating data in the scene, don't trigger more updates",

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -268,7 +268,6 @@ class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
         name="CAS",
         description="The CAS code to download and import",
         options={"TEXTEDIT_UPDATE"},
-        maxlen=12,
     )
 
     is_updating: BoolProperty(  # type: ignore

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -339,6 +339,12 @@ class MolecularNodesSceneProperties(bpy.types.PropertyGroup):
         items=STYLE_ITEMS,
         default="spheres",
     )
+    import_style_cas: EnumProperty(  # type: ignore
+        name="Style",
+        description="Default style for importing",
+        items=STYLE_ITEMS,
+        default="ball_and_stick",
+    )
     import_md_topology: StringProperty(  # type: ignore
         name="Topology",
         description="File path for the toplogy file for the trajectory",


### PR DESCRIPTION
Built out small molecule import pipeline. Originally meant to use CAS numbers, but as the pipeline ultimately makes a API requests, and the API used actually accepts CAS numbers, SMILES, common names, scientific names, and more, this addition organically became a bit more versatile.

Additions
-----------
CAS specific Scene panel (realizing this "CAS" annotation should probably be adjusted as I write this...)
New .download pipeline (can actually probably be refactored into the original .download pipeline)
New .cas_fetch pipeline (broke out from the original fetch more so for simplicity)
New CAS_Import operator
Some new props to setup the operator and styling (in my opinion, it seems like a ball and stick default better showcases small molecules as opposed to the space filling sphere, but this is subjective of course.

FINAL NOTE: As I'm literally writing this PR, I'm realizing the "CAS" naming convention should probably be adjusted to better match the fact that this new importer can accept more than just CAS. And, there are almost certainly some methods that can be refactored or merged with previously existing functions. At this point, I chose to leave everything as I built it, if not at least so it's clear how the pipeline works, and then I can later refactor things back down so it's a little more streamlined if desirable (most obvious to me at this point is the .download function.