### PR TITLE
Fix: #1149 Increase Clip End on Import

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,6 +22,8 @@ website:
       text: Documentation
     - text: API
       href: api/
+    - text: Changelog
+      href: changelog.qmd
     - href: examples/
       text: Examples
     - href: citations/

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -1,0 +1,8 @@
+---
+title: "Changelog"
+---
+
+# 5.2.0 - UNRELEASED
+
+## Added
+- On using the import operators, the camera and viewport end clipping distance is increased to 10000 from 100 so users aren't confused when importing larger structures and systems #1150

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -30,6 +30,7 @@ from ..nodes.node_management import (
 )
 from ..scene.compositor import setup_compositor
 from ..session import get_session
+from ..utils import _increase_view_distance
 from .pref import addon_preferences
 from .style import STYLE_ITEMS
 
@@ -159,6 +160,7 @@ class MN_OT_Import_Molecule(Import_Molecule):
             except Exception as e:
                 print(f"Failed importing {file}: {e}")
 
+        _increase_view_distance()
         return {"FINISHED"}
 
     def invoke(self, context, event):
@@ -310,6 +312,7 @@ class MN_OT_Import_Fetch(Import_Molecule, bpy.types.Operator):
 
         self.report({"INFO"}, message=message)
 
+        _increase_view_distance()
         return {"FINISHED"}
 
 
@@ -366,6 +369,8 @@ class MN_OT_Import_Ensemble(bpy.types.Operator):
                 file_path=file_path,
                 node_setup=self.node_setup,
             )
+
+        _increase_view_distance()
         return {"FINISHED"}
 
 
@@ -452,6 +457,7 @@ class MN_OT_Import_Map(bpy.types.Operator):
             center=self.center,
             overwrite=self.overwrite,
         )
+        _increase_view_distance()
         return {"FINISHED"}
 
 
@@ -667,6 +673,7 @@ class MN_OT_Import_Trajectory(bpy.types.Operator):
                 f"with {n_frames} frames from '{self.trajectory}'.",
             )
 
+        _increase_view_distance()
         return {"FINISHED"}
 
 

--- a/molecularnodes/utils.py
+++ b/molecularnodes/utils.py
@@ -2,11 +2,25 @@ import json
 import os
 import sys
 from contextlib import ExitStack
-from typing import List
+from typing import List, cast
 import addon_utils
 import bpy
 import numpy as np
 from mathutils import Matrix
+
+_INCREASED_CLIP_END = 1e4
+
+
+def _increase_view_distance():
+    context = bpy.context
+    scene = context.scene
+    assert scene
+    camera = cast(bpy.types.Camera, scene.camera.data)
+    if camera is not None and camera.clip_end == 1e2:
+        camera.clip_end = _INCREASED_CLIP_END
+
+    # TODO: Increase view distance for the viewports as well
+    # but it seems to be on a area-by-area basis rather than globally
 
 
 def load_extension_module():

--- a/molecularnodes/utils.py
+++ b/molecularnodes/utils.py
@@ -9,18 +9,29 @@ import numpy as np
 from mathutils import Matrix
 
 _INCREASED_CLIP_END = 1e4
+_DEFAULT_CAMERA_CLIP_END = 1e2
+_DEFAULT_VIEWPORT_CLIP_END = 1e3
 
 
 def _increase_view_distance():
-    context = bpy.context
-    scene = context.scene
+    scene = bpy.context.scene
     assert scene
-    camera = cast(bpy.types.Camera, scene.camera.data)
-    if camera is not None and camera.clip_end == 1e2:
-        camera.clip_end = _INCREASED_CLIP_END
+    if scene.camera is not None:
+        camera = cast(bpy.types.Camera, scene.camera.data)
+        if camera.clip_end == _DEFAULT_CAMERA_CLIP_END:
+            camera.clip_end = _INCREASED_CLIP_END
 
-    # TODO: Increase view distance for the viewports as well
-    # but it seems to be on a area-by-area basis rather than globally
+    # viewport clip end is stored per 3D Viewport space, so update every
+    # VIEW_3D area across all screens (covers currently inactive workspaces)
+    for screen in bpy.data.screens:
+        for area in screen.areas:
+            if area.type != "VIEW_3D":
+                continue
+            for space in area.spaces:
+                if space.type == "VIEW_3D":
+                    space = cast(bpy.types.SpaceView3D, space)
+                    if space.clip_end == _DEFAULT_VIEWPORT_CLIP_END:
+                        space.clip_end = _INCREASED_CLIP_END
 
 
 def load_extension_module():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,20 +2,35 @@ from typing import cast
 import bpy
 import numpy as np
 import pytest
-from bpy.types import Camera
+from bpy.types import Camera, SpaceView3D
 import molecularnodes as mn
 from molecularnodes.utils import frame_mapper
 from .constants import codes
 
 
-def test_view_distance_increaeses():
+def _viewport_spaces():
+    return [
+        cast(SpaceView3D, space)
+        for screen in bpy.data.screens
+        for area in screen.areas
+        if area.type == "VIEW_3D"
+        for space in area.spaces
+        if space.type == "VIEW_3D"
+    ]
+
+
+def test_view_distance_increases():
     context = bpy.context
     scene = context.scene
     assert scene
     camera = cast(Camera, scene.camera.data)
     assert camera.clip_end == pytest.approx(100.0)
+    for space in _viewport_spaces():
+        assert space.clip_end == pytest.approx(1000.0)
     bpy.ops.mn.import_fetch(code=codes[0])
     assert camera.clip_end == pytest.approx(mn.utils._INCREASED_CLIP_END)
+    for space in _viewport_spaces():
+        assert space.clip_end == pytest.approx(mn.utils._INCREASED_CLIP_END)
 
 
 def test_correct_1d():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,21 @@
+from typing import cast
+import bpy
 import numpy as np
+import pytest
+from bpy.types import Camera
 import molecularnodes as mn
 from molecularnodes.utils import frame_mapper
+from .constants import codes
+
+
+def test_view_distance_increaeses():
+    context = bpy.context
+    scene = context.scene
+    assert scene
+    camera = cast(Camera, scene.camera.data)
+    assert camera.clip_end == pytest.approx(100.0)
+    bpy.ops.mn.import_fetch(code=codes[0])
+    assert camera.clip_end == pytest.approx(mn.utils._INCREASED_CLIP_END)
 
 
 def test_correct_1d():


### PR DESCRIPTION
Now the `world_scale` has increased 10x a lot of structures and emsebles are not immediately visible on import. This PR increases the camera clip_end on import (if if was the default value) so that a user isn't confused by not being able to see the imported structure.
