### PR TITLE
ENH: Support comma-separated codes when fetching

### DIFF
--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -214,6 +214,20 @@ class MolecularEntity(
             self._tree = MolecularTree(self, self.modifier_node_tree)
         return self._tree
 
+    @tree.setter
+    def tree(self, value: "MolecularTree | TreeBuilder | GeometryNodeTree") -> None:
+        """Point this entity's Molecular Nodes modifier at an existing node
+        tree (e.g. another entity's), so multiple entities share one styling
+        tree and any style changes apply to all of them."""
+        if not isinstance(value, GeometryNodeTree):
+            value = cast(GeometryNodeTree, value.tree)
+        if "Molecular Nodes" not in self.object.modifiers:
+            self.object.modifiers.new("Molecular Nodes", "NODES")
+        mod = cast(NodesModifier, self.object.modifiers["Molecular Nodes"])
+        mod.node_group = value
+        value.is_modifier = True
+        self._tree = None
+
     @property
     def modifier_node_tree(self) -> bpy.types.GeometryNodeTree:
         if "Molecular Nodes" not in self.object.modifiers:

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -81,6 +81,15 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
         name="Build Biological Assembly",
         description="Build the biological assembly for the structure on import",
     )
+    share_node_group: BoolProperty(  # type: ignore
+        default=False,
+        name="Share Node Group",
+        description=(
+            "When importing multiple structures, style them all with the same "
+            "node group instead of creating one per structure, so tweaks apply "
+            "to every structure at once (useful for conformations of one protein)"
+        ),
+    )
     # filled in by the file handler when structure files are dropped into the 3D
     # viewport, in place of the dialog's own filepath field
     directory: StringProperty(  # type: ignore
@@ -124,7 +133,11 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
     )
     code: StringProperty(  # type: ignore
         name="PDB",
-        description="The PDB code to download (4-character e.g. '1abc' or 12-character e.g. 'pdb_00001abc')",
+        description=(
+            "The code to download (4-character e.g. '1abc' or 12-character e.g."
+            " 'pdb_00001abc'). Separate multiple codes with commas to download"
+            " several structures at once"
+        ),
         options={"TEXTEDIT_UPDATE"},
     )
     filepath: StringProperty(  # type: ignore
@@ -171,6 +184,8 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
         assert layout
         if self.files:
             layout.label(text=f"Importing {len(self.files)} molecules")
+            if len(self.files) > 1:
+                layout.prop(self, "share_node_group")
         else:
             layout.prop_tabs_enum(self, "method")
             if self.method == "local":
@@ -184,6 +199,8 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
                 # file format only applies to wwPDB downloads; others pick their own
                 if self.method == "fetch":
                     row.prop(self, "file_format", text="")
+                if "," in self.code:
+                    layout.prop(self, "share_node_group")
         row = layout.row()
         row.prop(self, "node_setup", text="")
         col = row.column()
@@ -214,10 +231,25 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
             )
             return {}
 
+    def _setup_molecule(self, mol, shared_tree=None):
+        """Apply the import options to a freshly imported molecule, re-using
+        `shared_tree` for the styling instead when one is given. Returns the
+        tree to share with subsequently imported molecules."""
+        if shared_tree is not None:
+            # re-use the first structure's node group rather than creating a
+            # separate styling tree per structure
+            if self.node_setup:
+                mol.create_asset_nodes()
+            mol.tree = shared_tree
+            return shared_tree
+        self.apply_import_options(mol)
+        return mol.tree if self.share_node_group else None
+
     def execute(self, context):
         if self.files:
             return self._execute_dropped_files(context)
 
+        mols = []
         try:
             if self.method == "local":
                 topology = path_resolve(self.filepath)
@@ -244,14 +276,26 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
                 else:
                     mol = Molecule.load(topology)
                     message = f"Imported '{self.filepath}' as {mol.name}"
+                mols = [mol]
             else:
-                mol = Molecule.fetch(
-                    code=self.code,
-                    cache=self.cache_dir,
-                    format=self.file_format,
-                    database=self.database,
-                )
-                message = f"Downloaded {self.code} as {mol.name}"
+                codes = [code.strip() for code in self.code.split(",") if code.strip()]
+                if not codes:
+                    self.report({"ERROR"}, "No code given to fetch")
+                    return {"CANCELLED"}
+                mols = [
+                    Molecule.fetch(
+                        code=code,
+                        cache=self.cache_dir,
+                        format=self.file_format,
+                        database=self.database,
+                    )
+                    for code in codes
+                ]
+                mol = mols[-1]
+                if len(mols) == 1:
+                    message = f"Downloaded {codes[0]} as {mol.name}"
+                else:
+                    message = f"Downloaded {len(mols)} structures: {', '.join(codes)}"
         except FileDownloadPDBError as e:
             self.report({"ERROR"}, str(e))
             if self.file_format == "pdb":
