### PR TITLE
FIX: Periodic correction drifiting during playback

### DIFF
--- a/molecularnodes/entities/molecule/helpers.py
+++ b/molecularnodes/entities/molecule/helpers.py
@@ -314,13 +314,26 @@ class FrameManager:
         if self.trajectory.average == 0:
             return self.cache[frame]
 
-        array = self.cache.get_ordered_array()
+        # park the universe on this frame so the box dimensions used by the
+        # corrections below are a deterministic function of `frame` — after
+        # cache updates the universe sits on whichever frame happened to be a
+        # cache miss, and in an NPT box a borderline (half-box) correction
+        # would flip between evaluations of the same frame
+        self.trajectory.uframe = frame
+
+        # average exactly the window for this frame — the cache can hold other
+        # frames (interpolation look-ahead, a previous window), which must not
+        # leak into the mean
+        array = np.array([self.cache[f] for f in self._frame_range(frame)])
         if self.trajectory.correct_periodic and self.trajectory._is_orthorhombic:
-            # Correct periodic boundary crossing relative to the first frame
-            for i, pos in enumerate(array):
-                if i == 0:
-                    continue
-                array[i] = self.adjust_periodic_positions(array[0], pos)
+            # correct each frame against its (corrected) predecessor:
+            # consecutive frames are where the nearest-image assumption holds.
+            # Correcting everything against the window's first frame mistakes
+            # real motion greater than half a box — legitimate in unwrapped or
+            # per-molecule-imaged trajectories — for a boundary crossing, and
+            # the windows of neighbouring frames then disagree by a whole box
+            for i in range(1, len(array)):
+                array[i] = self.adjust_periodic_positions(array[i - 1], array[i])
 
         return np.mean(array, axis=0)
 
@@ -373,18 +386,11 @@ class FrameManager:
             pos_current = self.position_cache_mean(uframe_current)
             pos_next = self.position_cache_mean(uframe_next)
 
