### PR TITLE
Fix and improve selection updating

### DIFF
--- a/molecularnodes/entities/molecule/selections.py
+++ b/molecularnodes/entities/molecule/selections.py
@@ -398,17 +398,22 @@ class SelectionManager:
             # creating the AtomGroup we set the messag to "" as a signal everything is OK
             # and continue on with setting the attribute value
             # We also have to track if we need to update the AtomGroup because the user has
-            # changed the input string at all. We just track with a "previous_string" which
-            # should only be updated if an AtomGroup has successfully been created with the
-            # input selection string
-            if item.string != item.previous_string or item.message != "":
+            # changed any of the selection inputs at all. We just track with "previous_*"
+            # values which should only be updated if an AtomGroup has successfully been
+            # created with the input selection parameters
+            if (
+                item.string != item.previous_string
+                or item.updating != item.previous_updating
+                or item.periodic != item.previous_periodic
+                or item.message != ""
+            ):
                 try:
-                    ag = self.universe.select_atoms(
-                        item.string, updating=item.updating, periodic=item.periodic
-                    )
+                    ag = self.ui_item_to_ag(item)
                     self.atomgroups[item.name] = ag
                     item.message = ""
                     item.previous_string = item.string
+                    item.previous_updating = item.updating
+                    item.previous_periodic = item.periodic
                     selection_has_changed = True
                 except Exception as e:
                     item.message = str(e)

--- a/molecularnodes/handlers.py
+++ b/molecularnodes/handlers.py
@@ -22,6 +22,17 @@ def _update_entities(self, context: bpy.types.Context) -> None:
     update_entities(context.scene)
 
 
+def _update_selections(self, context: bpy.types.Context) -> None:
+    """
+    Update callback for `TrajectorySelectionItem` properties. Re-evaluates the
+    selections on the owning entity directly, rather than going through the frame
+    update machinery which skips single-frame entities entirely
+    """
+    entity = context.scene.MNSession.match(self.id_data)
+    if entity is not None and hasattr(entity, "selections"):
+        entity.selections.update_attributes()
+
+
 # this is the 'perisisent' function which can be appended onto the
 # `bpy.app.handlers.frame_change_*` functions. Either before or after the frame changes
 # this function will then be called - ensuring all of the trajectories are up to date. We

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -725,12 +725,23 @@ class MN_OT_add_selection_to_style(Operator):
             self.report({"ERROR"}, message="No molecule found for this object")
             return {"CANCELLED"}
 
+        node_group = bpy.data.node_groups.get(self.node_tree)
+        if node_group is None:
+            self.report({"ERROR"}, message=f"Node tree '{self.node_tree}' not found")
+            return {"CANCELLED"}
+
+        node = node_group.nodes.get(self.node_name)
+        if node is None:
+            self.report(
+                {"ERROR"},
+                message=f"Node '{self.node_name}' not found in '{self.node_tree}'",
+            )
+            return {"CANCELLED"}
+
         selection = mol.selections.from_string("all")
 
-        node_group = bpy.data.node_groups.get(self.node_tree)
-
         with nodebpy.TreeBuilder(node_group):
