### PR TITLE
FIX: Type hinting for `pyrefly`

### DIFF
--- a/molecularnodes/scene/engines.py
+++ b/molecularnodes/scene/engines.py
@@ -1,7 +1,10 @@
 import warnings
 from abc import ABC
+from typing import Literal
 import bpy
 from .render import enable_optimal_gpu
+
+_CyclesDeviceTypes = Literal["CPU", "GPU"]
 
 
 class RenderEngine(ABC):
@@ -65,7 +68,7 @@ class Cycles(RenderEngine):
     def __init__(
         self,
         samples: int = 256,
-        device: str = "GPU",
+        device: _CyclesDeviceTypes = "GPU",
         denoise: bool = True,
         denoise_gpu: bool = True,
     ):
@@ -93,11 +96,11 @@ class Cycles(RenderEngine):
         self.engine.samples = value
 
     @property
-    def device(self) -> str:
+    def device(self) -> _CyclesDeviceTypes:
         return self.engine.device
 
     @device.setter
-    def device(self, value: str):
+    def device(self, value: _CyclesDeviceTypes):
         value = value.upper()
         self.engine.device = value
         if value == "GPU":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ requires = ["setuptools>=61.0"]
 [tool.setuptools]
 include-package-data = true
 
+[tool.uv]
+config-settings = { editable_mode = "compat" }
+
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["molecularnodes.nodes._generation*"]


### PR DESCRIPTION
Using the `pyrefly` type checking was failing with the default install. Addint the `tool.uv` option fixes the installation and pyrefly can now resolve the types well.
