### PR TITLE
Fix single frame Molecule's triggering update

### DIFF
--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -809,6 +809,12 @@ class Molecule(MolecularEntity):
         -----
         Typically called automatically by frame change handlers, not user code.
         """
+        # single-frame structures have no trajectory to update; skip so that
+        # manually modified positions aren't reset on scene frame changes.
+        # n_frames is None for streaming trajectories, which must still update.
+        n_frames = self.frame_manager.n_frames
+        if n_frames is not None and n_frames <= 1:
+            return
         if self._updating_in_progress:
             logger.debug("Update already in progress, skipping nested update")
             return

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -10,6 +10,7 @@ import pytest
 import molecularnodes as mn
 from .constants import data_dir
 from .utils import NumpySnapshotExtension
+from numpy.testing import assert_almost_equal
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore:.*Empty string to select atoms.*:UserWarning"),
@@ -22,6 +23,24 @@ pytestmark = [
 def dummy_calculation_for_pickle_test(universe):
     """Module-level function for testing calculations pickling."""
     return universe.atoms.positions.mean(axis=0)
+
+
+class TestMoleculeSingleStructure:
+    @pytest.fixture
+    def mol(self) -> mn.Molecule:
+        return mn.Molecule.fetch("4ozs", cache=data_dir)
+
+    def test_positions(self, mol: mn.Molecule):
+        pos_0 = mol.position
+        mol.position -= mol.centroid()
+        pos_moved = mol.position
+        assert not np.allclose(pos_0, pos_moved)
+        # changing the scene frame calls set_frame() on all entities; a
+        # single-frame structure should keep manually modified positions
+        # rather than having them reset to the universe coordinates
+        bpy.context.scene.frame_set(1)
+        bpy.context.scene.frame_set(0)
+        assert_almost_equal(pos_moved, mol.position)
 
 
 class TestTrajectory:

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -7,10 +7,10 @@ import databpy
 import MDAnalysis as mda
 import numpy as np
 import pytest
+from numpy.testing import assert_almost_equal
 import molecularnodes as mn
 from .constants import data_dir
 from .utils import NumpySnapshotExtension
-from numpy.testing import assert_almost_equal
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore:.*Empty string to select atoms.*:UserWarning"),


### PR DESCRIPTION
The `set_frame()` was triggering on every update, even on a single frame Molecule. This triggered a GN updated that wasn't required. This adds a guard to ensure it only triggers when multiple frames are present.