-            style = nodebpy.geometry.Group._from_node(node_group.get(self.node_name))
+            style = nodebpy.geometry.Group._from_node(node)
             selection.node() >> style.i["Selection"]
 
         return {"FINISHED"}

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -11,7 +11,7 @@ from bpy.props import (
 from nodebpy.nodes.geometry import NamedAttribute
 from ..blender.utils import set_object_visibility
 from ..entities.base import EntityType
-from ..handlers import _update_entities
+from ..handlers import _update_entities, _update_selections
 from ..session import get_entity
 
 uuid_property = StringProperty(
@@ -529,23 +529,25 @@ class TrajectorySelectionItem(bpy.types.PropertyGroup):
         name="Selection",
         description="Selection to be applied, written in the MDAnalysis selection language",
         default="name CA",
-        update=_update_entities,
+        update=_update_selections,
     )
 
     previous_string: StringProperty()  # type: ignore
+    previous_updating: BoolProperty(default=True)  # type: ignore
+    previous_periodic: BoolProperty(default=True)  # type: ignore
 
     updating: BoolProperty(  # type: ignore
         name="Updating",
         description="Potential recalculate the selection when the scene frame changes",
         default=True,
-        update=_update_entities,
+        update=_update_selections,
     )
 
     periodic: BoolProperty(  # type: ignore
         name="Periodic",
         description="For geometric selections, whether to account for atoms in different periodic images when searching",
         default=True,
-        update=_update_entities,
+        update=_update_selections,
     )
 
     message: StringProperty(  # type: ignore

--- a/tests/test_add_style.py
+++ b/tests/test_add_style.py
@@ -124,9 +124,7 @@ def test_add_selection_to_style_operator_missing_targets():
         )
 
     with pytest.raises(RuntimeError, match="not found"):
-        bpy.ops.mn.add_selection_to_style(
-            node_tree=ng.name, node_name="does not exist"
-        )
+        bpy.ops.mn.add_selection_to_style(node_tree=ng.name, node_name="does not exist")
 
     # the style node is untouched by the failed attempts
     assert not style.inputs["Selection"].links

--- a/tests/test_add_style.py
+++ b/tests/test_add_style.py
@@ -83,3 +83,50 @@ def test_swap_style_operator():
     style_nodes = [n for n in ng.nodes if is_style_node(n)]
     assert len(style_nodes) == 1
     assert style_nodes[0].node_tree.name == "Style Surface"
+
+
+def test_add_selection_to_style_operator():
+    """mn.add_selection_to_style wires a named-attribute selection into the style node."""
+    from molecularnodes.ui.panel import is_style_node
+
+    mol = mn.Molecule.load(data_dir / "1cd3.cif").add_style("cartoon")
+    ng = mol.modifier_node_tree
+    style = [n for n in ng.nodes if is_style_node(n)][0]
+    assert not style.inputs["Selection"].links
+
+    bpy.context.view_layer.objects.active = mol.object
+    res = bpy.ops.mn.add_selection_to_style(node_tree=ng.name, node_name=style.name)
+    assert res == {"FINISHED"}
+
+    # the style's Selection input is now driven by a named attribute node whose
+    # name matches a selection on the molecule, as the panel expects
+    links = style.inputs["Selection"].links
+    assert links
+    attr_node = links[0].from_node
+    assert isinstance(attr_node, bpy.types.GeometryNodeInputNamedAttribute)
+    selection = mol.selections.get(attr_node.inputs["Name"].default_value)
+    assert selection is not None
+    assert selection.string == "all"
+
+
+def test_add_selection_to_style_operator_missing_targets():
+    """mn.add_selection_to_style errors cleanly when the tree or node is gone."""
+    from molecularnodes.ui.panel import is_style_node
+
+    mol = mn.Molecule.load(data_dir / "1cd3.cif").add_style("cartoon")
+    ng = mol.modifier_node_tree
+    style = [n for n in ng.nodes if is_style_node(n)][0]
+    bpy.context.view_layer.objects.active = mol.object
+
+    with pytest.raises(RuntimeError, match="not found"):
+        bpy.ops.mn.add_selection_to_style(
+            node_tree="does not exist", node_name=style.name
+        )
+
+    with pytest.raises(RuntimeError, match="not found"):
+        bpy.ops.mn.add_selection_to_style(
+            node_tree=ng.name, node_name="does not exist"
+        )
+
+    # the style node is untouched by the failed attempts
+    assert not style.inputs["Selection"].links

--- a/tests/test_selections.py
+++ b/tests/test_selections.py
@@ -1,0 +1,69 @@
+import numpy as np
+import molecularnodes as mn
+
+
+def test_selection_string_changes():
+    mol = mn.Molecule.fetch("1bna")
+    sel = mol.selections.from_string("resid 1:10")
+
+    with mol.tree.reset() as (atoms, join):
+        atoms >> mn.nodes.geometry.SeparateAtoms(selection=sel.node()) >> join
+
+    current = mol.named_attribute("position", evaluate=True)
+    sel.string = "resid 1:5"
+    # narrowing the selection reduces the number of separated atoms
+    assert len(current) > len(mol.named_attribute("position", evaluate=True))
+
+
+def test_selection_updating_toggle_rebuilds_atomgroup():
+    """Toggling `updating` swaps between an UpdatingAtomGroup and a static one."""
+    mol = mn.Molecule.fetch("1bna")
+    sel = mol.selections.from_string("resid 1:10")
+    manager = mol.selections
+
+    ag = manager.atomgroups[sel.name]
+    assert manager.ag_is_updating(ag)
+
+    sel.updating = False
+    ag_static = manager.atomgroups[sel.name]
+    assert ag_static is not ag
+    assert not manager.ag_is_updating(ag_static)
+    assert sel.message == ""
+
+    sel.updating = True
+    ag_updating = manager.atomgroups[sel.name]
+    assert ag_updating is not ag_static
+    assert manager.ag_is_updating(ag_updating)
+
+
+def test_selection_periodic_toggle_rebuilds_atomgroup():
+    """Toggling `periodic` recreates the AtomGroup and re-stores the attribute."""
+    mol = mn.Molecule.fetch("1bna")
+    sel = mol.selections.from_string("around 5.0 resid 1")
+    manager = mol.selections
+
+    ag = manager.atomgroups[sel.name]
+    sel.periodic = False
+    ag_after = manager.atomgroups[sel.name]
+    assert ag_after is not ag
+    assert sel.message == ""
+
+    # the stored boolean attribute matches the rebuilt AtomGroup
+    mask = mol.named_attribute(sel.name)
+    assert mask.sum() == ag_after.n_atoms
+
+
+def test_selection_bad_string_sets_message_and_recovers():
+    """An invalid selection string flags an error and a valid one clears it."""
+    mol = mn.Molecule.fetch("1bna")
+    sel = mol.selections.from_string("resid 1:10")
+    mask_before = mol.named_attribute(sel.name)
+
+    sel.string = "not a valid selection"
+    assert sel.message != ""
+    # the attribute keeps its last good value
+    assert np.array_equal(mol.named_attribute(sel.name), mask_before)
+
+    sel.string = "resid 1:5"
+    assert sel.message == ""
+    assert mol.named_attribute(sel.name).sum() < mask_before.sum()


### PR DESCRIPTION
Selections weren't updating on single frame entities as they were blocked via `set_frame()`. They now use separate update handlers and have more robust tests.