@@ -266,7 +310,9 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
             self.report({"ERROR"}, str(e))
             return {"CANCELLED"}
 
-        self.apply_import_options(mol)
+        shared_tree = None
+        for imported in mols:
+            shared_tree = self._setup_molecule(imported, shared_tree)
 
         if isinstance(mol, StreamingTrajectory):
             context.scene.frame_start = 0
@@ -289,10 +335,11 @@ class MN_OT_Import_Molecule(bpy.types.Operator):
     def _execute_dropped_files(self, context):
         """Import each structure file dropped into the viewport."""
         imported = 0
+        shared_tree = None
         for file in self.files:
             try:
                 mol = Molecule.load(Path(self.directory, file.name))
-                self.apply_import_options(mol)
+                shared_tree = self._setup_molecule(mol, shared_tree)
                 imported += 1
             except Exception as e:
                 self.report({"WARNING"}, message=f"Failed importing {file.name}: {e}")

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -116,3 +116,91 @@ def test_op_api_mda(snapshot_custom: NumpySnapshotExtension):
 
     assert not np.allclose(pos_2, traj_op.position)
     assert not np.allclose(pos_2, traj_func.position)
+
+
+def test_op_dropped_files_share_node_group():
+    """With Share Node Group enabled, all dropped structures use one tree."""
+    session = bpy.context.scene.MNSession
+    paths = [
+        mn.download.StructureDownloader(cache=data_dir).download(
+            code=code, format="cif"
+        )
+        for code in codes[:2]
+    ]
+
+    with ObjectTracker() as o:
+        res = bpy.ops.mn.import_molecule(
+            directory=str(paths[0].parent),
+            files=[{"name": path.name} for path in paths],
+            style="ribbon",
+            share_node_group=True,
+        )
+        assert res == {"FINISHED"}
+        objects = o.new_objects()
+
+    mols = [session.match(obj) for obj in objects]
+    trees = [mol.modifier_node_tree for mol in mols]
+    assert trees[0] == trees[1]
+    style_trees = [
+        node.node_tree.name
+        for node in trees[0].nodes
+        if isinstance(node, bpy.types.GeometryNodeGroup)
+    ]
+    assert "Style Ribbon" in style_trees
+
+
+def test_share_node_group_api():
+    """Assigning one molecule's tree to another shares styling between them."""
+    mol1 = mn.Molecule.fetch(codes[0], cache=data_dir, format="cif")
+    mol2 = mn.Molecule.fetch(codes[1], cache=data_dir, format="cif")
+    mol1.add_style("spheres")
+
+    mol2.tree = mol1.tree
+    assert mol2.modifier_node_tree == mol1.modifier_node_tree
+
+    # a style added through either entity lands in the shared tree
+    mol2.add_style("ribbon")
+    style_trees = [
+        node.node_tree.name
+        for node in mol1.modifier_node_tree.nodes
+        if isinstance(node, bpy.types.GeometryNodeGroup)
+    ]
+    assert "Style Spheres" in style_trees
+    assert "Style Ribbon" in style_trees
+
+
+def test_op_fetch_comma_separated_codes():
+    """Comma-separated codes fetch multiple structures, sharing one tree."""
+    session = bpy.context.scene.MNSession
+
+    with ObjectTracker() as o:
+        res = bpy.ops.mn.import_molecule(
+            code=f"{codes[0]}, {codes[1]}",
+            file_format="cif",
+            style="ribbon",
+            share_node_group=True,
+            cache_dir=str(data_dir),
+        )
+        assert res == {"FINISHED"}
+        objects = o.new_objects()
+
+    assert len(objects) == 2
+    mols = [session.match(obj) for obj in objects]
+    assert sorted(mol.props.code for mol in mols) == sorted(codes[:2])
+    trees = [mol.modifier_node_tree for mol in mols]
+    assert trees[0] == trees[1]
+
+    # without sharing, each fetched structure gets its own tree
+    with ObjectTracker() as o:
+        res = bpy.ops.mn.import_molecule(
+            code=f"{codes[0]},{codes[1]}",
+            file_format="cif",
+            style="ribbon",
+            cache_dir=str(data_dir),
+        )
+        assert res == {"FINISHED"}
+        objects = o.new_objects()
+
+    mols = [session.match(obj) for obj in objects]
+    trees = [mol.modifier_node_tree for mol in mols]
+    assert trees[0] != trees[1]


### PR DESCRIPTION
Enables comma-separated codes to be input when fetching to download multiple structures. When downloading multiple or dragging-and-dropping multiple, add option to re-use the same node group across all of them.