### PR TITLE
Fix: #1112 StreamingTrajectory frame updating

### DIFF
--- a/molecularnodes/entities/molecule/imd.py
+++ b/molecularnodes/entities/molecule/imd.py
@@ -78,6 +78,7 @@ class StreamingTrajectory(Molecule):
         create_object=True,
     ):
         super().__init__(universe, name=name, create_object=create_object)
+        self._last_scene_frame: Optional[int] = None
 
     @property
     def n_frames(self) -> Optional[int]:
@@ -96,13 +97,16 @@ class StreamingTrajectory(Molecule):
     def _update_trajectory_positions(self, frame: int) -> None:
         """Override to handle streaming frame updates.
 
-        For streaming trajectories, we ignore the requested frame number
-        and simply advance to the next available frame from the stream.
+        For streaming trajectories, the requested frame number can't be seeked
+        to; instead the stream advances to the next available frame - but only
+        when the scene frame has changed since the last advance. Repeated
+        updates for the same scene frame (render handlers, UI property changes)
+        would otherwise silently consume streamed frames (#1112).
 
         Parameters
         ----------
         frame : int
-            Ignored for streaming trajectories
+            Scene frame number, only used to detect frame changes
 
         Raises
         ------
@@ -111,9 +115,12 @@ class StreamingTrajectory(Molecule):
         Exception
             If there's an error reading from the IMD stream
         """
+        if frame == self._last_scene_frame:
+            return
         try:
             self.universe.trajectory.next()
             self.position = self._scaled_position
+            self._last_scene_frame = frame
         except StopIteration:
             logger.warning("Stream ended or connection lost")
             raise

--- a/tests/test_imd.py
+++ b/tests/test_imd.py
@@ -1,0 +1,30 @@
+import MDAnalysis as mda
+from molecularnodes.entities.molecule.imd import StreamingTrajectory
+from .constants import data_dir
+
+
+def _streaming_trajectory() -> StreamingTrajectory:
+    # a regular multi-frame universe stands in for an IMD stream, as `.next()`
+    # behaves the same and lets the test observe the reader's frame
+    universe = mda.Universe(
+        data_dir / "md_ppr/box.gro",
+        data_dir / "md_ppr/first_5_frames.xtc",
+    )
+    return StreamingTrajectory(universe, name="stream")
+
+
+def test_stream_advances_once_per_scene_frame():
+    traj = _streaming_trajectory()
+    assert traj.universe.trajectory.frame == 0
+
+    traj.set_frame(1)
+    assert traj.universe.trajectory.frame == 1
+
+    # repeated updates for the same scene frame (render handlers, UI property
+    # changes) must not advance the stream
+    traj.set_frame(1)
+    traj.set_frame(1)
+    assert traj.universe.trajectory.frame == 1
+
+    traj.set_frame(2)
+    assert traj.universe.trajectory.frame == 2


### PR DESCRIPTION
Now only reqeusts the next frame and updates when the frame is set to a
_different_ frame to what was previously set. There was an issue where
rendering an image would advance the trajectory on each render, even if
the scene stayed on the same frame. Same with access via the API where
`set_frame()` would advance the trajectory even if setting it to the
same frame.

Fixes #1112