-            # Apply periodic correction if needed (and not already applied via averaging)
-            if (
-                self.trajectory.correct_periodic
-                and self.trajectory._is_orthorhombic
-                and self.trajectory.average == 0
-            ):
-                pos_next = correct_periodic_positions(
-                    pos_current,
-                    pos_next,
-                    dimensions=self.trajectory.universe.dimensions[:3]
-                    * self.trajectory.world_scale,
-                )
+            # interpolate towards the nearest periodic image. Averaging only
+            # corrects within each window, so two averaged endpoints can still
+            # sit on opposite sides of the box — the correction applies to them
+            # just the same
+            pos_next = self.adjust_periodic_positions(pos_current, pos_next)
 
             # Interpolate between the two sets of positions
             return db.lerp(

--- a/molecularnodes/utils.py
+++ b/molecularnodes/utils.py
@@ -62,11 +62,12 @@ def fraction(x, y):
 def correct_periodic_1d(
     value1: np.ndarray, value2: np.ndarray, boundary: float
 ) -> np.ndarray:
+    # shift value2 by whole box lengths to the periodic image nearest value1.
+    # A pure function of its inputs: mutating value2 in place would poison the
+    # frame position cache, chaining each frame's correction onto the previous
+    # already-shifted frame so positions unwrap further out every crossing
     diff = value2 - value1
-    half = boundary / 2
-    value2[diff > half] -= boundary
-    value2[diff < -half] += boundary
-    return value2
+    return value2 - boundary * np.round(diff / boundary)
 
 
 def correct_periodic_positions(

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -215,6 +215,53 @@ class TestTrajectory:
         assert snapshot_custom == pos_a
         traj.correct_periodic = False
 
+    def test_correct_periodic_no_drift(self, univ_across_boundary):
+        # the correction must only bridge the interpolation to the nearest
+        # periodic image: on exact frame ticks the wrapped trajectory positions
+        # are shown as-is. It used to mutate the cached positions, so each
+        # frame was corrected against the previous already-shifted frame and
+        # the trajectory unwrapped further out on every boundary crossing
+        traj = mn.entities.Molecule(univ_across_boundary)
+        traj.subframes = 3
+        traj.interpolate = True
+        traj.correct_periodic = True
+
+        n_frames = traj.universe.trajectory.n_frames
+        # walk the timeline through the subframes, as playback does
+        for scene_frame in range((n_frames - 1) * 4 + 1):
+            bpy.context.scene.frame_set(scene_frame)
+            if scene_frame % 4 == 0:
+                shown = traj.position.copy()
+                raw = traj.frame_manager._position_at_frame(scene_frame // 4)
+                assert np.allclose(shown, raw)
+        traj.correct_periodic = False
+
+    def test_correct_periodic_interpolates_averaged_frames(self, univ_across_boundary):
+        # subframes between averaged frames must also bridge to the nearest
+        # periodic image — the correction used to be skipped when averaging,
+        # so a crossing atom swept across the whole box over the subframes
+        traj = mn.entities.Molecule(univ_across_boundary)
+        traj.subframes = 3
+        traj.interpolate = True
+        traj.average = 1
+        traj.correct_periodic = True
+
+        # within a segment each subframe step is a quarter of the (corrected)
+        # frame-to-frame motion, far below the ~quarter-box sweeps of an
+        # uncorrected crossing; steps onto exact ticks are skipped, as that is
+        # where atoms legitimately wrap to the other side of the box
+        dimensions = traj.universe.dimensions[:3] * traj.world_scale
+        previous = None
+        for scene_frame in range(4, 4 * 7 + 1):
+            bpy.context.scene.frame_set(scene_frame)
+            position = np.asarray(traj.position).copy()
+            if previous is not None and scene_frame % 4 != 0:
+                step = np.abs(position - previous)
+                assert (step < dimensions * 0.2).all()
+            previous = position
+        traj.average = 0
+        traj.correct_periodic = False
+
     def test_position_at_frame(self, universe):
         traj = mn.entities.Molecule(universe)
         assert not np.allclose(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,23 @@ def test_correct_1d():
     )
 
 
+def test_correct_1d_is_pure():
+    # the correction must not touch its inputs — in-place mutation poisoned the
+    # frame position cache, unwrapping trajectories further out every crossing
+    value1 = np.array((0.9, 0.1))
+    value2 = np.array((0.1, 0.9))
+    mn.utils.correct_periodic_1d(value1, value2, 1.0)
+    assert np.allclose(value2, (0.1, 0.9))
+
+
+def test_correct_1d_multiple_wraps():
+    # a jump of several box lengths is folded back in a single correction
+    assert np.allclose(
+        mn.utils.correct_periodic_1d(np.array((0.0,)), np.array((2.3,)), 1.0),
+        np.array((0.3,)),
+    )
+
+
 def test_frame_mapper_basic():
     assert frame_mapper(10) == 10
     assert frame_mapper(0) == 0


### PR DESCRIPTION
The playback periodic correction accumulated instead of bridging frames, so positions unwrapped further out on every boundary crossing, and subframes interpolated across the whole box when averaging was enabled.

- correct_periodic_1d mutated its input in place; the input was often a cached frame's array (returned by reference), so each frame was corrected against the previous already-shifted frame — a running unwrap. Now a pure function using the minimum-image convention (round(diff / boundary)), which also folds multi-box jumps in one step.
- The interpolation branch skipped the correction when average > 0; averaging only corrects within its window, so the averaged endpoints could sit on opposite sides of the box. The correction now always applies to the interpolation endpoints.
- Window averaging corrected all frames against the window's first frame, mistaking real motion > half a box (legitimate in unwrapped / per-molecule-imaged trajectories) for a crossing, and neighbouring windows disagreed by a whole box. Frames are now corrected against their predecessor, and the mean covers exactly the window rather than whatever else the cache held.
- Box dimensions were read at whichever frame was last a cache miss, flipping borderline half-box corrections between evaluations in NPT boxes; the universe is now parked on the target frame first.

On exact frame ticks the raw (wrapped or unwrapped) positions show as-is; the correction only bridges each interpolation segment to the nearest periodic image, bounding subframe steps to half a box per segment. Tests cover purity, multi-wrap folding, no-drift on replay, and bounded subframe steps with averaging enabled.