### PR TITLE
Improvements to `add_style`

### DIFF
--- a/docs/api/_sidebar.yml
+++ b/docs/api/_sidebar.yml
@@ -10,6 +10,7 @@ website:
     - api/rendering.qmd
     - api/materials.qmd
     - api/annotations.qmd
+    - api/solvent.qmd
     - api/canvas.qmd
     - api/blender.qmd
     - text: '---'

--- a/docs/api/nodebpy.qmd
+++ b/docs/api/nodebpy.qmd
@@ -41,6 +41,39 @@ cv.snapshot()
 ```
 
 
+To use an MDAnalysis selection phrase inside a node tree, turn it into a node with
+[](`~molecularnodes.entities.molecule.selections.SelectionManager.node`). It stores the
+selection as a boolean attribute and returns a `Named Attribute` node reading it, reusing
+an existing selection where possible rather than creating a duplicate.
+
+```{python}
+with mol.tree.reset() as (atoms, join):
+    # 1bna is B-DNA, so split the two base-pair types across different styles
+    (
+        atoms
+        >> mg.StyleSpheres(
+            selection=mol.selections.node("resname DC DG"),
+            material=mat,
+        )
+        >> join
+    )
+    (
+        atoms
+        >> mg.StyleSticks(
+            selection=mol.selections.node("resname DA DT"),
+            material=mat,
+        )
+        >> join
+    )
+
+mol.tree
+```
+
+```{python}
+cv.look_at(mol)
+cv.snapshot()
+```
+
 ## Non-Linear Node Trees
 
 The of Geometry Nodes comes from the non-linear nature of working with node trees. We can express complex systems with relatively simple node setups.
@@ -51,7 +84,7 @@ with mol.tree.reset() as (atoms, join):
         atoms
         >> mg.SeparateAtoms(selection=~mg.IsSolvent())
         >> mg.CentreOnSelection()
-        >> mg.GeoemtryToPlanar() 
+        >> mg.GeoemtryToPlanar()
         >> g.TransformGeometry(rotation=(0, math.pi/2, 0))
     )
 
@@ -144,8 +177,8 @@ with mol.tree.reset() as (atoms, join):
                 subset=mg.IsNucleic(),
                 expand=True,
                 distance_a=4.0
-            ) 
-            & mg.IsPeptide() 
+            )
+            & mg.IsPeptide()
             & mg.IsSideChain(),
             scale=0.6,
             material=mat
@@ -170,7 +203,7 @@ The node tree creation code below is evaluated once, but the selection changes o
 ```{python}
 cv.scene_reset()
 animation_length = 100
-cv.resolution = (1280, 720)
+cv.resolution = (600, 480)
 cv.samples = 8
 cv.frame_range = (1, animation_length)
 
@@ -183,7 +216,7 @@ with mol.tree.reset() as (atoms, join):
     frame = g.SceneTime().o.frame
 
     # the `.frame` value changes to reflect current scene.frame_current
-    # we map that value to a range of 0 to 1 over the animation length, 
+    # we map that value to a range of 0 to 1 over the animation length,
     # and use that to select fraction of the chain that is selected and drawn
     sel = fac < g.MapRange.float(frame, 1, animation_length, 0, 1)
 

--- a/docs/api/rendering.qmd
+++ b/docs/api/rendering.qmd
@@ -25,7 +25,7 @@ u = mda.Universe(PSF, DCD)
 mol = mn.Molecule(u).add_style("cartoon")
 
 # add resid 1 and 129 with spheres style, using mesh geometry
-mol.add_style("spheres", selection="resid 1 129", sphere_geometry="Mesh")
+mol.add_style("spheres", selection="resid 1 129", sphere_geometry="Instance")
 ```
 
 ## Add annotations

--- a/docs/api/styles.qmd
+++ b/docs/api/styles.qmd
@@ -41,23 +41,32 @@ The [](`~mn.Molecule.add_style`) API takes the following arguments:
 Molecule.add_style(
     style="spheres",
     selection=None,
-    material=None,
+    material="MN Default",
+    color=None,
     **kwargs,
 )
 ```
 
 - `style` param
