### PR TITLE
ENH: Node add handlers

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,17 +2,17 @@
 title: "Changelog"
 ---
 
-# UNRELEASED
+# v520.1.0 - UNRELEASED
 
-## Fixed
-- Added a  general handler that triggers after nodes are added to the tree in the GUI. Sets the default material of style nodes and generates data objects for biological assemblies. [#1191](https://github.com/BradyAJohnston/MolecularNodes/pull/1191)
+## Added
+- Added a general handler that triggers after nodes are added to the tree in the GUI. Sets the default material of style nodes and generates data objects for biological assemblies. [#1191](https://github.com/BradyAJohnston/MolecularNodes/pull/1191)
 
-# v520.0.1 2026-09-06
+# v520.0.1 - 2026-09-06
 
 ## Fixed
 - Text printing in a jupyter notebook crashed rendering [#1185](https://github.com/BradyAJohnston/MolecularNodes/pull/1185)
 
-# 520.0.0 - 2026-09-05
+# v520.0.0 - 2026-09-05
 
 ## Added
 - On using the import operators, the camera and viewport end clipping distance is increased to 10000 from 100 so users aren't confused when importing larger structures and systems #1150

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,7 +2,17 @@
 title: "Changelog"
 ---
 
-# 5.2.0 - UNRELEASED
+# UNRELEASED
+
+## Fixed
+- Added a  general handler that triggers after nodes are added to the tree in the GUI. Sets the default material of style nodes and generates data objects for biological assemblies. [#1191](https://github.com/BradyAJohnston/MolecularNodes/pull/1191)
+
+# v520.0.1 2026-09-06
+
+## Fixed
+- Text printing in a jupyter notebook crashed rendering [#1185](https://github.com/BradyAJohnston/MolecularNodes/pull/1185)
+
+# 520.0.0 - 2026-09-05
 
 ## Added
 - On using the import operators, the camera and viewport end clipping distance is increased to 10000 from 100 so users aren't confused when importing larger structures and systems #1150

--- a/molecularnodes/blender_manifest.toml
+++ b/molecularnodes/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "molecularnodes"
-version = "520.0.0"
+version = "520.1.0"
 name = "Molecular Nodes"
 tagline = "A toolbox for molecular import and animation in Blender"
 maintainer = "Brady Johnston<brady.johnston@me.com>"

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -1595,6 +1595,4 @@ def _on_add_assembly_instance(
     socket.default_value = entity.create_data_object()
 
 
-node_handlers.register_on_add(
-    AssemblyInstance._name, node_setup=_on_add_assembly_instance
-)
+node_handlers.register_on_add(AssemblyInstance._name, _on_add_assembly_instance)

--- a/molecularnodes/entities/molecule/base.py
+++ b/molecularnodes/entities/molecule/base.py
@@ -25,6 +25,8 @@ from ...assets import data
 from ...blender import coll, path_resolve, set_obj_active
 from ...blender import utils as blender_utils
 from ...converters import universe_from_atoms
+from ...nodes import handlers as node_handlers
+from ...nodes.geometry import AssemblyInstance
 from ...nodes.material import PresetMaterial, append_material
 from ...nodes.nodes import STYLE_LITERALS, STYLE_NODE_MAPPING
 from ...utils import _UNSET, count_value_changes, temp_override_property
@@ -1566,3 +1568,33 @@ class Molecule(MolecularEntity):
 
             # return the 3D bounding box vertices of the selected AtomGroup
             return self._view_points(atom_group)
+
+
+def _on_add_assembly_instance(
+    node: bpy.types.GeometryNodeGroup, obj: bpy.types.Object | None
+) -> None:
+    """
+    Setup for an ``Assembly Instance`` node added from the asset library.
+
+    Builds (or reuses) the assembly-transforms data object for the entity whose
+    modifier tree received the node and assigns it to the node's Data Object
+    input, so dropping the node onto a structure with assembly data just works.
+    A no-op when a data object is already assigned or the entity has no
+    parseable assembly data.
+    """
+    from ...session import get_session
+
+    socket = node.inputs.get("Data Object")
+    if socket is None or socket.default_value is not None or obj is None:
+        return
+    entity = get_session().match(obj)
+    if not isinstance(entity, Molecule):
+        return
+    if entity.assemblies(as_array=True) is None:
+        return
+    socket.default_value = entity.create_data_object()
+
+
+node_handlers.register_on_add(
+    AssemblyInstance._name, node_setup=_on_add_assembly_instance
+)

--- a/molecularnodes/nodes/__init__.py
+++ b/molecularnodes/nodes/__init__.py
@@ -1,8 +1,18 @@
-from . import arrange, geometry, interface, material, node_management, nodes, shader
+from . import (
+    arrange,
+    geometry,
+    handlers,
+    interface,
+    material,
+    node_management,
+    nodes,
+    shader,
+)
 
 __all__ = [
     "nodes",
     "arrange",
+    "handlers",
     "material",
     "interface",
     "node_management",

--- a/molecularnodes/nodes/handlers.py
+++ b/molecularnodes/nodes/handlers.py
@@ -4,19 +4,21 @@ Run custom setup when MolecularNodes node group assets are added to a tree.
 Since the node groups are shipped as regular assets in an asset library, no
 MolecularNodes code runs when a user drags one into a node tree. The
 ``blend_import_post`` handler fires for every link/append operation — including
-asset drag-and-drop, and re-drops that reuse an already-appended group — which
-gives us a hook to restore the conveniences the old custom add operator
-provided (assigning a default material) and to add new ones (building assembly
-data for the entity the node was dropped onto).
+asset drag-and-drop and Add-menu asset adds, whether the asset library's import
+method appends, links or packs, and for re-adds that reuse an already imported
+group — which gives us a hook to restore the conveniences the old custom add
+operator provided (assigning a default material) and to add new ones (building
+assembly data for the entity the node was dropped onto).
 
-Setup runs in two phases, because the handler fires while the drop operator is
-still appending the datablock, before the node instance exists in the tree:
+Setup runs in two phases, because the handler fires while the add operator is
+still importing the datablock, before the node instance exists in the tree:
 
-- ``tree_setup`` runs immediately on the imported ``NodeTree`` datablock. Any
-  interface defaults set here are inherited by the node instance the drop
-  operator creates a moment later.
+- ``tree_setup`` runs immediately on the imported ``NodeTree`` datablock, and
+  only when the tree was appended — linked (and packed) trees are read-only.
 - ``node_setup`` runs on each new node instance via a one-shot timer scheduled
   by the handler, which fires right after the operator has created the node.
+  Node instances are local even when their node group is linked, so their
+  input socket values and custom properties are always writable.
 
 Callbacks must be idempotent — they may run more than once for the same
 datablock and are also invoked on nodes created programmatically, so they
@@ -26,6 +28,7 @@ entity, ...).
 
 import logging
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -36,7 +39,7 @@ from ..assets import MN_DATA_FILE
 logger = logging.getLogger(__name__)
 
 # stamped onto a node instance once its node_setup has been attempted, so a
-# later drop of the same asset doesn't re-run setup on pre-existing nodes
+# later add of the same asset doesn't re-run setup on pre-existing nodes
 _MARKER = "mn_on_add_done"
 _DUPLICATE_SUFFIX = re.compile(r"\.\d{3}$")
 
@@ -53,12 +56,39 @@ class AssetOnAdd:
 
 _registry: dict[str, AssetOnAdd] = {}
 _predicates: list[tuple[Callable[[str], bool], AssetOnAdd]] = []
-# (imported tree name, drop-target tree name, context object name) awaiting
-# node_setup once the drop operator has created the node instance
+# (imported group name, drop-target tree name, context object name) awaiting
+# node_setup once the add operator has created the node instance
 _pending: list[tuple[str, str | None, str | None]] = []
-# guards against re-entering the handler when a callback itself appends data
-# (e.g. materials) from another .blend file
-_in_setup = False
+
+# guards against re-entering the handler when a setup callback itself appends
+# data (e.g. materials) from another .blend file; attached to
+# bpy.types.WindowManager in ui.addon so the flag lives as a documented,
+# runtime-only Blender property rather than in module state
+importing_assets_property = bpy.props.BoolProperty(
+    name="MN Importing Assets",
+    description=(
+        "True while MolecularNodes' own on-add setup is importing data from a "
+        ".blend file (e.g. appending materials), so that its blend_import_post "
+        "handler ignores imports it caused itself. Runtime-only, never saved"
+    ),
+    default=False,
+    options={"HIDDEN", "SKIP_SAVE"},
+)
+
+
+def _in_setup() -> bool:
+    return bpy.context.window_manager.mn_importing_assets
+
+
+@contextmanager
+def _own_imports_flagged():
+    """Flag imports we cause ourselves so the handler ignores them."""
+    wm = bpy.context.window_manager
+    wm.mn_importing_assets = True
+    try:
+        yield
+    finally:
+        wm.mn_importing_assets = False
 
 
 def register_on_add(
@@ -77,8 +107,9 @@ def register_on_add(
         Either the exact name of the asset's node group, or a predicate called
         with the (duplicate-suffix stripped) name of each imported group.
     tree_setup : Callable, optional
-        Called with the imported ``NodeTree`` datablock during the import, before
-        the dropped node instance exists.
+        Called with the imported ``NodeTree`` datablock during the import,
+        before the dropped node instance exists. Only runs for appended trees,
+        as linked ones are read-only.
     node_setup : Callable, optional
         Called with each newly added node instance and the object whose modifier
         tree it was added to (or ``None`` when that can't be determined).
@@ -121,10 +152,10 @@ def node_asset_import_post(ctx: bpy.types.BlendImportContext) -> None:
     Dispatch registered setup for MN node group assets after they are imported.
 
     Registered on ``bpy.app.handlers.blend_import_post``, which fires for asset
-    drag-and-drop as well as any other link/append, including drops that reuse
-    an already-appended group.
+    drag-and-drop as well as any other link/append/pack, including adds that
+    reuse an already imported group.
     """
-    if _in_setup:
+    if _in_setup():
         return
     schedule = False
     for item in ctx.import_items:
@@ -132,15 +163,16 @@ def node_asset_import_post(ctx: bpy.types.BlendImportContext) -> None:
         if item.id_type != "NODETREE" or item.import_info:
             continue
         tree = item.id
-        # linked (rather than appended) data is read-only, so leave it alone
-        if tree is None or tree.library is not None:
+        if tree is None:
             continue
         if not _is_mn_source(item):
             continue
         entry = _lookup(item.name)
         if entry is None:
             continue
-        if entry.tree_setup is not None:
+        # linked (rather than appended) trees are read-only, so only run
+        # datablock-level setup on appended copies
+        if entry.tree_setup is not None and tree.library is None:
             _run_tree_setup(entry.tree_setup, tree)
         if entry.node_setup is not None:
             # the node instance doesn't exist yet — capture where the drop is
@@ -150,7 +182,7 @@ def node_asset_import_post(ctx: bpy.types.BlendImportContext) -> None:
             obj = getattr(bpy.context, "object", None)
             _pending.append(
                 (
-                    tree.name,
+                    _DUPLICATE_SUFFIX.sub("", tree.name),
                     target.name if target is not None else None,
                     obj.name if obj is not None else None,
                 )
@@ -164,14 +196,11 @@ def _run_tree_setup(
     setup: Callable[[bpy.types.GeometryNodeTree], None],
     tree: bpy.types.GeometryNodeTree,
 ) -> None:
-    global _in_setup
-    _in_setup = True
     try:
-        setup(tree)
+        with _own_imports_flagged():
+            setup(tree)
     except Exception:
         logger.exception(f"tree_setup failed for imported node group {tree.name!r}")
-    finally:
-        _in_setup = False
 
 
 def _object_using_tree(tree: bpy.types.NodeTree) -> bpy.types.Object | None:
@@ -186,11 +215,8 @@ def _object_using_tree(tree: bpy.types.NodeTree) -> bpy.types.Object | None:
 def _process_pending() -> None:
     """Run deferred node_setup callbacks on newly added node instances."""
     entries, _pending[:] = list(_pending), []
-    for tree_name, target_name, object_name in entries:
-        tree = bpy.data.node_groups.get(tree_name)
-        if tree is None:
-            continue
-        entry = _lookup(tree.name)
+    for group_name, target_name, object_name in entries:
+        entry = _lookup(group_name)
         if entry is None or entry.node_setup is None:
             continue
         if target_name is not None and target_name in bpy.data.node_groups:
@@ -206,7 +232,10 @@ def _process_pending() -> None:
             for node in host.nodes:
                 if (
                     node.bl_idname != "GeometryNodeGroup"
-                    or node.node_tree != tree
+                    or node.node_tree is None
+                    # match by name so appended, linked and packed copies of
+                    # the same asset group are all handled
+                    or _DUPLICATE_SUFFIX.sub("", node.node_tree.name) != group_name
                     or node.get(_MARKER)
                 ):
                     continue
@@ -214,7 +243,8 @@ def _process_pending() -> None:
                 # back to the object that was active when the asset was dropped
                 obj = _object_using_tree(host) or fallback_obj
                 try:
-                    entry.node_setup(node, obj)
+                    with _own_imports_flagged():
+                        entry.node_setup(node, obj)
                 except Exception:
                     logger.exception(
                         f"node_setup failed for node {node.name!r} in {host.name!r}"
@@ -230,31 +260,22 @@ def unregister_pending() -> None:
         bpy.app.timers.unregister(_process_pending)
 
 
-def _style_material_default(tree: bpy.types.GeometryNodeTree) -> None:
+def _style_node_material(
+    node: bpy.types.GeometryNodeGroup, obj: bpy.types.Object | None
+) -> None:
     """
-    Give a style's Material input the default MN material.
+    Give a newly added style node's Material input the default MN material.
 
-    Setting the default on the tree interface means every node instance created
-    from it — including the one about to be created by the asset drop — starts
-    with the material assigned, matching what the old custom add operator did.
+    Set on the node instance rather than the tree interface so it works for
+    linked and packed node groups too, matching what the old custom add
+    operator did.
     """
     from .material import add_all_materials
 
-    socket = next(
-        (
-            s
-            for s in tree.interface.items_tree
-            if s.item_type == "SOCKET"
-            and s.in_out == "INPUT"
-            and s.socket_type == "NodeSocketMaterial"
-        ),
-        None,
-    )
+    socket = next((s for s in node.inputs if s.bl_idname == "NodeSocketMaterial"), None)
     if socket is None or socket.default_value is not None:
         return
     socket.default_value = add_all_materials()["MN Default"]
 
 
-register_on_add(
-    lambda name: name.startswith("Style "), tree_setup=_style_material_default
-)
+register_on_add(lambda name: name.startswith("Style "), node_setup=_style_node_material)

--- a/molecularnodes/nodes/handlers.py
+++ b/molecularnodes/nodes/handlers.py
@@ -1,0 +1,260 @@
+"""
+Run custom setup when MolecularNodes node group assets are added to a tree.
+
+Since the node groups are shipped as regular assets in an asset library, no
+MolecularNodes code runs when a user drags one into a node tree. The
+``blend_import_post`` handler fires for every link/append operation — including
+asset drag-and-drop, and re-drops that reuse an already-appended group — which
+gives us a hook to restore the conveniences the old custom add operator
+provided (assigning a default material) and to add new ones (building assembly
+data for the entity the node was dropped onto).
+
+Setup runs in two phases, because the handler fires while the drop operator is
+still appending the datablock, before the node instance exists in the tree:
+
+- ``tree_setup`` runs immediately on the imported ``NodeTree`` datablock. Any
+  interface defaults set here are inherited by the node instance the drop
+  operator creates a moment later.
+- ``node_setup`` runs on each new node instance via a one-shot timer scheduled
+  by the handler, which fires right after the operator has created the node.
+
+Callbacks must be idempotent — they may run more than once for the same
+datablock and are also invoked on nodes created programmatically, so they
+should no-op when there is nothing to do (a value already set, no matching
+entity, ...).
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+import bpy
+from bpy.app.handlers import persistent
+from ..assets import MN_DATA_FILE
+
+logger = logging.getLogger(__name__)
+
+# stamped onto a node instance once its node_setup has been attempted, so a
+# later drop of the same asset doesn't re-run setup on pre-existing nodes
+_MARKER = "mn_on_add_done"
+_DUPLICATE_SUFFIX = re.compile(r"\.\d{3}$")
+
+
+@dataclass(frozen=True)
+class AssetOnAdd:
+    """Setup callbacks to run when a node group asset is added to a tree."""
+
+    tree_setup: Callable[[bpy.types.GeometryNodeTree], None] | None = None
+    node_setup: (
+        Callable[[bpy.types.GeometryNodeGroup, bpy.types.Object | None], None] | None
+    ) = None
+
+
+_registry: dict[str, AssetOnAdd] = {}
+_predicates: list[tuple[Callable[[str], bool], AssetOnAdd]] = []
+# (imported tree name, drop-target tree name, context object name) awaiting
+# node_setup once the drop operator has created the node instance
+_pending: list[tuple[str, str | None, str | None]] = []
+# guards against re-entering the handler when a callback itself appends data
+# (e.g. materials) from another .blend file
+_in_setup = False
+
+
+def register_on_add(
+    match: str | Callable[[str], bool],
+    *,
+    tree_setup: Callable[[bpy.types.GeometryNodeTree], None] | None = None,
+    node_setup: Callable[[bpy.types.GeometryNodeGroup, bpy.types.Object | None], None]
+    | None = None,
+) -> None:
+    """
+    Register setup callbacks for a node group asset.
+
+    Parameters
+    ----------
+    match : str | Callable[[str], bool]
+        Either the exact name of the asset's node group, or a predicate called
+        with the (duplicate-suffix stripped) name of each imported group.
+    tree_setup : Callable, optional
+        Called with the imported ``NodeTree`` datablock during the import, before
+        the dropped node instance exists.
+    node_setup : Callable, optional
+        Called with each newly added node instance and the object whose modifier
+        tree it was added to (or ``None`` when that can't be determined).
+    """
+    entry = AssetOnAdd(tree_setup=tree_setup, node_setup=node_setup)
+    if callable(match):
+        _predicates.append((match, entry))
+    else:
+        _registry[match] = entry
+
+
+def _lookup(name: str) -> AssetOnAdd | None:
+    name = _DUPLICATE_SUFFIX.sub("", name)
+    entry = _registry.get(name)
+    if entry is not None:
+        return entry
+    for predicate, entry in _predicates:
+        if predicate(name):
+            return entry
+    return None
+
+
+def _is_mn_source(item) -> bool:
+    """Whether an import item came from the MolecularNodes asset data file."""
+    library = item.source_library
+    if library is None:
+        # source not recorded (e.g. append without keeping the library);
+        # fall back to matching on name alone
+        return True
+    try:
+        source = Path(bpy.path.abspath(library.filepath)).resolve()
+    except (OSError, ValueError):
+        return False
+    return source == Path(MN_DATA_FILE).resolve()
+
+
+@persistent
+def node_asset_import_post(ctx: bpy.types.BlendImportContext) -> None:
+    """
+    Dispatch registered setup for MN node group assets after they are imported.
+
+    Registered on ``bpy.app.handlers.blend_import_post``, which fires for asset
+    drag-and-drop as well as any other link/append, including drops that reuse
+    an already-appended group.
+    """
+    if _in_setup:
+        return
+    schedule = False
+    for item in ctx.import_items:
+        # only directly requested node trees, not their dependencies
+        if item.id_type != "NODETREE" or item.import_info:
+            continue
+        tree = item.id
+        # linked (rather than appended) data is read-only, so leave it alone
+        if tree is None or tree.library is not None:
+            continue
+        if not _is_mn_source(item):
+            continue
+        entry = _lookup(item.name)
+        if entry is None:
+            continue
+        if entry.tree_setup is not None:
+            _run_tree_setup(entry.tree_setup, tree)
+        if entry.node_setup is not None:
+            # the node instance doesn't exist yet — capture where the drop is
+            # happening while the operator context is available, and defer
+            space = getattr(bpy.context, "space_data", None)
+            target = getattr(space, "edit_tree", None)
+            obj = getattr(bpy.context, "object", None)
+            _pending.append(
+                (
+                    tree.name,
+                    target.name if target is not None else None,
+                    obj.name if obj is not None else None,
+                )
+            )
+            schedule = True
+    if schedule and not bpy.app.timers.is_registered(_process_pending):
+        bpy.app.timers.register(_process_pending, first_interval=0.0)
+
+
+def _run_tree_setup(
+    setup: Callable[[bpy.types.GeometryNodeTree], None],
+    tree: bpy.types.GeometryNodeTree,
+) -> None:
+    global _in_setup
+    _in_setup = True
+    try:
+        setup(tree)
+    except Exception:
+        logger.exception(f"tree_setup failed for imported node group {tree.name!r}")
+    finally:
+        _in_setup = False
+
+
+def _object_using_tree(tree: bpy.types.NodeTree) -> bpy.types.Object | None:
+    """Find the object using this tree as a geometry nodes modifier, if any."""
+    for obj in bpy.data.objects:
+        for mod in obj.modifiers:
+            if mod.type == "NODES" and mod.node_group == tree:
+                return obj
+    return None
+
+
+def _process_pending() -> None:
+    """Run deferred node_setup callbacks on newly added node instances."""
+    entries, _pending[:] = list(_pending), []
+    for tree_name, target_name, object_name in entries:
+        tree = bpy.data.node_groups.get(tree_name)
+        if tree is None:
+            continue
+        entry = _lookup(tree.name)
+        if entry is None or entry.node_setup is None:
+            continue
+        if target_name is not None and target_name in bpy.data.node_groups:
+            hosts = [bpy.data.node_groups[target_name]]
+        else:
+            hosts = list(bpy.data.node_groups)
+        fallback_obj = (
+            bpy.data.objects.get(object_name) if object_name is not None else None
+        )
+        for host in hosts:
+            if not isinstance(host, bpy.types.GeometryNodeTree):
+                continue
+            for node in host.nodes:
+                if (
+                    node.bl_idname != "GeometryNodeGroup"
+                    or node.node_tree != tree
+                    or node.get(_MARKER)
+                ):
+                    continue
+                # a node in a nested group has no modifier of its own, so fall
+                # back to the object that was active when the asset was dropped
+                obj = _object_using_tree(host) or fallback_obj
+                try:
+                    entry.node_setup(node, obj)
+                except Exception:
+                    logger.exception(
+                        f"node_setup failed for node {node.name!r} in {host.name!r}"
+                    )
+                node[_MARKER] = True
+    return None
+
+
+def unregister_pending() -> None:
+    """Drop queued work and the timer; called when the add-on is unregistered."""
+    _pending.clear()
+    if bpy.app.timers.is_registered(_process_pending):
+        bpy.app.timers.unregister(_process_pending)
+
+
+def _style_material_default(tree: bpy.types.GeometryNodeTree) -> None:
+    """
+    Give a style's Material input the default MN material.
+
+    Setting the default on the tree interface means every node instance created
+    from it — including the one about to be created by the asset drop — starts
+    with the material assigned, matching what the old custom add operator did.
+    """
+    from .material import add_all_materials
+
+    socket = next(
+        (
+            s
+            for s in tree.interface.items_tree
+            if s.item_type == "SOCKET"
+            and s.in_out == "INPUT"
+            and s.socket_type == "NodeSocketMaterial"
+        ),
+        None,
+    )
+    if socket is None or socket.default_value is not None:
+        return
+    socket.default_value = add_all_materials()["MN Default"]
+
+
+register_on_add(
+    lambda name: name.startswith("Style "), tree_setup=_style_material_default
+)

--- a/molecularnodes/nodes/handlers.py
+++ b/molecularnodes/nodes/handlers.py
@@ -10,15 +10,12 @@ group — which gives us a hook to restore the conveniences the old custom add
 operator provided (assigning a default material) and to add new ones (building
 assembly data for the entity the node was dropped onto).
 
-Setup runs in two phases, because the handler fires while the add operator is
-still importing the datablock, before the node instance exists in the tree:
-
-- ``tree_setup`` runs immediately on the imported ``NodeTree`` datablock, and
-  only when the tree was appended — linked (and packed) trees are read-only.
-- ``node_setup`` runs on each new node instance via a one-shot timer scheduled
-  by the handler, which fires right after the operator has created the node.
-  Node instances are local even when their node group is linked, so their
-  input socket values and custom properties are always writable.
+The handler fires while the add operator is still importing the datablock,
+before the node instance exists in the tree, so it only records what was
+imported and where. The setup itself runs on each new node instance via a
+one-shot timer, which fires right after the operator has created the node.
+Node instances are local even when their node group is linked, so their input
+socket values and custom properties are always writable.
 
 Callbacks must be idempotent — they may run more than once for the same
 datablock and are also invoked on nodes created programmatically, so they
@@ -28,8 +25,6 @@ entity, ...).
 
 import logging
 import re
-from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 import bpy
@@ -38,97 +33,43 @@ from ..assets import MN_DATA_FILE
 
 logger = logging.getLogger(__name__)
 
-# stamped onto a node instance once its node_setup has been attempted, so a
-# later add of the same asset doesn't re-run setup on pre-existing nodes
+NodeSetup = Callable[[bpy.types.GeometryNodeGroup, bpy.types.Object | None], None]
+
+# stamped onto a node instance once its setup has been attempted, so a later
+# add of the same asset doesn't re-run setup on pre-existing nodes
 _MARKER = "mn_on_add_done"
 _DUPLICATE_SUFFIX = re.compile(r"\.\d{3}$")
 
-
-@dataclass(frozen=True)
-class AssetOnAdd:
-    """Setup callbacks to run when a node group asset is added to a tree."""
-
-    tree_setup: Callable[[bpy.types.GeometryNodeTree], None] | None = None
-    node_setup: (
-        Callable[[bpy.types.GeometryNodeGroup, bpy.types.Object | None], None] | None
-    ) = None
-
-
-_registry: dict[str, AssetOnAdd] = {}
-_predicates: list[tuple[Callable[[str], bool], AssetOnAdd]] = []
+_registry: list[tuple[Callable[[str], bool], NodeSetup]] = []
 # (imported group name, drop-target tree name, context object name) awaiting
-# node_setup once the add operator has created the node instance
+# setup once the add operator has created the node instance
 _pending: list[tuple[str, str | None, str | None]] = []
 
-# guards against re-entering the handler when a setup callback itself appends
-# data (e.g. materials) from another .blend file; attached to
-# bpy.types.WindowManager in ui.addon so the flag lives as a documented,
-# runtime-only Blender property rather than in module state
-importing_assets_property = bpy.props.BoolProperty(
-    name="MN Importing Assets",
-    description=(
-        "True while MolecularNodes' own on-add setup is importing data from a "
-        ".blend file (e.g. appending materials), so that its blend_import_post "
-        "handler ignores imports it caused itself. Runtime-only, never saved"
-    ),
-    default=False,
-    options={"HIDDEN", "SKIP_SAVE"},
-)
 
-
-def _in_setup() -> bool:
-    return bpy.context.window_manager.mn_importing_assets
-
-
-@contextmanager
-def _own_imports_flagged():
-    """Flag imports we cause ourselves so the handler ignores them."""
-    wm = bpy.context.window_manager
-    wm.mn_importing_assets = True
-    try:
-        yield
-    finally:
-        wm.mn_importing_assets = False
-
-
-def register_on_add(
-    match: str | Callable[[str], bool],
-    *,
-    tree_setup: Callable[[bpy.types.GeometryNodeTree], None] | None = None,
-    node_setup: Callable[[bpy.types.GeometryNodeGroup, bpy.types.Object | None], None]
-    | None = None,
-) -> None:
+def register_on_add(match: str | Callable[[str], bool], setup: NodeSetup) -> None:
     """
-    Register setup callbacks for a node group asset.
+    Register a setup callback for a node group asset.
 
     Parameters
     ----------
     match : str | Callable[[str], bool]
         Either the exact name of the asset's node group, or a predicate called
         with the (duplicate-suffix stripped) name of each imported group.
-    tree_setup : Callable, optional
-        Called with the imported ``NodeTree`` datablock during the import,
-        before the dropped node instance exists. Only runs for appended trees,
-        as linked ones are read-only.
-    node_setup : Callable, optional
+    setup : Callable
         Called with each newly added node instance and the object whose modifier
         tree it was added to (or ``None`` when that can't be determined).
     """
-    entry = AssetOnAdd(tree_setup=tree_setup, node_setup=node_setup)
-    if callable(match):
-        _predicates.append((match, entry))
-    else:
-        _registry[match] = entry
+    if not callable(match):
+        name = match
+        match = lambda n: n == name  # noqa: E731
+    _registry.append((match, setup))
 
 
-def _lookup(name: str) -> AssetOnAdd | None:
+def _lookup(name: str) -> NodeSetup | None:
     name = _DUPLICATE_SUFFIX.sub("", name)
-    entry = _registry.get(name)
-    if entry is not None:
-        return entry
-    for predicate, entry in _predicates:
+    for predicate, setup in _registry:
         if predicate(name):
-            return entry
+            return setup
     return None
 
 
@@ -149,58 +90,37 @@ def _is_mn_source(item) -> bool:
 @persistent
 def node_asset_import_post(ctx: bpy.types.BlendImportContext) -> None:
     """
-    Dispatch registered setup for MN node group assets after they are imported.
+    Queue registered setup for MN node group assets after they are imported.
 
     Registered on ``bpy.app.handlers.blend_import_post``, which fires for asset
     drag-and-drop as well as any other link/append/pack, including adds that
     reuse an already imported group.
     """
-    if _in_setup():
-        return
     schedule = False
     for item in ctx.import_items:
         # only directly requested node trees, not their dependencies
         if item.id_type != "NODETREE" or item.import_info:
             continue
         tree = item.id
-        if tree is None:
+        if tree is None or not _is_mn_source(item):
             continue
-        if not _is_mn_source(item):
+        if _lookup(item.name) is None:
             continue
-        entry = _lookup(item.name)
-        if entry is None:
-            continue
-        # linked (rather than appended) trees are read-only, so only run
-        # datablock-level setup on appended copies
-        if entry.tree_setup is not None and tree.library is None:
-            _run_tree_setup(entry.tree_setup, tree)
-        if entry.node_setup is not None:
-            # the node instance doesn't exist yet — capture where the drop is
-            # happening while the operator context is available, and defer
-            space = getattr(bpy.context, "space_data", None)
-            target = getattr(space, "edit_tree", None)
-            obj = getattr(bpy.context, "object", None)
-            _pending.append(
-                (
-                    _DUPLICATE_SUFFIX.sub("", tree.name),
-                    target.name if target is not None else None,
-                    obj.name if obj is not None else None,
-                )
+        # the node instance doesn't exist yet — capture where the drop is
+        # happening while the operator context is available, and defer
+        space = getattr(bpy.context, "space_data", None)
+        target = getattr(space, "edit_tree", None)
+        obj = getattr(bpy.context, "object", None)
+        _pending.append(
+            (
+                _DUPLICATE_SUFFIX.sub("", tree.name),
+                target.name if target is not None else None,
+                obj.name if obj is not None else None,
             )
-            schedule = True
+        )
+        schedule = True
     if schedule and not bpy.app.timers.is_registered(_process_pending):
         bpy.app.timers.register(_process_pending, first_interval=0.0)
-
-
-def _run_tree_setup(
-    setup: Callable[[bpy.types.GeometryNodeTree], None],
-    tree: bpy.types.GeometryNodeTree,
-) -> None:
-    try:
-        with _own_imports_flagged():
-            setup(tree)
-    except Exception:
-        logger.exception(f"tree_setup failed for imported node group {tree.name!r}")
 
 
 def _object_using_tree(tree: bpy.types.NodeTree) -> bpy.types.Object | None:
@@ -213,11 +133,11 @@ def _object_using_tree(tree: bpy.types.NodeTree) -> bpy.types.Object | None:
 
 
 def _process_pending() -> None:
-    """Run deferred node_setup callbacks on newly added node instances."""
+    """Run deferred setup callbacks on newly added node instances."""
     entries, _pending[:] = list(_pending), []
     for group_name, target_name, object_name in entries:
-        entry = _lookup(group_name)
-        if entry is None or entry.node_setup is None:
+        setup = _lookup(group_name)
+        if setup is None:
             continue
         if target_name is not None and target_name in bpy.data.node_groups:
             hosts = [bpy.data.node_groups[target_name]]
@@ -243,11 +163,10 @@ def _process_pending() -> None:
                 # back to the object that was active when the asset was dropped
                 obj = _object_using_tree(host) or fallback_obj
                 try:
-                    with _own_imports_flagged():
-                        entry.node_setup(node, obj)
+                    setup(node, obj)
                 except Exception:
                     logger.exception(
-                        f"node_setup failed for node {node.name!r} in {host.name!r}"
+                        f"setup failed for node {node.name!r} in {host.name!r}"
                     )
                 node[_MARKER] = True
     return None
@@ -278,4 +197,4 @@ def _style_node_material(
     socket.default_value = add_all_materials()["MN Default"]
 
 
-register_on_add(lambda name: name.startswith("Style "), node_setup=_style_node_material)
+register_on_add(lambda name: name.startswith("Style "), _style_node_material)

--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -13,6 +13,7 @@
 
 import bpy
 from bpy.app.handlers import (
+    blend_import_post,
     frame_change_pre,
     load_post,
     load_pre,
@@ -23,6 +24,7 @@ from bpy.app.handlers import (
 from bpy.props import CollectionProperty, PointerProperty
 from .. import assets, session
 from ..handlers import render_pre_handler, update_entities
+from ..nodes import handlers as node_handlers
 from ..templates import register_templates_menu, unregister_templates_menu
 from . import ops, panel, pref, props
 
@@ -72,6 +74,7 @@ def register():
     load_pre.append(session._remove_draw_handlers)
     frame_change_pre.append(update_entities)
     render_pre.append(render_pre_handler)
+    blend_import_post.append(node_handlers.node_asset_import_post)
 
     if _mn_session is not None:
         bpy.types.Scene.MNSession = _mn_session
@@ -119,6 +122,8 @@ def unregister():
     load_pre.remove(session._remove_draw_handlers)
     frame_change_pre.remove(update_entities)
     render_pre.remove(render_pre_handler)
+    blend_import_post.remove(node_handlers.node_asset_import_post)
+    node_handlers.unregister_pending()
 
     session._remove_draw_handlers(filepath=None)
 

--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -86,9 +86,6 @@ def register():
     bpy.types.Object.mn_trajectory_selections = CollectionProperty(  # type: ignore
         type=props.TrajectorySelectionItem
     )
-    bpy.types.WindowManager.mn_importing_assets = (  # type: ignore
-        node_handlers.importing_assets_property
-    )
     # bpy.types.Object.mn_annotations is dynamically created and updated based
     # on different annotation types. It has to be a top level property to avoid
     # AttributeError: '_PropertyDeferred' object has no attribute '...'
@@ -135,7 +132,6 @@ def unregister():
     del bpy.types.Scene.mn  # type: ignore
     del bpy.types.Object.mn  # type: ignore
     del bpy.types.Object.mn_trajectory_selections  # type: ignore
-    del bpy.types.WindowManager.mn_importing_assets  # type: ignore
     _mn_annotations = bpy.types.Object.mn_annotations
     del bpy.types.Object.mn_annotations  # type: ignore
     unregister_templates_menu()

--- a/molecularnodes/ui/addon.py
+++ b/molecularnodes/ui/addon.py
@@ -86,6 +86,9 @@ def register():
     bpy.types.Object.mn_trajectory_selections = CollectionProperty(  # type: ignore
         type=props.TrajectorySelectionItem
     )
+    bpy.types.WindowManager.mn_importing_assets = (  # type: ignore
+        node_handlers.importing_assets_property
+    )
     # bpy.types.Object.mn_annotations is dynamically created and updated based
     # on different annotation types. It has to be a top level property to avoid
     # AttributeError: '_PropertyDeferred' object has no attribute '...'
@@ -132,6 +135,7 @@ def unregister():
     del bpy.types.Scene.mn  # type: ignore
     del bpy.types.Object.mn  # type: ignore
     del bpy.types.Object.mn_trajectory_selections  # type: ignore
+    del bpy.types.WindowManager.mn_importing_assets  # type: ignore
     _mn_annotations = bpy.types.Object.mn_annotations
     del bpy.types.Object.mn_annotations  # type: ignore
     unregister_templates_menu()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "molecularnodes"
-version = "520.0.1"
+version = "520.1.0"
 description = "Toolbox for molecular animations with Blender and Geometry Nodes."
 readme = "README.md"
 dependencies = [

--- a/tests/test_node_on_add.py
+++ b/tests/test_node_on_add.py
@@ -1,0 +1,108 @@
+"""
+Tests for the on-add setup that runs when MN node group assets are imported.
+
+Asset drag-and-drop can't be simulated headlessly, but the drop operator's
+steps can: it appends the node group (which fires ``blend_import_post``) and
+then creates the node instance in the edited tree. The deferred node setup
+normally runs via a timer, which doesn't fire in background mode, so tests
+invoke ``_process_pending`` directly.
+"""
+
+import bpy
+import molecularnodes as mn
+from molecularnodes.assets import MN_DATA_FILE
+from molecularnodes.nodes import handlers as node_handlers
+from .constants import data_dir
+
+
+def _append_asset(name: str, reuse: bool = False) -> bpy.types.GeometryNodeTree:
+    "Append a node group the way an asset drop does, firing blend_import_post."
+    bpy.ops.wm.append(
+        filepath=f"{MN_DATA_FILE}/NodeTree/{name}",
+        directory=f"{MN_DATA_FILE}/NodeTree/",
+        filename=name,
+        do_reuse_local_id=reuse,
+    )
+    return bpy.data.node_groups[name]
+
+
+def _material_socket(tree):
+    return next(
+        (
+            s
+            for s in tree.interface.items_tree
+            if s.item_type == "SOCKET"
+            and s.in_out == "INPUT"
+            and s.socket_type == "NodeSocketMaterial"
+        ),
+        None,
+    )
+
+
+def test_handler_registered():
+    assert node_handlers.node_asset_import_post in bpy.app.handlers.blend_import_post
+
+
+def test_style_import_sets_material_default():
+    tree = _append_asset("Style Spheres")
+    socket = _material_socket(tree)
+    assert socket.default_value is not None
+    assert socket.default_value.name == "MN Default"
+
+    # a node instance created from the tree inherits the default, which is
+    # what the drop operator does right after the append
+    host = bpy.data.node_groups.new("host", "GeometryNodeTree")
+    node = host.nodes.new("GeometryNodeGroup")
+    node.node_tree = tree
+    assert node.inputs["Material"].default_value.name == "MN Default"
+
+
+def test_style_import_keeps_existing_material_default():
+    mat = bpy.data.materials.new("Existing")
+    tree = _append_asset("Style Ribbon")
+    socket = _material_socket(tree)
+    socket.default_value = mat
+    # a re-drop that reuses the local group must not clobber the user's choice
+    _append_asset("Style Ribbon", reuse=True)
+    assert socket.default_value == mat
+
+
+def test_assembly_instance_drop_builds_data_object():
+    node_handlers._pending.clear()
+    mol = mn.Molecule.load(data_dir / "1cd3.cif").add_style("cartoon")
+    assert mol.assemblies(as_array=True) is not None
+
+    tree = _append_asset("Assembly Instance")
+    assert node_handlers._pending
+
+    # the drop operator creates the node after the append
+    node = mol.modifier_node_tree.nodes.new("GeometryNodeGroup")
+    node.node_tree = tree
+    assert node.inputs["Data Object"].default_value is None
+
+    node_handlers._process_pending()
+    data_obj = node.inputs["Data Object"].default_value
+    assert data_obj is not None
+    assert data_obj.name == f".data_{mol.name}_assemblies"
+    assert node.get(node_handlers._MARKER)
+
+    # a second drop reuses the same data object and doesn't touch the first node
+    _append_asset("Assembly Instance", reuse=True)
+    second = mol.modifier_node_tree.nodes.new("GeometryNodeGroup")
+    second.node_tree = tree
+    node_handlers._process_pending()
+    assert second.inputs["Data Object"].default_value == data_obj
+    assert node.inputs["Data Object"].default_value == data_obj
+
+
+def test_assembly_instance_without_entity_is_untouched():
+    node_handlers._pending.clear()
+    # dropped into a tree that belongs to no MN entity: setup must no-op
+    tree = _append_asset("Assembly Instance")
+    host = bpy.data.node_groups.new("host", "GeometryNodeTree")
+    node = host.nodes.new("GeometryNodeGroup")
+    node.node_tree = tree
+
+    node_handlers._process_pending()
+    assert node.inputs["Data Object"].default_value is None
+    assert not node_handlers._pending

--- a/tests/test_node_on_add.py
+++ b/tests/test_node_on_add.py
@@ -1,83 +1,93 @@
 """
 Tests for the on-add setup that runs when MN node group assets are imported.
 
-Asset drag-and-drop can't be simulated headlessly, but the drop operator's
-steps can: it appends the node group (which fires ``blend_import_post``) and
-then creates the node instance in the edited tree. The deferred node setup
-normally runs via a timer, which doesn't fire in background mode, so tests
-invoke ``_process_pending`` directly.
+Asset drag-and-drop can't be simulated headlessly, but the add operator's
+steps can: it imports the node group (which fires ``blend_import_post``) and
+then creates the node instance in the edited tree. Depending on the asset
+library's import method the group is appended or linked (the default "Pack"
+method is a link plus packing), so both paths are covered. The deferred node
+setup normally runs via a timer, which doesn't fire in background mode, so
+tests invoke ``_process_pending`` directly.
 """
 
 import bpy
+import pytest
 import molecularnodes as mn
 from molecularnodes.assets import MN_DATA_FILE
 from molecularnodes.nodes import handlers as node_handlers
 from .constants import data_dir
 
 
-def _append_asset(name: str, reuse: bool = False) -> bpy.types.GeometryNodeTree:
-    "Append a node group the way an asset drop does, firing blend_import_post."
-    bpy.ops.wm.append(
+def _import_asset(
+    name: str, link: bool = False, reuse: bool = False
+) -> bpy.types.GeometryNodeTree:
+    "Import a node group the way an asset add does, firing blend_import_post."
+    op = bpy.ops.wm.link if link else bpy.ops.wm.append
+    kwargs = {} if link else {"do_reuse_local_id": reuse}
+    op(
         filepath=f"{MN_DATA_FILE}/NodeTree/{name}",
         directory=f"{MN_DATA_FILE}/NodeTree/",
         filename=name,
-        do_reuse_local_id=reuse,
+        **kwargs,
     )
-    return bpy.data.node_groups[name]
-
-
-def _material_socket(tree):
     return next(
-        (
-            s
-            for s in tree.interface.items_tree
-            if s.item_type == "SOCKET"
-            and s.in_out == "INPUT"
-            and s.socket_type == "NodeSocketMaterial"
-        ),
-        None,
+        ng
+        for ng in bpy.data.node_groups
+        if ng.name == name and (ng.library is not None) == link
     )
+
+
+def _new_group_node(tree, host=None):
+    if host is None:
+        host = bpy.data.node_groups.new("host", "GeometryNodeTree")
+    node = host.nodes.new("GeometryNodeGroup")
+    node.node_tree = tree
+    return node
 
 
 def test_handler_registered():
     assert node_handlers.node_asset_import_post in bpy.app.handlers.blend_import_post
 
 
-def test_style_import_sets_material_default():
-    tree = _append_asset("Style Spheres")
-    socket = _material_socket(tree)
-    assert socket.default_value is not None
-    assert socket.default_value.name == "MN Default"
+@pytest.mark.parametrize("link", [False, True], ids=["appended", "linked"])
+def test_style_import_sets_node_material(link):
+    node_handlers._pending.clear()
+    tree = _import_asset("Style Spheres", link=link)
+    assert node_handlers._pending
 
-    # a node instance created from the tree inherits the default, which is
-    # what the drop operator does right after the append
-    host = bpy.data.node_groups.new("host", "GeometryNodeTree")
-    node = host.nodes.new("GeometryNodeGroup")
-    node.node_tree = tree
+    node = _new_group_node(tree)
+    assert node.inputs["Material"].default_value is None
+
+    node_handlers._process_pending()
+    assert node.inputs["Material"].default_value is not None
     assert node.inputs["Material"].default_value.name == "MN Default"
+    assert node.get(node_handlers._MARKER)
 
 
-def test_style_import_keeps_existing_material_default():
+def test_style_import_keeps_existing_material():
+    node_handlers._pending.clear()
     mat = bpy.data.materials.new("Existing")
-    tree = _append_asset("Style Ribbon")
-    socket = _material_socket(tree)
-    socket.default_value = mat
-    # a re-drop that reuses the local group must not clobber the user's choice
-    _append_asset("Style Ribbon", reuse=True)
-    assert socket.default_value == mat
+    tree = _import_asset("Style Ribbon")
+    node = _new_group_node(tree)
+    node.inputs["Material"].default_value = mat
+
+    # a re-add that reuses the group must not clobber the already-set value
+    _import_asset("Style Ribbon", reuse=True)
+    node_handlers._process_pending()
+    assert node.inputs["Material"].default_value == mat
 
 
-def test_assembly_instance_drop_builds_data_object():
+@pytest.mark.parametrize("link", [False, True], ids=["appended", "linked"])
+def test_assembly_instance_add_builds_data_object(link):
     node_handlers._pending.clear()
     mol = mn.Molecule.load(data_dir / "1cd3.cif").add_style("cartoon")
     assert mol.assemblies(as_array=True) is not None
 
-    tree = _append_asset("Assembly Instance")
+    tree = _import_asset("Assembly Instance", link=link)
     assert node_handlers._pending
 
-    # the drop operator creates the node after the append
-    node = mol.modifier_node_tree.nodes.new("GeometryNodeGroup")
-    node.node_tree = tree
+    # the add operator creates the node after the import
+    node = _new_group_node(tree, host=mol.modifier_node_tree)
     assert node.inputs["Data Object"].default_value is None
 
     node_handlers._process_pending()
@@ -86,10 +96,9 @@ def test_assembly_instance_drop_builds_data_object():
     assert data_obj.name == f".data_{mol.name}_assemblies"
     assert node.get(node_handlers._MARKER)
 
-    # a second drop reuses the same data object and doesn't touch the first node
-    _append_asset("Assembly Instance", reuse=True)
-    second = mol.modifier_node_tree.nodes.new("GeometryNodeGroup")
-    second.node_tree = tree
+    # a second add reuses the same data object and doesn't touch the first node
+    _import_asset("Assembly Instance", link=link, reuse=True)
+    second = _new_group_node(tree, host=mol.modifier_node_tree)
     node_handlers._process_pending()
     assert second.inputs["Data Object"].default_value == data_obj
     assert node.inputs["Data Object"].default_value == data_obj
@@ -97,11 +106,9 @@ def test_assembly_instance_drop_builds_data_object():
 
 def test_assembly_instance_without_entity_is_untouched():
     node_handlers._pending.clear()
-    # dropped into a tree that belongs to no MN entity: setup must no-op
-    tree = _append_asset("Assembly Instance")
-    host = bpy.data.node_groups.new("host", "GeometryNodeTree")
-    node = host.nodes.new("GeometryNodeGroup")
-    node.node_tree = tree
+    # added to a tree that belongs to no MN entity: setup must no-op
+    tree = _import_asset("Assembly Instance")
+    node = _new_group_node(tree)
 
     node_handlers._process_pending()
     assert node.inputs["Data Object"].default_value is None

--- a/uv.lock
+++ b/uv.lock
@@ -557,7 +557,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -1344,7 +1346,7 @@ wheels = [
 
 [[package]]
 name = "molecularnodes"
-version = "520.0.0"
+version = "520.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
Adds handlers for appending / linking nodes. This way when a user adds a "Style Ribbon" or similar style node, then the default material is set instead of it being blank. This matches previous and more convienient behaviour.

Generalises the approach so we also have the functionality for the "Assembly Instance" so we can build the required data object for creating biological assemblies as well.

Fixes #1187, originally flagged in #1186