### PR TITLE
ENH: Render panel for common render settings collected in one place

### DIFF
--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -39,8 +39,12 @@ class ResetSockets(NamedTuple):
 
 class MolecularTree(TreeBuilder[GeometryNodeTree]):
     def __init__(
-        self, entity: "MolecularEntity", tree: TreeBuilder | GeometryNodeTree | str
+        self,
+        entity: "MolecularEntity | None",
+        tree: TreeBuilder | GeometryNodeTree | str,
     ) -> None:
+        # the entity is optional so a tree can be built for an object that is
+        # not linked to a session entity (e.g. the UI's object-level add style)
         self._entity = entity
         if isinstance(tree, TreeBuilder):
             super().__init__(cast(GeometryNodeTree, tree.tree))

--- a/molecularnodes/entities/base.py
+++ b/molecularnodes/entities/base.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta
 from contextlib import contextmanager
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Iterator, List, NamedTuple, cast
 import bpy
 from bpy.types import GeometryNodeTree, NodesModifier
@@ -17,10 +17,12 @@ if TYPE_CHECKING:
     from ..ui.props import MolecularNodesObjectProperties
 
 
-# create a EntityType enum
-# These should match the entity_type EnumProperty in props.py
-class EntityType(Enum):
-    MD = "md"
+# These should match the entity_type EnumProperty in props.py. As a StrEnum,
+# members compare equal to their string values (e.g. obj.mn.entity_type), so
+# no .value is needed at comparison sites
+class EntityType(StrEnum):
+    # "molecule" covers static structures and MD trajectories alike, both being
+    # Universe-backed; only the specialised loaders keep their own md-* types
     MD_OXDNA = "md-oxdna"
     MD_STREAMING = "md-streaming"
     MOLECULE = "molecule"