-  - A string, one of `ball_and_stick`, `cartoon`, `ribbon`, `spheres`, `sticks` or `surface`.
+  - A string, one of `ball_and_stick`, `cartoon`, `ribbon`, `spheres`, `sticks` or
+    `surface`; or a callable returning a style node (see
+    [Callables](#callables-for-full-control) below).
 - `selection` param
-  - An MDAnalysis selection phrase, an `AtomGroup`, or the name of an existing boolean
-    attribute. A selection phrase is stored as a named attribute and used to mask the style.
+  - An MDAnalysis selection phrase, an `AtomGroup`, the name of an existing boolean
+    attribute, or a callable returning a boolean socket. A selection phrase is stored
+    as a named attribute and used to mask the style.
 - `material` param
   - One of the pre-built materials from `mn.material`, e.g.
     `mn.material.AmbientOcclusion(distance=0.5)`, a Blender material, or a material
     name to append from the asset file, e.g. `MN Default` or `MN Squishy`.
+- `color` param
+  - `"common"` / `"default"`, `"plddt"`, an RGBA tuple, the name of an existing colour
+    attribute, or a callable returning a colour socket. Anything else warns rather than
+    silently rendering black.
 - `**kwargs`
   - Any remaining keyword arguments are passed to the style node, e.g. `geometry`,
-    `quality`, `scale`, `peptide_radius`.
+    `quality`, `scale`, `peptide_radius`. Names that are not inputs on that node raise
+    a `TypeError`.
 
 ## Selections
 
@@ -88,6 +97,69 @@ canvas.look_at(mol)
 canvas.snapshot()
 ```
 
+## Callables for Full Control {#callables-for-full-control}
+
+`style`, `selection` and `color` all accept a **callable**, which is evaluated inside the
+node tree context. This reaches the full node API without having to write out a whole
+tree, and is the recommended middle ground between `add_style` and
+[building the tree yourself](#building-a-style-tree).
+
+A callable `color` reaches any of the `Color*` nodes:
+
+```{python}
+canvas.clear()
+mol = mn.Molecule.fetch("8H1B")
+mol.add_style("cartoon", color=lambda: g.ColorSecondaryStructure())
+canvas.look_at(mol)
+canvas.snapshot()
+```
+
+A callable `selection` composes the selection nodes with `&`, `|` and `~`:
+
+```{python}
+mol.add_style("sticks", selection=lambda: g.IsPeptide() & g.IsSideChain())
+canvas.look_at(mol)
+canvas.snapshot()
+```
+
+A callable `style` sets any input on the style node itself:
+
+```{python}
+mol.add_style(lambda: g.StyleSpheres(sphere_geometry="Mesh", quality=4, scale=0.4))
+canvas.look_at(mol)
+canvas.snapshot()
+```
+
+A callable `style` defines the style node completely, so `selection`, `material` and
+style keyword arguments cannot be passed alongside it - set them inside the callable
+instead. To use an MDAnalysis selection phrase there, turn it into a node with
+[](`~molecularnodes.entities.molecule.selections.SelectionManager.node`):
+
+```{python}
+canvas.clear()
+mol = mn.Molecule.fetch("9EYM")
+mol.add_style("cartoon", color=lambda: g.ColorRainbow())
+mol.add_style(
+    lambda: g.StyleSpheres(
+        selection=mol.selections.node("not protein"),
+        sphere_geometry="Mesh",
+    )
+)
+canvas.look_at(mol)
+canvas.snapshot()
+```
+
+`selections.node()` reuses an existing selection where it can, so calling it repeatedly
+(inside a loop, or on every rebuild of a tree) does not pile up duplicate selections:
+
+```{python}
+before = len(mol.selections)
+with mol.tree:
+    for _ in range(5):
+        mol.selections.node("not protein")
+print(f"{before} selection(s) before, {len(mol.selections)} after")
+```
+
 ## Building a Style Tree
 
 To take full control — or to start from a clean slate — build the node tree yourself with
@@ -104,6 +176,8 @@ specialised scripting interface for node trees.
 mat = mn.material.AmbientOcclusion()
 
 mol.dssp.init()
+# `from_string` creates a managed selection; `.node()` gives a node reading its
+# boolean attribute, ready to plug into a style node's `Selection` input
 sel = mol.selections.from_string("resname LYS")
 
 with mol.tree.reset() as (atoms, join):
@@ -142,7 +216,7 @@ mol = (
     .add_style(
         style="surface",
         selection="protein",
-        material="MN Transparent Outline",
+        material="MN Default",
     )
 )
 canvas.look_at(mol)

--- a/docs/api/styles.qmd
+++ b/docs/api/styles.qmd
@@ -84,7 +84,7 @@ canvas.snapshot()
 ```
 
 ```{python}
-mol.add_style("surface", selection="resid 100:150", material="MN Transparent Outline")
+mol.add_style("surface", selection="resid 100:150", material="MN Flat")
 canvas.look_at(mol)
 canvas.snapshot()
 ```
@@ -122,10 +122,17 @@ canvas.look_at(mol)
 canvas.snapshot()
 ```
 
-A callable `style` sets any input on the style node itself:
+A callable `style` sets allows easier setting of the values of the node itself.
 
 ```{python}
-mol.add_style(lambda: g.StyleSpheres(sphere_geometry="Mesh", quality=4, scale=0.4))
+mol.add_style(
+  lambda: g.StyleSpheres(
+    sphere_geometry="Instance",
+    quality=4,
+    scale=0.4,
+    material=mn.material.Default().material
+    )
+  )
 canvas.look_at(mol)
 canvas.snapshot()
 ```
@@ -142,7 +149,7 @@ mol.add_style("cartoon", color=lambda: g.ColorRainbow())
 mol.add_style(
     lambda: g.StyleSpheres(
         selection=mol.selections.node("not protein"),
-        sphere_geometry="Mesh",
+        sphere_geometry="Instance",
     )
 )
 canvas.look_at(mol)
@@ -181,7 +188,7 @@ mol.dssp.init()
 sel = mol.selections.from_string("resname LYS")
 
 with mol.tree.reset() as (atoms, join):
-  atoms >> g.StyleSticks(selection = sel.node(), scale=0.3, material=mat.material) >> join
+  atoms >> g.StyleSticks(selection = sel.node(), scale=0.6, material=mat.material) >> join
   atoms >> g.SetColor(color=g.ColorRainbow()) >> g.StyleCartoon(material=mat.material) >> join
 
 canvas.look_at(mol)

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -11,7 +11,7 @@ title: "Changelog"
   ```python
   mol.add_style("cartoon", color=lambda: g.ColorSecondaryStructure())
   mol.add_style("sticks", selection=lambda: g.IsPeptide() & g.IsSideChain())
-  mol.add_style(lambda: g.StyleSpheres(sphere_geometry="Mesh", quality=4))
+  mol.add_style(lambda: g.StyleSpheres(sphere_geometry="Instance", quality=4))
   ```
 
   A callable `style` defines the style node itself, so `selection`, `material` and style keyword arguments cannot be passed alongside it - passing them raises a `TypeError` rather than silently dropping them.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -6,3 +6,27 @@ title: "Changelog"
 
 ## Added
 - On using the import operators, the camera and viewport end clipping distance is increased to 10000 from 100 so users aren't confused when importing larger structures and systems #1150
+- `Molecule.add_style()` accepts a callable for `style`, `selection` and `color`. The callable is evaluated inside the node tree context, so it can build any nodes from `molecularnodes.nodes.geometry` without having to write out a whole node tree:
+
+  ```python
+  mol.add_style("cartoon", color=lambda: g.ColorSecondaryStructure())
+  mol.add_style("sticks", selection=lambda: g.IsPeptide() & g.IsSideChain())
+  mol.add_style(lambda: g.StyleSpheres(sphere_geometry="Mesh", quality=4))
+  ```
+
+  A callable `style` defines the style node itself, so `selection`, `material` and style keyword arguments cannot be passed alongside it - passing them raises a `TypeError` rather than silently dropping them.
+- `SelectionManager.node()` returns a `Named Attribute` node for a selection, creating the selection if it does not already exist. This is the bridge between selections and the node tree API, and is how an MDAnalysis selection phrase is used inside a callable style:
+
+  ```python
+  mol.add_style(lambda: g.StyleSpheres(selection=mol.selections.node("not protein")))
+  ```
+
+  Existing selections are reused - matched on the selection string together with the `updating` and `periodic` flags, or on `name` - so repeated calls do not pile up duplicate selections and mesh attributes.
+- `SelectionManager.find()` looks up an existing selection by the selection string that created it, where `get()` looks a selection up by its name.
+
+## Changed
+- `add_style(color=...)` now validates its argument. A string must be a known keyword (`"common"`, `"default"`, `"plddt"`) or the name of an existing *colour* attribute on the molecule. Anything else raises a `UserWarning` and adds no colour, rather than silently rendering the geometry black. This includes names of attributes that exist but are not colours, such as `"b_factor"` or `"lipophobicity"`.
+- `add_style(style=...)` is validated against the styles that can actually be dispatched, and the error lists them.
+
+## Fixed
+- `add_style()` raised a bare `KeyError` for style names that were accepted by validation but had no corresponding style node - `"vdw"`, `"atoms"`, `"sphere"` and `"ball+stick"` among them. These now raise a `ValueError` naming the supported styles.

--- a/docs/tutorials/selections.qmd
+++ b/docs/tutorials/selections.qmd
@@ -65,6 +65,61 @@ Selecting based on the `entity_id`, to reveal the rotary axel of the protein com
 
 ![](https://imgur.com/aUpiFYe.mp4)
 
+## Selections from Python
+
+The same selections are available from Python. `mol.selections` manages them, storing
+each one as a boolean attribute on the mesh that the node tree reads. Selections created
+this way appear in the UI list, and stay editable there.
+
+The simplest route is the `selection` argument of `add_style`, which takes an MDAnalysis
+selection phrase, an `AtomGroup`, or the name of an existing boolean attribute:
+
+```python
+mol.add_style("cartoon", selection="protein")
+mol.add_style("ball_and_stick", selection="not protein")
+```
+
+To use a selection inside the node API, turn it into a node with `selections.node()`. It
+returns a `Named Attribute` node reading that selection, ready to plug into any
+`Selection` input:
+
+```python
+from molecularnodes.nodes import geometry as g
+
+mol.add_style(
+    lambda: g.StyleSpheres(
+        selection=mol.selections.node("not protein"),
+        sphere_geometry="Mesh",
+    )
+)
+```
+
+It works the same inside an explicit tree context:
+
+```python
+with mol.tree.reset() as (atoms, join):
+    atoms >> g.StyleCartoon(selection=mol.selections.node("protein")) >> join
+    atoms >> g.StyleSticks(selection=mol.selections.node("not protein")) >> join
+```
+
+`selections.node()` reuses an existing selection with the same phrase rather than
+creating a duplicate, so it is safe to call on every rebuild of a tree. The `updating`
+and `periodic` flags are part of a selection's identity, so a static selection and a
+per-frame one built from the same phrase remain separate:
+
+```python
+mol.selections.node("around 5 resname LYS")                  # re-evaluated each frame
+mol.selections.node("around 5 resname LYS", updating=False)  # a separate, static one
+```
+
+Like every node, this has to be created inside an active node tree — either a
+`with mol.tree:` block or a callable passed to `add_style`.
+
+To always create a new selection instead of reusing one, use `selections.from_string()`
+or `selections.from_atomgroup()` directly, then call `.node()` on the result. To find an
+existing selection by its phrase, use `selections.find()`; note that `selections.get()`
+looks selections up by their *name* (`"selection_0"`), not their phrase.
+
 ## Open a Local File
 
 To open a `.pdb`, `.mmCIF`, `.pdbx` or other similar files, use the <kbd>Local File</kbd> tab.

--- a/docs/tutorials/selections.qmd
+++ b/docs/tutorials/selections.qmd
@@ -65,61 +65,6 @@ Selecting based on the `entity_id`, to reveal the rotary axel of the protein com
 
 ![](https://imgur.com/aUpiFYe.mp4)
 
-## Selections from Python
-
-The same selections are available from Python. `mol.selections` manages them, storing
-each one as a boolean attribute on the mesh that the node tree reads. Selections created
-this way appear in the UI list, and stay editable there.
-
-The simplest route is the `selection` argument of `add_style`, which takes an MDAnalysis
-selection phrase, an `AtomGroup`, or the name of an existing boolean attribute:
-
-```python
-mol.add_style("cartoon", selection="protein")
-mol.add_style("ball_and_stick", selection="not protein")
-```
-
-To use a selection inside the node API, turn it into a node with `selections.node()`. It
-returns a `Named Attribute` node reading that selection, ready to plug into any
-`Selection` input:
-
-```python
-from molecularnodes.nodes import geometry as g
-
-mol.add_style(
-    lambda: g.StyleSpheres(
-        selection=mol.selections.node("not protein"),
-        sphere_geometry="Mesh",
-    )
-)
-```
-
-It works the same inside an explicit tree context:
-
-```python
-with mol.tree.reset() as (atoms, join):
-    atoms >> g.StyleCartoon(selection=mol.selections.node("protein")) >> join
-    atoms >> g.StyleSticks(selection=mol.selections.node("not protein")) >> join
-```
-
-`selections.node()` reuses an existing selection with the same phrase rather than
-creating a duplicate, so it is safe to call on every rebuild of a tree. The `updating`
-and `periodic` flags are part of a selection's identity, so a static selection and a
-per-frame one built from the same phrase remain separate:
-
-```python
-mol.selections.node("around 5 resname LYS")                  # re-evaluated each frame
-mol.selections.node("around 5 resname LYS", updating=False)  # a separate, static one
-```
-
-Like every node, this has to be created inside an active node tree — either a
-`with mol.tree:` block or a callable passed to `add_style`.
-
-To always create a new selection instead of reusing one, use `selections.from_string()`
-or `selections.from_atomgroup()` directly, then call `.node()` on the result. To find an
-existing selection by its phrase, use `selections.find()`; note that `selections.get()`
-looks selections up by their *name* (`"selection_0"`), not their phrase.
-
 ## Open a Local File
 
 To open a `.pdb`, `.mmCIF`, `.pdbx` or other similar files, use the <kbd>Local File</kbd> tab.

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -107,7 +107,7 @@ class Molecule(MolecularEntity):
     canvas = mn.Canvas()
     u = mda.Universe(PSF, DCD)
     traj = mn.Molecule(u)
-    traj.add_style("spheres", sphere_geometry="Mesh", selection="resname LYS")
+    traj.add_style("spheres", sphere_geometry="Instance", selection="resname LYS")
     canvas.look_at(traj)
     canvas.snapshot()
     ```

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -24,7 +24,7 @@ from ...blender import coll, path_resolve, set_obj_active
 from ...blender import utils as blender_utils
 from ...converters import universe_from_atoms
 from ...nodes.material import PresetMaterial, append_material
-from ...nodes.nodes import STYLE_LITERALS, STYLE_NODE_MAPPING, styles_mapping
+from ...nodes.nodes import STYLE_LITERALS, STYLE_NODE_MAPPING
 from ...utils import (
     count_value_changes,
     temp_override_property,
@@ -42,6 +42,20 @@ from .helpers import FrameManager, _ag_to_bool
 from .selections import SelectionManager
 
 logger = logging.getLogger(__name__)
+
+#: Colour keywords understood by ``Molecule.add_style(color=...)``. Anything else must
+#: name an existing attribute, be an RGBA sequence, or be a callable building the nodes.
+COLOR_KEYWORDS = ("common", "default", "plddt")
+
+
+class _Unset:
+    """Sentinel for an argument that was not passed (``None`` is a meaningful value)."""
+
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_UNSET = _Unset()
 
 
 class Molecule(MolecularEntity):
@@ -963,6 +977,9 @@ class Molecule(MolecularEntity):
         """
         if selection is None:
             return None
+        if callable(selection):
+            # evaluated later, inside the tree context, by `add_style`
+            return None
         if isinstance(selection, AtomGroup):
             return self.selections.from_atomgroup(selection).name
         if isinstance(selection, str):
@@ -985,10 +1002,18 @@ class Molecule(MolecularEntity):
             return self.selections.from_string(selection).name
         return None
 
-    def _style_color_input(self, color: str | Sequence[float]):
-        """Resolve `add_style`'s color argument into the `Set Color` node input."""
+    def _style_color_input(self, color: str | Sequence[float] | Callable):
+        """Resolve `add_style`'s color argument into the `Set Color` node input.
+
+        Returns ``None`` if no ``Set Color`` node should be added, which happens when
+        the argument names neither a known keyword nor an existing attribute.
+        """
         from ...nodes import geometry as g
 
+        # a callable is evaluated here, inside the tree context, so that it can build
+        # nodes from `molecularnodes.nodes.geometry` (which require that context)
+        if callable(color):
+            return color()
         if not isinstance(color, str):
             return tuple(color)
         if color.lower() in ("common", "default"):
@@ -996,19 +1021,37 @@ class Molecule(MolecularEntity):
             return g.ColorElement(c=g.RandomColor(g.ChainID(), 3))
         if color.lower() == "plddt":
             return g.ColorPLDDT()
-        # otherwise treat it as the name of a color attribute on the geometry
-        return NamedAttribute.color(color)
+        # otherwise it must name an existing *color* attribute on the geometry. Reading
+        # a non-color attribute (a float, say) as a color silently renders black, so
+        # check the data type too and not just that the name exists
+        color_attributes = [
+            attribute.name
+            for attribute in self.object.data.attributes
+            if attribute.data_type in ("FLOAT_COLOR", "BYTE_COLOR")
+        ]
+        if color in color_attributes:
+            return NamedAttribute.color(color)
+        warnings.warn(
+            f"Color '{color}' is neither a known color keyword {COLOR_KEYWORDS} nor a "
+            f"color attribute on this molecule (available: {color_attributes}). No "
+            "color will be applied. For coloring beyond the keywords, pass a callable "
+            "that builds the color nodes:\n"
+            "    from molecularnodes.nodes import geometry as mg\n"
+            "    mol.add_style('cartoon', color=lambda: mg.ColorRainbow())",
+            category=UserWarning,
+        )
+        return None
 
     def add_style(
         self,
-        style: STYLE_LITERALS = "spheres",
-        selection: str | AtomGroup | None = None,
+        style: STYLE_LITERALS | Callable = "spheres",
+        selection: str | AtomGroup | Callable | None = None,
         material: bpy.types.Material
         | PresetMaterial
         | MaterialBuilder
         | str
-        | None = "MN Default",
-        color: str | Sequence[float] | None = None,
+        | None = _UNSET,
+        color: str | Sequence[float] | Callable | None = None,
         assembly: bool = False,
         name: str | None = None,
         **kwargs,
@@ -1021,17 +1064,27 @@ class Molecule(MolecularEntity):
 
         Parameters
         ----------
-        style : bpy.types.GeometryNodeTree | str, optional
-            The style to apply to the trajectory. Can be a GeometryNodeTree or a string
-            identifying a predefined style (e.g., "spheres", "sticks", "ball_stick").
-            Default is "spheres".
+        style : str | Callable, optional
+            The style to apply. Either a string naming a predefined style
+            ("spheres", "cartoon", "ribbon", "surface", "sticks", "ball_and_stick"),
+            or a zero-argument callable returning a style node, evaluated inside the
+            node tree context::
 
-        selection : str | AtomGroup | None, optional
+                mol.add_style(lambda: mg.StyleCartoon(quality=5, loop_radius=0.6))
+
+            A callable defines the style node itself, so ``selection``, ``material``
+            and extra keyword arguments cannot be combined with it - set them inside
+            the callable. Default is "spheres".
+
+        selection : str | AtomGroup | Callable | None, optional
             Apply the style only to atoms matching this selection. Can be:
             - A string naming an existing boolean attribute on the molecule (used directly)
             - A string MDAnalysis selection phrase (evaluated and stored as a new
               managed selection attribute)
             - A AtomGroup object defining a selection criteria
+            - A zero-argument callable returning a boolean socket, evaluated inside
+              the node tree context, e.g.
+              ``lambda: mg.IsPeptide() & mg.IsSideChain()``
             - None to apply to all atoms (default)
 
             A string is treated as an existing attribute name first; only if no such
@@ -1044,15 +1097,22 @@ class Molecule(MolecularEntity):
             material name to append from the asset file, or None for no material.
             Default is "MN Default".
 
-        color : str | Sequence[float] | None, optional
+        color : str | Sequence[float] | Callable | None, optional
             Coloring to apply upstream of the style via a ``Set Color`` node. Can be:
             - ``"common"`` / ``"default"`` for standard element colors with carbons
               colored randomly per chain
             - ``"plddt"`` to color by pLDDT (B-factor) confidence
-            - any other string, treated as the name of a color attribute on the geometry
+            - the name of an existing *color* attribute on the geometry
             - an RGBA sequence of floats for a single uniform color
+            - a zero-argument callable returning a color socket, evaluated inside the
+              node tree context, e.g. ``lambda: mg.ColorRainbow()``. This is the way
+              to reach the full set of ``Color*`` nodes without writing out a whole
+              node tree.
             - None (default) to add no color node, leaving the baked ``Color``
               attribute in use.
+
+            A string that is neither a keyword nor an existing color attribute raises
+            a ``UserWarning`` and no color is applied.
 
         assembly : bool, optional
             Instance the style over the biological assembly transforms parsed from
@@ -1063,7 +1123,10 @@ class Molecule(MolecularEntity):
             style lists. Default is None.
 
         **kwargs : optional
-            Additional keyword arguments to pass to the added style node.
+            Additional keyword arguments passed to the style node, matching that
+            node's inputs (e.g. ``quality``, ``scale``, ``sphere_geometry`` for
+            ``spheres``). Unknown names raise a ``TypeError``. Cannot be combined
+            with a callable ``style``.
 
         Returns
         -------
@@ -1074,6 +1137,10 @@ class Molecule(MolecularEntity):
         ------
         ValueError
             If an unsupported style string is passed
+        TypeError
+            If a callable ``style`` is combined with ``selection``, ``material`` or
+            extra keyword arguments, or if a keyword argument does not match an input
+            on the style node
 
         Notes
         -----
@@ -1084,10 +1151,35 @@ class Molecule(MolecularEntity):
         from ...nodes import geometry as g
         from . import OXDNA
 
-        if isinstance(style, str) and style not in styles_mapping:
+        style_is_callable = callable(style)
+        if not style_is_callable and style not in STYLE_NODE_MAPPING:
             raise ValueError(
-                f"Invalid style '{style}'. Supported styles are {[key for key in styles_mapping.keys()]}"
+                f"Invalid style '{style}'. Supported styles are "
+                f"{sorted(STYLE_NODE_MAPPING)}"
             )
+        if style_is_callable:
+            # a callable builds the style node itself, so arguments belonging to that
+            # node would be silently discarded - reject them instead of ignoring them
+            owned = [
+                argname
+                for argname, was_given in (
+                    ("selection", selection is not None),
+                    ("material", material is not _UNSET),
+                    *((key, True) for key in kwargs),
+                )
+                if was_given
+            ]
+            if owned:
+                raise TypeError(
+                    "When `style` is a callable it defines the style node itself, so "
+                    f"{owned} cannot also be passed to `add_style()`. Set them inside "
+                    "the callable instead:\n"
+                    "    mol.add_style(lambda: mg.StyleCartoon(quality=5))"
+                )
+
+        material = "MN Default" if material is _UNSET else material
+        # a callable selection is evaluated inside the tree context, below
+        selection_is_callable = callable(selection)
         attribute_name = self._resolve_style_selection(selection)
 
         if isinstance(self, OXDNA):
@@ -1099,22 +1191,26 @@ class Molecule(MolecularEntity):
         material = append_material(material) if isinstance(material, str) else material
 
         with self.tree as tree:
-            style_node = STYLE_NODE_MAPPING[style](
-                selection=NamedAttribute.boolean(attribute_name)
-                if attribute_name
-                else None,
-                material=material,
-                **kwargs,
-            )
+            if style_is_callable:
+                style_node = style()
+            else:
+                if selection_is_callable:
+                    selection_input = selection()
+                elif attribute_name:
+                    selection_input = NamedAttribute.boolean(attribute_name)
+                else:
+                    selection_input = None
+                style_node = STYLE_NODE_MAPPING[style](
+                    selection=selection_input,
+                    material=material,
+                    **kwargs,
+                )
             if name:
                 style_node.node.label = name
+            color_input = self._style_color_input(color) if color is not None else None
             (
                 tree.atoms
-                >> (
-                    g.SetColor(color=self._style_color_input(color))
-                    if color is not None
-                    else None
-                )
+                >> (g.SetColor(color=color_input) if color_input is not None else None)
                 >> style_node
                 >> (
                     g.AssemblyInstance(data_object=self.create_data_object())

--- a/molecularnodes/entities/molecule/selections.py
+++ b/molecularnodes/entities/molecule/selections.py
@@ -608,7 +608,7 @@ class SelectionManager:
         mol.add_style(
             lambda: g.StyleSpheres(
                 selection=mol.selections.node("not protein"),
-                sphere_geometry="Mesh",
+                sphere_geometry="Instance",
             )
         )
         canvas.look_at(mol)

--- a/molecularnodes/entities/molecule/selections.py
+++ b/molecularnodes/entities/molecule/selections.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from nodebpy.nodes.geometry import NamedAttribute
     from ...ui.props import TrajectorySelectionItem
     from .base import Molecule
 import bpy
@@ -479,6 +480,200 @@ class SelectionManager:
             The matching UI item, or ``None`` if no match was found.
         """
         return self.ui_items.get(name)
+
+    def find(
+        self,
+        selection: str,
+        *,
+        updating: bool = True,
+        periodic: bool = True,
+    ) -> TrajectorySelectionItem | None:
+        """Find an existing selection created from a given selection string.
+
+        Unlike :meth:`get`, which looks up a selection by its *name* (the attribute
+        name, e.g. ``"selection_0"``), this searches by the MDAnalysis selection
+        *string* that created it.
+
+        The ``updating`` and ``periodic`` flags form part of the match, because a
+        static selection and a per-frame updating one built from the same string are
+        not interchangeable.
+
+        Parameters
+        ----------
+        selection : str
+            MDAnalysis selection string to search for, e.g. ``"protein"``.
+        updating : bool, default=True
+            Only match selections with this ``updating`` flag.
+        periodic : bool, default=True
+            Only match selections with this ``periodic`` flag.
+
+        Returns
+        -------
+        TrajectorySelectionItem | None
+            The first matching selection, or ``None`` if there is no match.
+
+        Examples
+        --------
+        ```{python}
+        import molecularnodes as mn
+
+        canvas = mn.Canvas()
+        mol = mn.Molecule.fetch("4ozs")
+
+        print(mol.selections.find("protein"))
+        item = mol.selections.from_string("protein")
+        print(mol.selections.find("protein").name)
+        ```
+
+        Selections made in the Blender UI are found too, and the flags are part of
+        the match:
+
+        ```{python}
+        print(mol.selections.find("protein", updating=False))
+        ```
+
+        See Also
+        --------
+        get : Look a selection up by its name rather than its selection string.
+        node : Find or create a selection and return a node for it.
+        """
+        for item in self.ui_items:
+            if (
+                item.string == selection
+                and item.updating == updating
+                and item.periodic == periodic
+            ):
+                return item
+        return None
+
+    def node(
+        self,
+        selection: str | AtomGroup,
+        *,
+        updating: bool = True,
+        periodic: bool = True,
+        name: str | None = None,
+    ) -> NamedAttribute:
+        """Get a ``Named Attribute`` node for a selection, creating it if needed.
+
+        This is the bridge between the selection API and the node tree API. It
+        resolves ``selection`` to a managed selection - reusing an existing one where
+        possible - and returns a node whose boolean output can be plugged straight
+        into a style node's ``Selection`` input.
+
+        Existing selections are reused so that repeated calls (a style rebuilt in a
+        loop, say) do not pile up duplicate selections and mesh attributes. Reuse is
+        matched on the selection string together with the ``updating`` and
+        ``periodic`` flags, or on ``name`` when one is given. An ``AtomGroup`` is
+        always stored as a new selection, since two groups cannot be compared cheaply.
+
+        Parameters
+        ----------
+        selection : str | AtomGroup
+            An MDAnalysis selection string, or an ``AtomGroup``.
+        updating : bool, default=True
+            If ``True``, the selection is re-evaluated each frame where required, for
+            example for distance-based selections. Ignored when ``selection`` is an
+            ``AtomGroup``, where updating is a property of the group itself.
+        periodic : bool, default=True
+            Consider periodic boundary conditions for geometric selections. Ignored
+            when ``selection`` is an ``AtomGroup``.
+        name : str, optional
+            Name for the selection, used as the mesh attribute name. When given, an
+            existing selection with this name is reused. Auto-generated otherwise.
+
+        Returns
+        -------
+        NamedAttribute
+            A ``Named Attribute`` node reading the selection's boolean attribute.
+
+        Notes
+        -----
+        Like every node, this must be created inside an active node tree context -
+        either a ``with mol.tree:`` block, or the callable passed to
+        [](`~mn.Molecule.add_style`). Calling it outside one raises a ``RuntimeError``.
+
+        Examples
+        --------
+        The main use is inside a callable passed to
+        [](`~mn.Molecule.add_style`), which is evaluated inside the tree context:
+
+        ```{python}
+        import molecularnodes as mn
+        from molecularnodes.nodes import geometry as g
+
+        canvas = mn.Canvas()
+        mol = mn.Molecule.fetch("8H1B")
+        mol.add_style("cartoon")
+        mol.add_style(
+            lambda: g.StyleSpheres(
+                selection=mol.selections.node("not protein"),
+                sphere_geometry="Mesh",
+            )
+        )
+        canvas.look_at(mol)
+        canvas.snapshot()
+        ```
+
+        It works the same inside an explicit tree context:
+
+        ```{python}
+        with mol.tree.reset() as (atoms, join):
+            atoms >> g.StyleCartoon(selection=mol.selections.node("protein")) >> join
+            atoms >> g.StyleSticks(selection=mol.selections.node("not protein")) >> join
+
+        canvas.look_at(mol)
+        canvas.snapshot()
+        ```
+
+        Selections are reused rather than duplicated, so calling it in a loop is safe:
+
+        ```{python}
+        before = len(mol.selections)
+        with mol.tree:
+            for _ in range(5):
+                mol.selections.node("protein")
+        print(f"{before} selections before, {len(mol.selections)} after")
+        ```
+
+        A static selection is a different selection to an updating one, and gets its
+        own attribute:
+
+        ```{python}
+        with mol.tree:
+            mol.selections.node("around 5 resname LYS")
+            mol.selections.node("around 5 resname LYS", updating=False)
+        print([item.name for item in mol.selections.ui_items])
+        ```
+
+        An ``AtomGroup`` can be used instead of a selection string:
+
+        ```{python}
+        with mol.tree:
+            node = mol.selections.node(mol.universe.select_atoms("resid 1:20"))
+        print(node.node.inputs["Name"].default_value)
+        ```
+
+        See Also
+        --------
+        find : Look up an existing selection by its selection string.
+        from_string : Always create a new selection from a selection string.
+        from_atomgroup : Always create a new selection from an ``AtomGroup``.
+        molecularnodes.ui.props.TrajectorySelectionItem.node : The per-item equivalent.
+        """
+        if name is not None and (existing := self.get(name)) is not None:
+            return existing.node()
+        if isinstance(selection, AtomGroup):
+            # `updating`/`periodic` are properties of the AtomGroup itself (an
+            # `UpdatingAtomGroup` re-evaluates), so `from_atomgroup` takes neither
+            item = self.from_atomgroup(selection, name=name)
+        else:
+            item = self.find(selection, updating=updating, periodic=periodic)
+            if item is None:
+                item = self.from_string(
+                    selection, updating=updating, periodic=periodic, name=name
+                )
+        return item.node()
 
     def __len__(self) -> int:
         """Return the number of selections.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "imdclient>=0.2.3",
     "pandas<3.0.0",
     "griddataformats>=1.2.0",
-    "nodebpy>=520.14",
+    "nodebpy>=520.15",
 ]
 maintainers = [{ name = "Brady Johnston", email = "brady.johnston@me.com" }]
 requires-python = "~=3.13.0"

--- a/tests/test_add_style.py
+++ b/tests/test_add_style.py
@@ -186,3 +186,89 @@ def test_add_selection_to_style_operator_missing_targets():
 
     # the style node is untouched by the failed attempts
     assert not style.inputs["Selection"].links
+
+
+def test_add_style_invalid_style_raises():
+    "A style string that isn't dispatchable should raise, not KeyError deeper down."
+    mol = mn.Molecule.fetch("4ozs")
+    # 'vdw' used to pass validation against `styles_mapping` and then KeyError
+    for style in ("vdw", "atoms", "sphere", "bogus"):
+        with pytest.raises(ValueError, match="Invalid style"):
+            mol.add_style(style)
+
+
+@pytest.mark.parametrize("color", ["chain", "lipophobicity", "b_factor", "nonsense"])
+def test_add_style_unknown_color_warns(color):
+    """Unknown colors, and non-color attributes, must warn rather than render black.
+
+    `lipophobicity` and `b_factor` exist but are FLOAT attributes - reading them as a
+    color silently produced black geometry.
+    """
+    mol = mn.Molecule.fetch("4ozs")
+    with pytest.warns(UserWarning, match="is neither a known color keyword"):
+        mol.add_style("cartoon", color=color)
+    # no Set Color node should have been added
+    assert not _nodes_using_tree(mol.modifier_node_tree, "Set Color")
+
+
+@pytest.mark.parametrize("color", ["common", "default", "plddt", "Color"])
+def test_add_style_valid_color_adds_node(color):
+    mol = mn.Molecule.fetch("4ozs")
+    mol.add_style("cartoon", color=color)
+    assert _nodes_using_tree(mol.modifier_node_tree, "Set Color")
+
+
+def test_add_style_callable_color():
+    "A callable is evaluated inside the tree context, reaching any Color* node."
+    from molecularnodes.nodes import geometry as mg
+
+    mol = mn.Molecule.fetch("4ozs")
+    mol.add_style("cartoon", color=lambda: mg.ColorRainbow())
+    assert _nodes_using_tree(mol.modifier_node_tree, "Set Color")
+    assert _nodes_using_tree(mol.modifier_node_tree, "Color Rainbow")
+
+
+def test_add_style_callable_selection():
+    from molecularnodes.nodes import geometry as mg
+
+    mol = mn.Molecule.fetch("4ozs")
+    mol.add_style("sticks", selection=lambda: mg.IsPeptide() & mg.IsSideChain())
+    style = _nodes_using_tree(mol.modifier_node_tree, "Style Sticks")[0]
+    # the selection input is driven by a link, not a named attribute lookup
+    assert style.inputs["Selection"].links
+
+
+def test_add_style_callable_style():
+    from molecularnodes.nodes import geometry as mg
+
+    mol = mn.Molecule.fetch("4ozs")
+    mol.add_style(lambda: mg.StyleCartoon(quality=5))
+    style = _nodes_using_tree(mol.modifier_node_tree, "Style Cartoon")[0]
+    assert style.inputs["Quality"].default_value == 5
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"selection": "protein"},
+        {"material": "MN Default"},
+        {"quality": 5},
+    ],
+)
+def test_add_style_callable_style_rejects_owned_args(kwargs):
+    "Args belonging to the style node must not be silently dropped."
+    from molecularnodes.nodes import geometry as mg
+
+    mol = mn.Molecule.fetch("4ozs")
+    with pytest.raises(TypeError, match="cannot also be passed"):
+        mol.add_style(lambda: mg.StyleCartoon(), **kwargs)
+
+
+def test_add_style_callable_style_allows_color_and_name():
+    "color/assembly/name are separate nodes, so they compose with a callable style."
+    from molecularnodes.nodes import geometry as mg
+
+    mol = mn.Molecule.fetch("4ozs")
+    mol.add_style(lambda: mg.StyleCartoon(), color=lambda: mg.ColorRainbow(), name="x")
+    assert _nodes_using_tree(mol.modifier_node_tree, "Color Rainbow")
+    assert _nodes_using_tree(mol.modifier_node_tree, "Style Cartoon")[0].label == "x"

--- a/tests/test_selections.py
+++ b/tests/test_selections.py
@@ -1,4 +1,6 @@
+import bpy
 import numpy as np
+import pytest
 import molecularnodes as mn
 
 
@@ -67,3 +69,69 @@ def test_selection_bad_string_sets_message_and_recovers():
     sel.string = "resid 1:5"
     assert sel.message == ""
     assert mol.named_attribute(sel.name).sum() < mask_before.sum()
+
+
+def test_selections_find_by_string():
+    "`find` searches by selection string; `get` searches by selection name."
+    mol = mn.Molecule.fetch("4ozs")
+    assert mol.selections.find("protein") is None
+    item = mol.selections.from_string("protein")
+    assert mol.selections.find("protein").name == item.name
+    # `get` keys on the name, not the string
+    assert mol.selections.get("protein") is None
+    assert mol.selections.get(item.name) is not None
+    # the flags are part of the identity
+    assert mol.selections.find("protein", updating=False) is None
+
+
+def test_selections_node_reuses_existing():
+    "Repeated calls must not pile up duplicate selections and mesh attributes."
+    mol = mn.Molecule.fetch("4ozs")
+    with mol.tree:
+        for _ in range(5):
+            mol.selections.node("protein")
+    assert len(mol.selections) == 1
+
+
+def test_selections_node_flags_are_distinct():
+    mol = mn.Molecule.fetch("4ozs")
+    with mol.tree:
+        mol.selections.node("protein")
+        mol.selections.node("protein", updating=False)
+    assert len(mol.selections) == 2
+
+
+def test_selections_node_reuses_by_name():
+    mol = mn.Molecule.fetch("4ozs")
+    with mol.tree:
+        mol.selections.node("protein", name="my_sel")
+        mol.selections.node("a different phrase", name="my_sel")
+    assert len([i for i in mol.selections.ui_items if i.name == "my_sel"]) == 1
+
+
+def test_selections_node_from_atomgroup():
+    mol = mn.Molecule.fetch("4ozs")
+    with mol.tree:
+        node = mol.selections.node(mol.universe.select_atoms("resid 1:20"))
+    assert node.node.inputs["Name"].default_value == mol.selections.ui_items[0].name
+
+
+def test_selections_node_requires_tree_context():
+    mol = mn.Molecule.fetch("4ozs")
+    with pytest.raises(RuntimeError, match="TreeBuilder context"):
+        mol.selections.node("protein")
+
+
+def test_selections_node_in_add_style_callable():
+    "The motivating case: an MDA selection inside a callable style."
+    from molecularnodes.nodes import geometry as g
+
+    mol = mn.Molecule.fetch("4ozs")
+    mol.add_style(lambda: g.StyleSpheres(selection=mol.selections.node("resid 1:20")))
+    style = [
+        n
+        for n in mol.modifier_node_tree.nodes
+        if isinstance(n, bpy.types.GeometryNodeGroup)
+        and n.node_tree.name == "Style Spheres"
+    ][0]
+    assert style.inputs["Selection"].links

--- a/uv.lock
+++ b/uv.lock
@@ -1417,7 +1417,7 @@ requires-dist = [
     { name = "mdanalysistests", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "mdanalysistests", marker = "extra == 'docs'", specifier = ">=2.7.0" },
     { name = "mrcfile" },
-    { name = "nodebpy", specifier = ">=520.14" },
+    { name = "nodebpy", specifier = ">=520.15" },
     { name = "nodepad", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">2.2" },
     { name = "pandas", specifier = "<3.0.0" },
@@ -1555,11 +1555,11 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "520.14.0"
+version = "520.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/f7/c5b2335595d27a9bc11bdd039a22e787fe30242a8193038cfbb41ce1eb32/nodebpy-520.14.0.tar.gz", hash = "sha256:cc1a53b0a479d59ff0ba9b88d18c346fe7f236390ff71958fdad58813a58f2d3", size = 330924, upload-time = "2026-08-24T08:20:19.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b5/e026e76c2f946950c61b2d08e79a92438d19d5991321d100279feaded9cd/nodebpy-520.16.0.tar.gz", hash = "sha256:7f55f265d8d1086ac4ae66cf3efcf0bcd1cc3891bf8bd141a19534782af63420", size = 332527, upload-time = "2026-08-28T14:48:34.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/a3/223251e85123c01aaeadc18d3a6f983f230fc81081d4909a06ba463f28df/nodebpy-520.14.0-py3-none-any.whl", hash = "sha256:0203f7b9e0629505e5f0dce9ec88b8e45b3fff675c71bae0bf04db9b3243c461", size = 371356, upload-time = "2026-08-24T08:20:18.542Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/77/9e95762b5eeac5078b115f4f56bfa6d48af8ff89b5e840e4269da0796e27/nodebpy-520.16.0-py3-none-any.whl", hash = "sha256:b164d4733d08d4abd2781bba076a843687a1a96f22bfdf8440dbb1c1f96780fe", size = 372960, upload-time = "2026-08-28T14:48:29.802Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Allows using lambda functions `lambda: mg.StyleCartoon()` when passing to add_style for `style`, `selection` and `color`.

- **Improvements to add_style**
- **Update changelog.qmd**