@@ -300,7 +302,7 @@ class MolecularEntity(
         By default, this returns the string value of the Entity type.
 
         Eg: OXDNA and StreamingTrajectory that derive from the Molecule entity
-        can return EntityType.MD.value to re-use the annotations from
+        can return EntityType.MOLECULE to re-use the annotations from
         the parent Molecule entity.
 
         """

--- a/molecularnodes/entities/molecule/annotations.py
+++ b/molecularnodes/entities/molecule/annotations.py
@@ -55,7 +55,7 @@ class MoleculeAnnotationManager(BaseAnnotationManager):
     are backed by an MDAnalysis ``Universe``.
     """
 
-    _entity_type = EntityType.MD
+    _entity_type = EntityType.MOLECULE
     _classes = {}  # Entity class specific annotation classes
 
     def __init__(self, entity):

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -28,7 +28,7 @@ from ...converters import universe_from_atoms
 from ...nodes.material import PresetMaterial, append_material
 from ...nodes.nodes import STYLE_LITERALS, STYLE_NODE_MAPPING
 from ...utils import _UNSET, count_value_changes, temp_override_property
-from ..base import EntityType, MolecularEntity
+from ..base import EntityType, MolecularEntity, MolecularTree
 from ..utilities import (
     BoolObjectMNProperty,
     IntObjectMNProperty,
@@ -67,6 +67,82 @@ def _sphere_for_engine(style_node: type, engine: str) -> str | None:
     if parameter is None or parameter.default != "Point":
         return None
     return "Instance"
+
+
+def add_style_to_tree(
+    node_tree: bpy.types.GeometryNodeTree,
+    style: STYLE_LITERALS = "spheres",
+    material: bpy.types.Material
+    | PresetMaterial
+    | MaterialBuilder
+    | str = "MN Default",
+    color: Sequence[float] | None = None,
+    selection_attribute: str | None = None,
+    name: str | None = None,
+) -> None:
+    """
+    Add a style branch directly to a node tree, without a session entity.
+
+    The tree-level counterpart of [](`~mn.Molecule.add_style`), used by the UI
+    when an object is not linked to a session entity. Everything that needs the
+    entity's universe is unavailable here: selections must name an existing
+    boolean attribute (MDAnalysis phrases can't be evaluated), color is limited
+    to a uniform RGBA (schemes need chain information), and assembly instancing
+    is not offered.
+
+    Parameters
+    ----------
+    node_tree : bpy.types.GeometryNodeTree
+        The tree to add the style branch to, typically the tree of an object's
+        "Molecular Nodes" modifier.
+    style : str, default "spheres"
+        Name of a predefined style (see ``STYLE_NODE_MAPPING``).
+    material : bpy.types.Material | PresetMaterial | MaterialBuilder | str, default "MN Default"
+        Material for the styled geometry; a string is appended from the asset
+        file.
+    color : Sequence[float] | None, optional
+        Uniform RGBA color applied via a ``Set Color`` node. ``None`` (default)
+        leaves the baked ``Color`` attribute in use.
+    selection_attribute : str | None, optional
+        Name of an existing boolean attribute to restrict the style to.
+    name : str | None, optional
+        Label for the added style node.
+    """
+    from ...nodes import geometry as g
+
+    if style not in STYLE_NODE_MAPPING:
+        raise ValueError(
+            f"Invalid style '{style}'. Supported styles are "
+            f"{sorted(STYLE_NODE_MAPPING)}"
+        )
+
+    kwargs = {}
+    # spheres default to point clouds, which only Cycles can draw
+    geometry = _sphere_for_engine(
+        STYLE_NODE_MAPPING[style], bpy.context.scene.render.engine
+    )
+    if geometry is not None:
+        kwargs["sphere"] = geometry
+
+    if isinstance(material, (PresetMaterial, MaterialBuilder)):
+        material = material.material
+    material = append_material(material) if isinstance(material, str) else material
+
+    with MolecularTree(None, node_tree) as tree:
+        selection_input = (
+            NamedAttribute.boolean(selection_attribute) if selection_attribute else None
+        )
+        style_node = STYLE_NODE_MAPPING[style](
+            selection=selection_input, material=material, **kwargs
+        )
+        if name:
+            style_node.node.label = name
+        (
+            tree.atoms
+            >> (g.SetColor(color=tuple(color)) if color is not None else None)
+            >> style_node
+            >> tree.join
+        )
 
 
 class Molecule(MolecularEntity):

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -213,7 +213,7 @@ class Molecule(MolecularEntity):
     _mn_filepath_topology = StringObjectMNProperty("filepath_topology")
     _mn_filepath_trajectory = StringObjectMNProperty("filepath_trajectory")
     _mn_n_frames = IntObjectMNProperty("n_frames", _validate_non_negative)
-    _entity_type: EntityType = EntityType.MD
+    _entity_type: EntityType = EntityType.MOLECULE
 
     def __init__(
         self,
@@ -875,9 +875,7 @@ class Molecule(MolecularEntity):
         self, reader, file_path: str | Path | io.BytesIO
     ) -> None:
         """Store file-parsed assembly/entity/chain metadata on the Blender object."""
-        # a structure loaded from a single file is a "molecule" rather than an MD
-        # trajectory; whether playback UI is shown is decided by the frame count.
-        self.props.entity_type = EntityType.MOLECULE.value
+        self.props.entity_type = EntityType.MOLECULE
         self.props.entity_ids = reader.entity_ids()
         self.props.chain_ids = reader.chain_ids()
         self.props.biological_assemblies = reader.assemblies(as_json_string=True)

--- a/molecularnodes/entities/molecule/imd.py
+++ b/molecularnodes/entities/molecule/imd.py
@@ -154,4 +154,4 @@ class StreamingTrajectory(Molecule):
 
     def _get_annotation_entity_type(self) -> str:
         "Interna: Re-use the annotations for Molecule entity"
-        return EntityType.MD.value
+        return EntityType.MOLECULE

--- a/molecularnodes/entities/molecule/oxdna.py
+++ b/molecularnodes/entities/molecule/oxdna.py
@@ -476,4 +476,4 @@ class OXDNA(Molecule):
 
     def _get_annotation_entity_type(self) -> str:
         "Interna: Re-use the annotations for Molecule entity"
-        return EntityType.MD.value
+        return EntityType.MOLECULE

--- a/molecularnodes/entities/reload.py
+++ b/molecularnodes/entities/reload.py
@@ -25,6 +25,10 @@ from .molecule.reader import read_structure
 
 def _reload_molecule(obj: bpy.types.Object) -> Molecule:
     mn = obj.mn
+    # a molecule loaded from topology (+ trajectory) files records those paths;
+    # one parsed from a structure file or fetched records filepath/code instead
+    if mn.filepath_topology:
+        return _reload_trajectory(obj)
     if mn.code:
         file_path = StructureDownloader().download(
             code=mn.code, format="bcif", database=mn.database or "rcsb"
@@ -86,7 +90,6 @@ def _reload_ensemble_cellpack(obj: bpy.types.Object) -> CellPack:
 # so they are intentionally absent and cannot be reloaded
 _RELOADERS = {
     EntityType.MOLECULE.value: _reload_molecule,
-    EntityType.MD.value: _reload_trajectory,
     EntityType.MD_OXDNA.value: _reload_trajectory,
     EntityType.DENSITY.value: _reload_density,
     EntityType.ENSEMBLE_STAR.value: _reload_ensemble_star,

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -24,6 +24,7 @@ from ..entities import (
     ensemble,
     molecule,
 )
+from ..entities.base import EntityType
 from ..nodes import nodes
 from ..nodes.node_management import (
     remove_style_node,
@@ -509,7 +510,12 @@ class MN_OT_Reload_Trajectory(bpy.types.Operator):
     def poll(cls, context):
         obj = context.active_object
         loaded_trajectory = context.scene.MNSession.match(obj)
-        return obj.mn.entity_type.startswith("md") and not loaded_trajectory
+        # "molecule" covers MD trajectories too — reloadable here when loaded
+        # from topology (+ trajectory) files
+        reloadable = obj.mn.entity_type.startswith("md") or (
+            obj.mn.entity_type == EntityType.MOLECULE and obj.mn.filepath_topology
+        )
+        return bool(reloadable) and not loaded_trajectory
 
     def execute(self, context):
         obj = context.active_object

--- a/molecularnodes/ui/ops.py
+++ b/molecularnodes/ui/ops.py
@@ -695,9 +695,13 @@ class MN_OT_Add_Style(Operator):
 
     bl_idname = "mn.add_style"
     bl_label = "Add Style"
-    bl_description = "Add new style to Fpointntity"
+    bl_description = "Add a new style to the entity"
+    bl_options = {"REGISTER", "UNDO"}
 
     uuid: StringProperty()  # type: ignore
+    # fallback identifier for objects not linked to a session entity, whose
+    # style branch is built directly in the object's node tree
+    name_object: StringProperty()  # type: ignore
 
     style: EnumProperty(  # type: ignore
         name="Style",
@@ -755,15 +759,57 @@ class MN_OT_Add_Style(Operator):
 
     def execute(self, context: Context):
         entity = get_session().get(self.uuid)
-        if self.use_uniform_color:
-            color = self.uniform_color
-        else:
-            color = self.color_scheme
-        entity.add_style(
+        selection = self.selection.strip() or None
+        name = self.name.strip() or None
+        if entity is not None:
+            entity.add_style(
+                style=self.style,
+                color=self.uniform_color
+                if self.use_uniform_color
+                else self.color_scheme,
+                selection=selection,
+                name=name,
+            )
+            return {"FINISHED"}
+
+        # without a session entity the style branch is built directly in the
+        # object's node tree — no universe means no MDAnalysis selections and
+        # no color schemes, so those degrade with a warning
+        obj = bpy.data.objects.get(self.name_object)
+        mod = obj.modifiers.get("Molecular Nodes") if obj is not None else None
+        tree = getattr(mod, "node_group", None)
+        if tree is None:
+            self.report({"ERROR"}, "Object has no Molecular Nodes node tree")
+            return {"CANCELLED"}
+
+        attribute = None
+        if selection is not None and selection != "all":
+            if obj.data is not None and selection in obj.data.attributes:
+                attribute = selection
+            else:
+                self.report(
+                    {"WARNING"},
+                    f"'{selection}' is not an attribute on the object; selections "
+                    "need the entity reloaded (linked) to be evaluated. Style "
+                    "added to all atoms",
+                )
+        if not self.use_uniform_color and self.color_scheme not in (
+            "common",
+            "default",
+        ):
+            # baked attribute colors already reflect the common scheme; anything
+            # else needs the entity to compute
+            self.report(
+                {"WARNING"},
+                f"Color scheme '{self.color_scheme}' needs a linked entity; "
+                "keeping the existing colors",
+            )
+        molecule.base.add_style_to_tree(
+            tree,
             style=self.style,
-            color=color,
-            selection=self.selection.strip() or None,
-            name=self.name.strip() or None,
+            color=tuple(self.uniform_color) if self.use_uniform_color else None,
+            selection_attribute=attribute,
+            name=name,
         )
         return {"FINISHED"}
 
@@ -778,18 +824,33 @@ class MN_OT_Remove_Style(Operator):
 
     bl_idname = "mn.remove_style"
     bl_label = "Remove Style"
-    bl_description = "Remove style from entity"
+    bl_description = (
+        "Remove the selected style, along with its selection and color nodes"
+    )
+    bl_options = {"REGISTER", "UNDO"}
 
-    uuid: StringProperty()  # type: ignore
-    style_node_index: IntProperty()  # type: ignore
+    # the node is identified by tree + node name, as operators can't take
+    # pointers; working on Blender data directly (rather than through the
+    # session) keeps removal available for unlinked objects
+    name_tree: StringProperty()  # type: ignore
+    name_node: StringProperty()  # type: ignore
 
     def execute(self, context: Context):
-        entity = get_session().get(self.uuid)
-        node_group = entity.node_group
-        style_node = node_group.nodes[self.style_node_index]
-        remove_style_node(style_node)
-        # set the active index in UI to the last style
-
+        tree = bpy.data.node_groups.get(self.name_tree)
+        if tree is None or self.name_node not in tree.nodes:
+            self.report({"ERROR"}, "Style node to remove was not found")
+            return {"CANCELLED"}
+        remove_style_node(tree.nodes[self.name_node])
+        # keep the styles list selection valid by pointing it at the last
+        # remaining style node, on every object rendered by this tree
+        last = max(
+            (i for i, node in enumerate(tree.nodes) if "Style" in node.name),
+            default=-1,
+        )
+        for obj in bpy.data.objects:
+            mod = obj.modifiers.get("Molecular Nodes")
+            if mod is not None and getattr(mod, "node_group", None) == tree:
+                obj.mn.styles_active_index = last
         return {"FINISHED"}
 
     def invoke(self, context, event):

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -778,8 +778,19 @@ class MN_PT_Styles(bpy.types.Panel):
             layout.label(text="No Molecular Nodes modifier on this object")
             return
 
+        # the style node selected in the list, if any
+        index = obj.mn.styles_active_index
+        style_node = None
+        if 0 <= index < len(node_group.nodes):
+            node = node_group.nodes[index]
+            if is_style_node(node):
+                style_node = node
+
+        entity = context.scene.MNSession.get(obj.uuid)
+
         # list the style nodes in the tree and let the user select one
-        layout.template_list(
+        row = layout.row()
+        row.template_list(
             "MN_UL_StylesList",
             "styles_list",
             node_group,
@@ -788,14 +799,24 @@ class MN_PT_Styles(bpy.types.Panel):
             "styles_active_index",
             rows=3,
         )
+        col = row.column()
+        # adding uses the entity API when linked, and otherwise builds the
+        # style branch directly in the object's node tree; density styles are
+        # different nodes, so density objects only get swap/remove
+        add = col.row()
+        add.enabled = isinstance(entity, Molecule) or (
+            entity is None and obj.mn.entity_type != EntityType.DENSITY.value
+        )
+        op = add.operator("mn.add_style", icon="ADD", text="")
+        op.uuid = obj.uuid
+        op.name_object = obj.name
+        remove = col.row()
+        remove.enabled = style_node is not None
+        op = remove.operator("mn.remove_style", icon="REMOVE", text="")
+        if style_node is not None:
+            op.name_tree = node_group.name
+            op.name_node = style_node.name
 
-        # the style node selected in the list, if any
-        index = obj.mn.styles_active_index
-        style_node = None
-        if 0 <= index < len(node_group.nodes):
-            node = node_group.nodes[index]
-            if is_style_node(node):
-                style_node = node
         if style_node is None:
             layout.label(text="Select a style to edit its properties")
             return
@@ -812,8 +833,6 @@ class MN_PT_Styles(bpy.types.Panel):
         op.name_node = style_node.name
 
         # display the selection string if using a named attribute
-        entity = context.scene.MNSession.get(obj.uuid)
-
         if style_node.inputs["Selection"].links and entity is not None:
             node = style_node.inputs["Selection"].links[0].from_node
             if isinstance(node, bpy.types.GeometryNodeInputNamedAttribute):

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -261,44 +261,123 @@ def panel_object(layout: bpy.types.UILayout, context: bpy.types.Context):
         return None
 
 
-def panel_scene(layout, context):
+# must match molecularnodes.scene.world.mn_world_shader_node_name — not imported
+# from there because the scene package is an optional dependency of the addon UI
+MN_WORLD_SHADER_NODE = "MN_world_shader"
+
+
+def get_world_shader_node(scene: bpy.types.Scene) -> bpy.types.Node | None:
+    """The ``MN_world_shader`` node driving the world background, or None."""
+    world = scene.world
+    if world is None or world.node_tree is None:
+        return None
+    return world.node_tree.nodes.get(MN_WORLD_SHADER_NODE)
+
+
+def panel_render(layout: UILayout, context: bpy.types.Context) -> None:
+    """
+    The common render settings in one place, mirroring the convenience
+    properties that ``mn.Canvas`` exposes for scripting.
+    """
     scene = context.scene
+    layout.use_property_split = True
+    layout.use_property_decorate = False
 
-    cam = bpy.data.cameras[bpy.data.scenes["Scene"].camera.name]
-    world_shader = bpy.data.worlds["World Shader"].node_tree.nodes["MN_world_shader"]
-    grid = layout.grid_flow()
-    col = grid.column()
-    col.label(text="World Settings")
-    world = col.box()
-    world.prop(bpy.data.scenes["Scene"].render, "engine")
+    col = layout.column()
+    col.prop(scene.render, "engine")
     if scene.render.engine == "CYCLES":
-        world.prop(bpy.data.scenes["Scene"].cycles, "samples")
+        col.prop(scene.cycles, "device")
+        col.prop(scene.cycles, "samples")
+        col.prop(scene.cycles, "use_denoising", text="Denoise")
     else:
-        world.prop(bpy.data.scenes["Scene"].eevee, "taa_render_samples")
-    world.label(text="Background")
-    world.prop(world_shader.inputs[1], "default_value", text="HDRI Strength")
-    row = world.row()
-    row.prop(scene.render, "film_transparent")
-    row.prop(world_shader.inputs[2], "default_value", text="Background")
+        col.prop(scene.eevee, "taa_render_samples", text="Samples")
 
-    col = grid.column()
-    col.label(text="Camera Settings")
-    camera = col.box()
-    camera.prop(cam, "lens")
-    col = camera.column(align=True)
-    row = col.row(align=True)
-    row.prop(bpy.data.scenes["Scene"].render, "resolution_x", text="X")
-    row.prop(bpy.data.scenes["Scene"].render, "resolution_y", text="Y")
-    row = camera.grid_flow()
-    row.prop(cam.dof, "use_dof")
-    row.prop(bpy.data.scenes["Scene"].render, "use_motion_blur")
-    focus = camera.column()
-    focus.enabled = cam.dof.use_dof
-    focus.prop(cam.dof, "focus_object")
-    distance = focus.row()
-    distance.enabled = cam.dof.focus_object is None
-    distance.prop(cam.dof, "focus_distance")
-    focus.prop(cam.dof, "aperture_fstop")
+    col = layout.column(align=True)
+    col.prop(scene.render, "resolution_x", text="Resolution X")
+    col.prop(scene.render, "resolution_y", text="Y")
+    col.prop(scene.render, "resolution_percentage", text="%")
+    layout.prop(scene.render, "film_transparent", text="Transparent")
+
+    col = layout.column()
+    # the background shortcuts need the world shader node from the MN preset;
+    # sockets match molecularnodes.scene.world.WorldTree
+    world_shader = get_world_shader_node(scene)
+    if world_shader is not None:
+        col.prop(world_shader.inputs[3], "default_value", text="Background")
+        col.prop(world_shader.inputs[1], "default_value", text="HDRI Strength")
+
+    header, body = layout.panel(idname="mn_render_camera", default_closed=False)
+    header.label(text="Camera")
+    if body is not None:
+        # aimed at scenes with a single camera, so the scene's active camera
+        # is edited directly rather than offering a picker
+        camera = scene.camera
+        if camera is None:
+            body.label(text="No camera in the scene")
+        else:
+            cam_data = cast(bpy.types.Camera, camera.data)
+            dof = cam_data.dof
+            assert cam_data is not None
+            body.prop(cam_data, "lens", text="Focal Length")
+            body.prop(dof, "use_dof", text="Depth of Field")
+            focus = body.column()
+            focus.enabled = dof.use_dof
+            focus.prop(dof, "focus_object")
+            distance = focus.row()
+            distance.active = dof.focus_object is None
+            row = distance.row(align=True)
+            row.prop(dof, "focus_distance", text="Focus Distance")
+            # the depth eyedropper samples through the camera, so its poll only
+            # passes while the viewport is in camera view — grey it out
+            # deliberately (rather than letting the poll flicker it on hover)
+            # and hint at how to enable it
+            region_3d = getattr(context.space_data, "region_3d", None)
+            in_camera_view = (
+                region_3d is not None and region_3d.view_perspective == "CAMERA"
+            )
+            pick = row.row(align=True)
+            pick.enabled = in_camera_view
+            op = pick.operator("ui.eyedropper_depth", icon="EYEDROPPER", text="")
+            op.prop_data_path = "scene.camera.data.dof.focus_distance"
+            if not in_camera_view:
+                focus.label(
+                    text="Enter camera view to pick focus distance", icon="INFO"
+                )
+            focus.prop(dof, "aperture_fstop", text="F-Stop")
+
+    header, body = layout.panel(idname="mn_render_color", default_closed=True)
+    header.label(text="Color Management")
+    if body is not None:
+        view = scene.view_settings
+        body.prop(view, "view_transform")
+        body.prop(view, "look")
+        body.prop(view, "exposure")
+        body.prop(view, "gamma")
+
+    header, body = layout.panel(idname="mn_render_animation", default_closed=True)
+    header.label(text="Animation")
+    if body is not None:
+        col = body.column(align=True)
+        col.prop(scene, "frame_start", text="Frame Start")
+        col.prop(scene, "frame_end", text="End")
+        body.prop(scene.render, "fps", text="FPS")
+
+
+class MN_PT_Render(bpy.types.Panel):
+    """
+    Panel collecting the common render settings (Viewport)
+    """
+
+    bl_idname = "MN_PT_render"
+    bl_label = "Render"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Molecular Nodes"
+
+    def draw(self, context):
+        layout = self.layout
+        assert layout
+        panel_render(layout, context)
 
 
 class MN_PT_Scene(bpy.types.Panel):
@@ -820,6 +899,7 @@ class MN_PT_Annotations(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "Molecular Nodes"
+    bl_options = {"DEFAULT_CLOSED"}
 
     @classmethod
     def poll(cls, context):
@@ -984,5 +1064,6 @@ CLASSES = [
     MN_PT_Styles,
     MN_UL_AnnotationsList,
     MN_PT_Annotations,
+    MN_PT_Render,
     MN_PT_Compositor,
 ]

--- a/molecularnodes/ui/panel.py
+++ b/molecularnodes/ui/panel.py
@@ -250,10 +250,17 @@ def panel_object(layout: bpy.types.UILayout, context: bpy.types.Context):
     if not object.mn.is_entity:
         layout.label(text="No MN object selected")
         return None
-    if mol_type.startswith("md") or mol_type == EntityType.MOLECULE.value:
+    if mol_type.startswith("md") or mol_type == EntityType.MOLECULE:
         # molecules and trajectories are both Universe-backed, so both expose selections
         # and (frame-count permitting) playback
         panel_md_properties(layout, context)
+    if mol_type in STYLED_ENTITY_TYPES:
+        # the same styles list as the viewport sidebar, since styles belong to
+        # this object
+        header, body = layout.panel(idname="object_styles")
+        header.label(text="Styles", icon="MATERIAL")
+        if body is not None:
+            panel_styles(body, context, object)
     if mol_type == "ensemble-star":
         layout.label(text="Ensemble")
         box = layout.box()
@@ -578,16 +585,13 @@ class MN_PT_trajectory(bpy.types.Panel):
         if obj is None or context.scene.MNSession.get(obj.uuid) is None:
             return False
         if obj.mn.entity_type not in (
-            EntityType.MD.value,
-            EntityType.MD_STREAMING.value,
-            EntityType.MD_OXDNA.value,
-            EntityType.MOLECULE.value,
+            EntityType.MD_STREAMING,
+            EntityType.MD_OXDNA,
+            EntityType.MOLECULE,
         ):
             return False
         # a single static structure has no playback; streaming has an unknown frame count
-        return (
-            obj.mn.entity_type == EntityType.MD_STREAMING.value or obj.mn.n_frames > 1
-        )
+        return obj.mn.entity_type == EntityType.MD_STREAMING or obj.mn.n_frames > 1
 
     def draw(self, context):
         layout = cast(UILayout, self.layout)
@@ -618,10 +622,10 @@ class MN_PT_trajectory_dssp(bpy.types.Panel):
         obj = get_active_entity_object(context)
         if obj is None or context.scene.MNSession.get(obj.uuid) is None:
             return False
-        return obj.mn.entity_type in (
-            EntityType.MD.value,
-            EntityType.MD_STREAMING.value,
-        )
+        # DSSP is computed over trajectory frames, so a molecule needs playback
+        if obj.mn.entity_type == EntityType.MD_STREAMING:
+            return True
+        return obj.mn.entity_type == EntityType.MOLECULE and obj.mn.n_frames > 1
 
     def draw(self, context):
         layout = self.layout
@@ -636,7 +640,7 @@ class MN_PT_trajectory_dssp(bpy.types.Panel):
             return
         props = traj.props.dssp
         # display options
-        if traj._entity_type == EntityType.MD:
+        if traj._entity_type == EntityType.MOLECULE:
             row = layout.row()
             row.prop(props, "display_option")
         elif traj._entity_type == EntityType.MD_STREAMING:
@@ -743,6 +747,103 @@ class MN_UL_StylesList(bpy.types.UIList):
         return filtered, ordered
 
 
+# entity types whose objects carry styles in a "Molecular Nodes" modifier tree
+STYLED_ENTITY_TYPES = (
+    EntityType.MD_STREAMING,
+    EntityType.MOLECULE,
+    EntityType.DENSITY,
+)
+
+
+def panel_styles(
+    layout: UILayout, context: bpy.types.Context, obj: bpy.types.Object
+) -> None:
+    """
+    The styles list and controls for an object, shared between the viewport
+    Styles panel and the Object properties panel.
+    """
+    # style nodes live in the object's node tree — read them directly from
+    # Blender data so the panel does not depend on the session being linked
+    node_group = get_entity_node_group(obj)
+    if node_group is None:
+        layout.label(text="No Molecular Nodes modifier on this object")
+        return
+
+    # the style node selected in the list, if any
+    index = obj.mn.styles_active_index
+    style_node = None
+    if 0 <= index < len(node_group.nodes):
+        node = node_group.nodes[index]
+        if is_style_node(node):
+            style_node = node
+
+    entity = context.scene.MNSession.get(obj.uuid)
+
+    # list the style nodes in the tree and let the user select one
+    row = layout.row()
+    row.template_list(
+        "MN_UL_StylesList",
+        "styles_list",
+        node_group,
+        "nodes",
+        obj.mn,
+        "styles_active_index",
+        rows=3,
+    )
+    col = row.column()
+    # adding uses the entity API when linked, and otherwise builds the
+    # style branch directly in the object's node tree; density styles are
+    # different nodes, so density objects only get swap/remove
+    add = col.row()
+    add.enabled = isinstance(entity, Molecule) or (
+        entity is None and obj.mn.entity_type != EntityType.DENSITY
+    )
+    op = add.operator("mn.add_style", icon="ADD", text="")
+    op.uuid = obj.uuid
+    op.name_object = obj.name
+    remove = col.row()
+    remove.enabled = style_node is not None
+    op = remove.operator("mn.remove_style", icon="REMOVE", text="")
+    if style_node is not None:
+        op.name_tree = node_group.name
+        op.name_node = style_node.name
+
+    if style_node is None:
+        layout.label(text="Select a style to edit its properties")
+        return
+
+    # swap the selected style node for a different style
+    row = layout.row(align=True)
+    row.label(text="Style:")
+    op = row.operator_menu_enum(
+        "mn.swap_style",
+        "style",
+        text=style_node.node_tree.name.replace("Style ", ""),
+    )
+    op.name_tree = node_group.name
+    op.name_node = style_node.name
+
+    # display the selection string if using a named attribute
+    if style_node.inputs["Selection"].links and entity is not None:
+        node = style_node.inputs["Selection"].links[0].from_node
+        if isinstance(node, bpy.types.GeometryNodeInputNamedAttribute):
+            if isinstance(entity, Molecule):
+                selection = entity.selections.get(node.inputs["Name"].default_value)
+                layout.prop(selection, "string", text="Selection")
+    else:
+        op: MN_OT_add_selection_to_style = layout.operator(
+            operator="mn.add_selection_to_style"
+        )
+        op.node_tree = node_group.name
+        op.node_name = style_node.name
+
+    # display the selected style node's name and its input properties
+    header, body = layout.panel(idname="style_properties")
+    header.label(text=style_node.label or style_node.name)
+    if body is not None:
+        body.template_node_inputs(style_node)
+
+
 class MN_PT_Styles(bpy.types.Panel):
     """
     Panel for styles
@@ -758,12 +859,7 @@ class MN_PT_Styles(bpy.types.Panel):
     def poll(cls, context):
         """Visible only if the active entity is a trajectory, molecule or density"""
         obj = get_active_entity_object(context)
-        return obj is not None and obj.mn.entity_type in (
-            EntityType.MD.value,
-            EntityType.MD_STREAMING.value,
-            EntityType.MOLECULE.value,
-            EntityType.DENSITY.value,
-        )
+        return obj is not None and obj.mn.entity_type in STYLED_ENTITY_TYPES
 
     def draw(self, context):
         layout = self.layout
@@ -771,86 +867,7 @@ class MN_PT_Styles(bpy.types.Panel):
         obj = get_active_entity_object(context)
         if obj is None:
             return
-        # style nodes live in the object's node tree — read them directly from
-        # Blender data so the panel does not depend on the session being linked
-        node_group = get_entity_node_group(obj)
-        if node_group is None:
-            layout.label(text="No Molecular Nodes modifier on this object")
-            return
-
-        # the style node selected in the list, if any
-        index = obj.mn.styles_active_index
-        style_node = None
-        if 0 <= index < len(node_group.nodes):
-            node = node_group.nodes[index]
-            if is_style_node(node):
-                style_node = node
-
-        entity = context.scene.MNSession.get(obj.uuid)
-
-        # list the style nodes in the tree and let the user select one
-        row = layout.row()
-        row.template_list(
-            "MN_UL_StylesList",
-            "styles_list",
-            node_group,
-            "nodes",
-            obj.mn,
-            "styles_active_index",
-            rows=3,
-        )
-        col = row.column()
-        # adding uses the entity API when linked, and otherwise builds the
-        # style branch directly in the object's node tree; density styles are
-        # different nodes, so density objects only get swap/remove
-        add = col.row()
-        add.enabled = isinstance(entity, Molecule) or (
-            entity is None and obj.mn.entity_type != EntityType.DENSITY.value
-        )
-        op = add.operator("mn.add_style", icon="ADD", text="")
-        op.uuid = obj.uuid
-        op.name_object = obj.name
-        remove = col.row()
-        remove.enabled = style_node is not None
-        op = remove.operator("mn.remove_style", icon="REMOVE", text="")
-        if style_node is not None:
-            op.name_tree = node_group.name
-            op.name_node = style_node.name
-
-        if style_node is None:
-            layout.label(text="Select a style to edit its properties")
-            return
-
-        # swap the selected style node for a different style
-        row = layout.row(align=True)
-        row.label(text="Style:")
-        op = row.operator_menu_enum(
-            "mn.swap_style",
-            "style",
-            text=style_node.node_tree.name.replace("Style ", ""),
-        )
-        op.name_tree = node_group.name
-        op.name_node = style_node.name
-
-        # display the selection string if using a named attribute
-        if style_node.inputs["Selection"].links and entity is not None:
-            node = style_node.inputs["Selection"].links[0].from_node
-            if isinstance(node, bpy.types.GeometryNodeInputNamedAttribute):
-                if isinstance(entity, Molecule):
-                    selection = entity.selections.get(node.inputs["Name"].default_value)
-                    layout.prop(selection, "string", text="Selection")
-        else:
-            op: MN_OT_add_selection_to_style = layout.operator(
-                operator="mn.add_selection_to_style"
-            )
-            op.node_tree = node_group.name
-            op.node_name = style_node.name
-
-        # display the selected style node's name and its input properties
-        header, body = layout.panel(idname="style_properties")
-        header.label(text=style_node.label or style_node.name)
-        if body is not None:
-            body.template_node_inputs(style_node)
+        panel_styles(layout, context, obj)
 
 
 class MN_UL_AnnotationsList(bpy.types.UIList):
@@ -927,10 +944,9 @@ class MN_PT_Annotations(bpy.types.Panel):
         if obj is None or context.scene.MNSession.get(obj.uuid) is None:
             return False
         return obj.mn.entity_type in (
-            EntityType.MD.value,
-            EntityType.MD_STREAMING.value,
-            EntityType.MOLECULE.value,
-            EntityType.DENSITY.value,
+            EntityType.MD_STREAMING,
+            EntityType.MOLECULE,
+            EntityType.DENSITY,
         )
 
     def draw(self, context):

--- a/molecularnodes/ui/props.py
+++ b/molecularnodes/ui/props.py
@@ -25,7 +25,6 @@ ENTITY_ITEMS = (
     ("molecule", "Molecule", "A single molecule"),
     ("ensemble", "Ensemble", "A collection of molecules"),
     ("density", "Density", "A density grid"),
-    ("md", "Trajectory", "A molecular dynamics trajectory"),
     ("md-oxdna", "oxDNA Trajectory", "A oxDNA molecular dynamics trajectory"),
     (
         "md-streaming",

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -101,7 +101,7 @@ def test_op_api_mda(snapshot_custom: NumpySnapshotExtension):
     assert traj_op.name == "box.gro"
     traj_op.name = name
     assert traj_op.name == name
-    assert traj_op._mn_entity_type == mn.entities.base.EntityType.MD.value
+    assert traj_op._mn_entity_type == mn.entities.base.EntityType.MOLECULE
 
     traj_func = mn.entities.molecule.Molecule.load(
         topo, traj, name="test", style="ribbon"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -235,7 +235,7 @@ def test_entity_blender_properties(session: MNSession, universe):
     assert t1.uuid in session.entities
     obj = bpy.data.objects["u1"]
     # entity type is stored on the object properties
-    assert obj.mn.entity_type == "md"
+    assert obj.mn.entity_type == "molecule"
     assert obj.uuid == t1.uuid
     # visibility is driven through the object properties
     assert obj.mn.visible


### PR DESCRIPTION
Hunting around the various panels for common render settings is quite annoying and _very_ confusing for new users unfamiliar with Blender. This collects them into a single panel for display in the MN panel for convenience.