### PR TITLE
FIX: Updated nodebpy codegen typing

### DIFF
--- a/molecularnodes/nodes/geometry/_shared/accumulate_domain_transform.py
+++ b/molecularnodes/nodes/geometry/_shared/accumulate_domain_transform.py
@@ -1,8 +1,10 @@
-# Node group '.Accumulate Domain Transform' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Accumulate Domain Transform" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -83,7 +85,7 @@ class AccumulateDomainTransform(CustomGeometryGroup):
             **{"Domain": domain, "Transform": transform, "Group ID": group_id}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         domain = tree.inputs.menu("Domain", optional_label=True, hide_value=True)
         transform = tree.inputs.matrix("Transform", hide_value=True)
         group_id = tree.inputs.integer("Group ID", 0, hide_value=True)

--- a/molecularnodes/nodes/geometry/_shared/animate_collection_pick.py
+++ b/molecularnodes/nodes/geometry/_shared/animate_collection_pick.py
@@ -1,8 +1,10 @@
-# Node group 'Animate Collection Pick' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Animate Collection Pick" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -87,7 +89,7 @@ class AnimateCollectionPick(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         collection = tree.inputs.collection("Collection", optional_label=True)
         realize_instances = tree.inputs.boolean("Realize Instances", True)
         item = tree.inputs.float("Item", 1.0, min_value=0.0, max_value=10_000.0)

--- a/molecularnodes/nodes/geometry/_shared/animate_fraction.py
+++ b/molecularnodes/nodes/geometry/_shared/animate_fraction.py
@@ -1,8 +1,10 @@
-# Node group 'Animate Fraction' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Animate Fraction" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     BooleanSocket,
     CustomGeometryGroup,
@@ -80,7 +82,7 @@ class AnimateFraction(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         interpolate = tree.inputs.boolean("Interpolate", False)
         smoother_step = tree.inputs.boolean("Smoother Step", False)
         float = tree.inputs.float("Float", 0.0)

--- a/molecularnodes/nodes/geometry/_shared/attribute_at_index.py
+++ b/molecularnodes/nodes/geometry/_shared/attribute_at_index.py
@@ -1,8 +1,10 @@
-# Node group 'Attribute at Index' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Attribute at Index" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -64,7 +66,7 @@ class AttributeAtIndex(CustomGeometryGroup):
     ):
         super().__init__(**{"Index": index, "Name": name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         name = tree.inputs.string("Name", "res_id")
         value = tree.outputs.integer("Value")

--- a/molecularnodes/nodes/geometry/_shared/backbone_position.py
+++ b/molecularnodes/nodes/geometry/_shared/backbone_position.py
@@ -1,8 +1,10 @@
-# Node group '.Backbone Position' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Backbone Position" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -70,7 +72,7 @@ class BackbonePosition(CustomGeometryGroup):
     ):
         super().__init__(**{"Method": method, "Menu": menu})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         menu = tree.inputs.menu(
             "Menu",

--- a/molecularnodes/nodes/geometry/_shared/ca_value_float.py
+++ b/molecularnodes/nodes/geometry/_shared/ca_value_float.py
@@ -1,8 +1,10 @@
-# Node group 'CA Value Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "CA Value Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, FloatSocket, SocketAccessor
 from nodebpy.types import InputFloat
@@ -53,7 +55,7 @@ class CAValueFloat(CustomGeometryGroup):
     ):
         super().__init__(**{"Value": value})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.float("Value", 0.0, hide_value=True)
         value_1 = tree.outputs.float("Value")
 

--- a/molecularnodes/nodes/geometry/_shared/ca_value_vector.py
+++ b/molecularnodes/nodes/geometry/_shared/ca_value_vector.py
@@ -1,8 +1,10 @@
-# Node group 'CA Value Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "CA Value Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, SocketAccessor, VectorSocket
 from nodebpy.types import InputVector
@@ -53,7 +55,7 @@ class CAValueVector(CustomGeometryGroup):
     ):
         super().__init__(**{"Vector": vector})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vector = tree.inputs.vector("Vector", (0.0, 0.0, 0.0), hide_value=True)
         vector_1 = tree.outputs.vector("Vector")
 

--- a/molecularnodes/nodes/geometry/_shared/check_end_face_corner.py
+++ b/molecularnodes/nodes/geometry/_shared/check_end_face_corner.py
@@ -1,8 +1,10 @@
-# Node group '.Check End Face Corner' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Check End Face Corner" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -57,7 +59,7 @@ class CheckEndFaceCorner(CustomGeometryGroup):
     ):
         super().__init__(**{"Captured Index": captured_index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         captured_index = tree.inputs.integer("Captured Index", 0)
         is_end_face_corner = tree.outputs.boolean("Is End Face Corner")
 

--- a/molecularnodes/nodes/geometry/_shared/cleanup.py
+++ b/molecularnodes/nodes/geometry/_shared/cleanup.py
@@ -1,8 +1,10 @@
-# Node group '.Cleanup' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Cleanup" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -88,7 +90,7 @@ class Cleanup(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         color_source = tree.inputs.geometry("Color Source")
         material = tree.inputs.material(

--- a/molecularnodes/nodes/geometry/_shared/curve_split_splines.py
+++ b/molecularnodes/nodes/geometry/_shared/curve_split_splines.py
@@ -1,8 +1,10 @@
-# Node group 'Curve Split Splines' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Curve Split Splines" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -177,7 +179,7 @@ class CurveSplitSplines(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         curve_normal = tree.inputs.menu("Curve Normal", optional_label=True)

--- a/molecularnodes/nodes/geometry/_shared/curve_to_mesh_with_uvmap.py
+++ b/molecularnodes/nodes/geometry/_shared/curve_to_mesh_with_uvmap.py
@@ -1,8 +1,10 @@
-# Node group 'Curve to Mesh with UVMap' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Curve to Mesh with UVMap" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -92,7 +94,7 @@ class CurveToMeshWithUVMap(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         u_component = tree.inputs.menu("U Component", optional_label=True)
         profile_resolution = tree.inputs.integer(

--- a/molecularnodes/nodes/geometry/_shared/domain_switch_matrix.py
+++ b/molecularnodes/nodes/geometry/_shared/domain_switch_matrix.py
@@ -1,8 +1,10 @@
-# Node group 'Domain Switch Matrix' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Domain Switch Matrix" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -113,7 +115,7 @@ class DomainSwitchMatrix(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         menu = tree.inputs.menu("Menu", optional_label=True)
         point = tree.inputs.matrix("Point")
         edge = tree.inputs.matrix("Edge")

--- a/molecularnodes/nodes/geometry/_shared/find_connected.py
+++ b/molecularnodes/nodes/geometry/_shared/find_connected.py
@@ -1,8 +1,10 @@
-# Node group 'Find Connected' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Find Connected" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -88,7 +90,7 @@ class FindConnected(CustomGeometryGroup):
             **{"Value": value, "Match": match, "Distance": distance, "Method": method}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.integer("Value", 0, hide_value=True)
         match = tree.inputs.integer("Match", 2)
         distance = tree.inputs.integer("Distance", 2, min_value=1, max_value=3)

--- a/molecularnodes/nodes/geometry/_shared/geometry_principal_components.py
+++ b/molecularnodes/nodes/geometry/_shared/geometry_principal_components.py
@@ -1,8 +1,10 @@
-# Node group 'Geometry Principal Components' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Geometry Principal Components" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -90,7 +92,7 @@ class GeometryPrincipalComponents(CustomGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Position": position})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry",
             description="Geometry to evaluate the given fields and store the resulting attributes on. All geometry types except volumes are supported",

--- a/molecularnodes/nodes/geometry/_shared/hydrogen_bonding_partner.py
+++ b/molecularnodes/nodes/geometry/_shared/hydrogen_bonding_partner.py
@@ -1,8 +1,10 @@
-# Node group 'Hydrogen Bonding Partner' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Hydrogen Bonding Partner" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, IntegerSocket, SocketAccessor
 from ..is_hydrogen import IsHydrogen
@@ -38,7 +40,7 @@ class HydrogenBondingPartner(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.outputs.integer("Index")
 
         edge_vertices = g.EdgeVertices()

--- a/molecularnodes/nodes/geometry/_shared/index_mixed.py
+++ b/molecularnodes/nodes/geometry/_shared/index_mixed.py
@@ -1,8 +1,10 @@
-# Node group 'Index Mixed' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Index Mixed" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -73,7 +75,7 @@ class IndexMixed(CustomGeometryGroup):
     ):
         super().__init__(**{"Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index",
             0,

--- a/molecularnodes/nodes/geometry/_shared/index_to_factor.py
+++ b/molecularnodes/nodes/geometry/_shared/index_to_factor.py
@@ -1,8 +1,10 @@
-# Node group 'Index to Factor' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Index to Factor" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -64,7 +66,7 @@ class IndexToFactor(CustomGeometryGroup):
     ):
         super().__init__(**{"Index": index, "Size": size})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index",
             0,

--- a/molecularnodes/nodes/geometry/_shared/is_extra_bonds.py
+++ b/molecularnodes/nodes/geometry/_shared/is_extra_bonds.py
@@ -1,8 +1,10 @@
-# Node group '.Is Extra Bonds' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Is Extra Bonds" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 
@@ -45,7 +47,7 @@ class IsExtraBonds(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         is_extra_bonds = tree.outputs.boolean("Is Extra Bonds")
         is_double_bond = tree.outputs.boolean("Is Double Bond")
         is_triple_bond = tree.outputs.boolean("Is Triple Bond")

--- a/molecularnodes/nodes/geometry/_shared/map_bond_type.py
+++ b/molecularnodes/nodes/geometry/_shared/map_bond_type.py
@@ -1,8 +1,10 @@
-# Node group '.map_bond_type' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".map_bond_type" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, IntegerSocket, SocketAccessor
 
@@ -36,7 +38,7 @@ class Map_bond_type(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         bond_count = tree.outputs.integer("Bond Count")
 
         (

--- a/molecularnodes/nodes/geometry/_shared/mn_bs_smooth.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_bs_smooth.py
@@ -1,8 +1,10 @@
-# Node group '.MN_bs_smooth' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_bs_smooth" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -77,7 +79,7 @@ class MN_bs_smooth(CustomGeometryGroup):
             **{"Geometry": geometry, "Factor": factor, "Iterations": iterations}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         factor = tree.inputs.float(
             "Factor", 1.0, min_value=0.0, max_value=1.0, subtype="FACTOR"

--- a/molecularnodes/nodes/geometry/_shared/mn_chi_atom_names.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_chi_atom_names.py
@@ -1,8 +1,10 @@
-# Node group '.MN_chi_atom_names' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_chi_atom_names" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import CustomGeometryGroup, IntegerSocket, SocketAccessor
 from ..menu_atom_name import MenuAtomName
 from ..menu_residue_name import MenuResidueName
@@ -55,7 +57,7 @@ class MN_chi_atom_names(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         x1 = tree.outputs.integer("X1")
         x2 = tree.outputs.integer("X2")
         x3 = tree.outputs.integer("X3")

--- a/molecularnodes/nodes/geometry/_shared/mn_constants_atom_name_nucleic.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_constants_atom_name_nucleic.py
@@ -1,8 +1,10 @@
-# Node group '.MN_constants_atom_name_nucleic' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_constants_atom_name_nucleic" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, IntegerSocket, SocketAccessor
 
@@ -53,7 +55,7 @@ class MN_constants_atom_name_nucleic(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         backbone_lower = tree.outputs.integer("Backbone Lower")
         backbone_upper = tree.outputs.integer("Backbone Upper")
         side_chain_lower = tree.outputs.integer("Side Chain Lower")

--- a/molecularnodes/nodes/geometry/_shared/mn_constants_atom_name_peptide.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_constants_atom_name_peptide.py
@@ -1,8 +1,10 @@
-# Node group '.MN_constants_atom_name_peptide' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_constants_atom_name_peptide" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, IntegerSocket, SocketAccessor
 
@@ -53,7 +55,7 @@ class MN_constants_atom_name_peptide(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         backbone_lower = tree.outputs.integer("Backbone Lower")
         backbone_upper = tree.outputs.integer("Backbone Upper")
         side_chain_lower = tree.outputs.integer("Side Chain Lower")

--- a/molecularnodes/nodes/geometry/_shared/mn_ensure_ures_id.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_ensure_ures_id.py
@@ -1,8 +1,10 @@
-# Node group '.MN_ensure_ures_id' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_ensure_ures_id" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, GeometrySocket, SocketAccessor
 from nodebpy.types import InputGeometry
@@ -56,7 +58,7 @@ class MN_ensure_ures_id(CustomGeometryGroup):
     ):
         super().__init__(**{"Input": input})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         input = tree.inputs.geometry("Input")
         output = tree.outputs.geometry("Output")
 

--- a/molecularnodes/nodes/geometry/_shared/mn_init_tmp_attributes.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_init_tmp_attributes.py
@@ -1,8 +1,10 @@
-# Node group '.MN_init_tmp_attributes' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_init_tmp_attributes" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, GeometrySocket, SocketAccessor
 from nodebpy.types import InputGeometry
@@ -55,7 +57,7 @@ class MN_init_tmp_attributes(CustomGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         geometry_1 = tree.outputs.geometry("Geometry")
 

--- a/molecularnodes/nodes/geometry/_shared/mn_peptide_chi_values.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_peptide_chi_values.py
@@ -1,8 +1,10 @@
-# Node group '.MN_peptide_chi_values' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_peptide_chi_values" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -89,7 +91,7 @@ class MN_peptide_chi_values(CustomGeometryGroup):
     ):
         super().__init__(**{"X1": x1, "X2": x2, "X3": x3, "X4": x4, "X5": x5})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         x1 = tree.inputs.float("X1", 0.0)
         x2 = tree.inputs.float("X2", 0.0)
         x3 = tree.inputs.float("X3", 0.0)

--- a/molecularnodes/nodes/geometry/_shared/mn_pivot_nucleic.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_pivot_nucleic.py
@@ -1,8 +1,10 @@
-# Node group '.MN_pivot_nucleic' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_pivot_nucleic" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 from ..atom_name import AtomName
@@ -50,7 +52,7 @@ class MN_pivot_nucleic(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         accumulate_backbone = tree.outputs.boolean("Accumulate Backbone")
         pivot_backbone = tree.outputs.boolean("Pivot Backbone")
         accumulate_base = tree.outputs.boolean("Accumulate Base")

--- a/molecularnodes/nodes/geometry/_shared/mn_pivot_peptide.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_pivot_peptide.py
@@ -1,8 +1,10 @@
-# Node group '.MN_pivot_peptide' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_pivot_peptide" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 from ..atom_name import AtomName
@@ -39,7 +41,7 @@ class MN_pivot_peptide(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         pivot_side_chain = tree.outputs.boolean("Pivot Side Chain")
 
         group = MN_select_res_name_peptide(

--- a/molecularnodes/nodes/geometry/_shared/mn_select_attribute.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_select_attribute.py
@@ -1,8 +1,10 @@
-# Node group '.MN_select_attribute' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_select_attribute" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -76,7 +78,7 @@ class MN_select_attribute(CustomGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Name": name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/_shared/mn_select_nucleic.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_select_nucleic.py
@@ -1,8 +1,10 @@
-# Node group '.MN_select_nucleic' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_select_nucleic" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 from .mn_constants_atom_name_nucleic import MN_constants_atom_name_nucleic
@@ -46,7 +48,7 @@ class MN_select_nucleic(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         is_backbone = tree.outputs.boolean(
             "Is Backbone",
             description="True for atoms that are part of the sugar-phosphate backbone for the nucleotides",

--- a/molecularnodes/nodes/geometry/_shared/mn_select_peptide.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_select_peptide.py
@@ -1,8 +1,10 @@
-# Node group '.MN_select_peptide' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_select_peptide" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 from ..atom_name import AtomName
@@ -51,7 +53,7 @@ class MN_select_peptide(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         is_backbone = tree.outputs.boolean("Is Backbone")
         is_side_chain = tree.outputs.boolean("Is Side Chain")
         is_peptide = tree.outputs.boolean("Is Peptide")

--- a/molecularnodes/nodes/geometry/_shared/mn_select_res_name_peptide.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_select_res_name_peptide.py
@@ -1,8 +1,10 @@
-# Node group '.MN_select_res_name_peptide' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_select_res_name_peptide" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 from nodebpy.types import InputBoolean
@@ -213,7 +215,7 @@ class MN_select_res_name_peptide(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         ala = tree.inputs.boolean("ALA", False, description="Select the AA residue ALA")
         arg = tree.inputs.boolean("ARG", False, description="Select the AA residue ARG")
         asn = tree.inputs.boolean("ASN", False, description="Select the AA residue ASN")

--- a/molecularnodes/nodes/geometry/_shared/mn_select_sec_struct.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_select_sec_struct.py
@@ -1,8 +1,10 @@
-# Node group '.MN_select_sec_struct' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_select_sec_struct" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import BooleanSocket, CustomGeometryGroup, SocketAccessor
 from nodebpy.types import InputBoolean
 from ..is_helix import IsHelix
@@ -66,7 +68,7 @@ class MN_select_sec_struct(CustomGeometryGroup):
     ):
         super().__init__(**{"And": and_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/_shared/mn_select_sec_struct_id.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_select_sec_struct_id.py
@@ -1,8 +1,10 @@
-# Node group '.MN_select_sec_struct_id' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_select_sec_struct_id" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -76,7 +78,7 @@ class MN_select_sec_struct_id(CustomGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "id": id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/_shared/mn_topo_assign_backbone.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_topo_assign_backbone.py
@@ -1,8 +1,10 @@
-# Node group '.MN_topo_assign_backbone' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_topo_assign_backbone" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -70,7 +72,7 @@ class MN_topo_assign_backbone(CustomGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/_shared/mn_units.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_units.py
@@ -1,8 +1,10 @@
-# Node group 'MN Units' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "MN Units" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import CustomGeometryGroup, FloatSocket, SocketAccessor
 from nodebpy.types import InputFloat
 from .mn_world_scale import MN_world_scale
@@ -57,7 +59,7 @@ class MNUnits(CustomGeometryGroup):
     ):
         super().__init__(**{"Value": value})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.float(
             "Value",
             3.0,

--- a/molecularnodes/nodes/geometry/_shared/mn_utils_aa_atom_pos.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_utils_aa_atom_pos.py
@@ -1,8 +1,10 @@
-# Node group '.MN_utils_aa_atom_pos' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_utils_aa_atom_pos" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -69,7 +71,7 @@ class MN_utils_aa_atom_pos(CustomGeometryGroup):
     ):
         super().__init__(**{"atom_name": atom_name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atom_name = tree.inputs.integer("atom_name", 5)
         position = tree.outputs.vector("Position")
         group_index = tree.outputs.integer("Group Index")

--- a/molecularnodes/nodes/geometry/_shared/mn_utils_style_ribbon_nucleic.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_utils_style_ribbon_nucleic.py
@@ -1,9 +1,11 @@
-# Node group '.MN_utils_style_ribbon_nucleic' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_utils_style_ribbon_nucleic" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -182,7 +184,7 @@ class MN_utils_style_ribbon_nucleic(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/_shared/mn_utils_style_spheres_icosphere.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_utils_style_spheres_icosphere.py
@@ -1,9 +1,11 @@
-# Node group '.MN_utils_style_spheres_icosphere' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_utils_style_spheres_icosphere" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -116,7 +118,7 @@ class MN_utils_style_spheres_icosphere(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/_shared/mn_utils_style_spheres_points.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_utils_style_spheres_points.py
@@ -1,8 +1,10 @@
-# Node group '.MN_utils_style_spheres_points' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_utils_style_spheres_points" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -89,7 +91,7 @@ class MN_utils_style_spheres_points(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/_shared/mn_utils_style_sticks.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_utils_style_sticks.py
@@ -1,9 +1,11 @@
-# Node group '.MN_utils_style_sticks' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_utils_style_sticks" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -150,7 +152,7 @@ class MN_utils_style_sticks(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/_shared/mn_world_scale.py
+++ b/molecularnodes/nodes/geometry/_shared/mn_world_scale.py
@@ -1,8 +1,10 @@
-# Node group '.MN_world_scale' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".MN_world_scale" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, FloatSocket, SocketAccessor
 
@@ -36,7 +38,7 @@ class MN_world_scale(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world_scale = tree.outputs.float("world_scale", 0.01)
 
         g.Value(0.1) >> world_scale

--- a/molecularnodes/nodes/geometry/_shared/oklab_matrices.py
+++ b/molecularnodes/nodes/geometry/_shared/oklab_matrices.py
@@ -1,8 +1,10 @@
-# Node group '.OKLab Matrices' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".OKLab Matrices" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, MatrixSocket, SocketAccessor
 
@@ -41,7 +43,7 @@ class OKLabMatrices(CustomGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         m1 = tree.outputs.matrix("M1")
         m2 = tree.outputs.matrix("M2")
 

--- a/molecularnodes/nodes/geometry/_shared/override_index.py
+++ b/molecularnodes/nodes/geometry/_shared/override_index.py
@@ -1,8 +1,10 @@
-# Node group 'Override Index' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Override Index" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     BooleanSocket,
     CustomGeometryGroup,
@@ -72,7 +74,7 @@ class OverrideIndex(CustomGeometryGroup):
             **{"Selection": selection, "Index": index, "Override": override}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         index = tree.inputs.integer("Index", 0, hide_value=True, default_input="INDEX")
         override = tree.inputs.integer("Override", 0)

--- a/molecularnodes/nodes/geometry/_shared/principal_components.py
+++ b/molecularnodes/nodes/geometry/_shared/principal_components.py
@@ -1,8 +1,10 @@
-# Node group 'Principal Components' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Principal Components" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -89,7 +91,7 @@ class PrincipalComponents(CustomGeometryGroup):
     ):
         super().__init__(**{"Position": position, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position", (0.0, 0.0, 0.0), subtype="TRANSLATION", default_input="POSITION"
         )

--- a/molecularnodes/nodes/geometry/_shared/profile_type_picker.py
+++ b/molecularnodes/nodes/geometry/_shared/profile_type_picker.py
@@ -1,8 +1,10 @@
-# Node group '.Profile Type Picker' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Profile Type Picker" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -58,7 +60,7 @@ class ProfileTypePicker(CustomGeometryGroup):
     ):
         super().__init__(**{"Menu": menu})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         menu = tree.inputs.menu("Menu", optional_label=True)
         output = tree.outputs.integer("Output")
 

--- a/molecularnodes/nodes/geometry/_shared/sample_atomic_attributes.py
+++ b/molecularnodes/nodes/geometry/_shared/sample_atomic_attributes.py
@@ -1,8 +1,10 @@
-# Node group '.Sample Atomic Attributes' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Sample Atomic Attributes" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -73,7 +75,7 @@ class SampleAtomicAttributes(CustomGeometryGroup):
             **{"Atoms": atoms, "Sample Atoms": sample_atoms, "Index": index}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry("Atoms")
         sample_atoms = tree.inputs.geometry("Sample Atoms")
         index = tree.inputs.integer("Index", 0, default_input="INDEX")

--- a/molecularnodes/nodes/geometry/_shared/sample_atomic_attributes_to_face_corner.py
+++ b/molecularnodes/nodes/geometry/_shared/sample_atomic_attributes_to_face_corner.py
@@ -1,8 +1,10 @@
-# Node group '.Sample Atomic Attributes to Face Corner' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Sample Atomic Attributes to Face Corner" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     CustomGeometryGroup,
@@ -74,7 +76,7 @@ class SampleAtomicAttributesToFaceCorner(CustomGeometryGroup):
             **{"Geometry": geometry, "Sample Atoms": sample_atoms, "Index": index}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         sample_atoms = tree.inputs.geometry("Sample Atoms")
         index = tree.inputs.integer("Index", 0, default_input="INDEX")

--- a/molecularnodes/nodes/geometry/_shared/sample_nucleic_base_values.py
+++ b/molecularnodes/nodes/geometry/_shared/sample_nucleic_base_values.py
@@ -1,8 +1,10 @@
-# Node group '.Sample Nucleic Base Values' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".Sample Nucleic Base Values" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -80,7 +82,7 @@ class SampleNucleicBaseValues(CustomGeometryGroup):
     ):
         super().__init__(**{"Input": input})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         _input = tree.inputs.integer("Input", 0)
         base_valid = tree.outputs.boolean("base_valid")
         base_pivot = tree.outputs.vector("base_pivot'")

--- a/molecularnodes/nodes/geometry/_shared/set_instancer.py
+++ b/molecularnodes/nodes/geometry/_shared/set_instancer.py
@@ -1,8 +1,10 @@
-# Node group 'Set Instancer' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Set Instancer" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -63,7 +65,7 @@ class SetInstancer(CustomGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "is_instanced": is_instanced})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/_shared/smooth_by_angle.py
+++ b/molecularnodes/nodes/geometry/_shared/smooth_by_angle.py
@@ -1,9 +1,11 @@
-# Node group 'Smooth by Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Smooth by Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -80,7 +82,7 @@ class SmoothByAngle(CustomGeometryGroup):
             **{"Mesh": mesh, "Angle": angle, "Ignore Sharpness": ignore_sharpness}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         mesh = tree.inputs.geometry("Mesh")
         angle = tree.inputs.float(
             "Angle",

--- a/molecularnodes/nodes/geometry/_shared/sorted_bundle_paths.py
+++ b/molecularnodes/nodes/geometry/_shared/sorted_bundle_paths.py
@@ -1,8 +1,10 @@
-# Node group 'Sorted Bundle Paths' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Sorted Bundle Paths" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BundleSocket,
@@ -63,7 +65,7 @@ class SortedBundlePaths(CustomGeometryGroup):
     ):
         super().__init__(**{"Bundle": bundle, "Bundle Type": bundle_type})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         bundle = tree.inputs.bundle("Bundle")
         bundle_type = tree.inputs.string("Bundle Type", "MN*", optional_label=True)
         list = tree.outputs.string("List")

--- a/molecularnodes/nodes/geometry/_shared/unit_convert.py
+++ b/molecularnodes/nodes/geometry/_shared/unit_convert.py
@@ -1,8 +1,10 @@
-# Node group 'Unit Convert' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Unit Convert" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import CustomGeometryGroup, FloatSocket, MenuSocket, SocketAccessor
 from nodebpy.types import InputFloat, InputMenu
@@ -62,7 +64,7 @@ class UnitConvert(CustomGeometryGroup):
     ):
         super().__init__(**{"Distance Type": distance_type, "From": from_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         distance_type = tree.inputs.menu(
             "Distance Type",
             description="What unit to scale the value to",

--- a/molecularnodes/nodes/geometry/_shared/utils_group_field_at_selection.py
+++ b/molecularnodes/nodes/geometry/_shared/utils_group_field_at_selection.py
@@ -1,8 +1,10 @@
-# Node group '.utils_group_field_at_selection' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group ".utils_group_field_at_selection" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     BooleanSocket,
@@ -138,7 +140,7 @@ class Utils_group_field_at_selection(CustomGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean(
             "Selection", False, description="Selection of atoms to apply this node to"
         )

--- a/molecularnodes/nodes/geometry/_shared/vector_in_angstroms.py
+++ b/molecularnodes/nodes/geometry/_shared/vector_in_angstroms.py
@@ -1,8 +1,10 @@
-# Node group 'Vector in Angstroms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Vector in Angstroms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     BooleanSocket,
     CustomGeometryGroup,
@@ -75,7 +77,7 @@ class VectorInAngstroms(CustomGeometryGroup):
             **{"Vector": vector, "Normalize": normalize, "Angstrom": angstrom}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vector = tree.inputs.vector(
             "Vector", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0
         )

--- a/molecularnodes/nodes/geometry/accumulate_axis_rotation.py
+++ b/molecularnodes/nodes/geometry/accumulate_axis_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Accumulate Axis Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Accumulate Axis Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -112,7 +114,7 @@ class AccumulateAxisRotation(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/angstrom_to_world.py
+++ b/molecularnodes/nodes/geometry/angstrom_to_world.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Angstrom to World' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Angstrom to World" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -59,7 +61,7 @@ class AngstromToWorld(AssetGeometryGroup):
     ):
         super().__init__(**{"Angstrom": angstrom})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         angstrom = tree.inputs.float(
             "Angstrom", 3.0, min_value=-10_000.0, max_value=10_000.0
         )

--- a/molecularnodes/nodes/geometry/animate_action.py
+++ b/molecularnodes/nodes/geometry/animate_action.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Animate Action' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Action" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class AnimateAction(AssetGeometryGroup):
     ):
         super().__init__(**{"Start": start, "Length": length})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         start = tree.inputs.integer("Start", 1)
         length = tree.inputs.integer("Length", 100, min_value=0)
         factor = tree.outputs.float("Factor")

--- a/molecularnodes/nodes/geometry/animate_dihedrals.py
+++ b/molecularnodes/nodes/geometry/animate_dihedrals.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Animate Dihedrals' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Dihedrals" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -32,7 +34,7 @@ class SampleMixAngle(CustomGeometryGroup):
         "node_tool_idname": "geometry.sample_mix_angle",
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.geometry("A", description="Geometry A to sample and mix from")
         b = tree.inputs.geometry("B", description="Geometry B to sample and mix to")
         angle = tree.inputs.float(
@@ -174,7 +176,7 @@ class AnimateDihedrals(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/animate_frames.py
+++ b/molecularnodes/nodes/geometry/animate_frames.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Animate Frames' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Frames" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -116,7 +118,7 @@ class AnimateFrames(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/animate_peptide_to_curve.py
+++ b/molecularnodes/nodes/geometry/animate_peptide_to_curve.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Animate Peptide to Curve' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Peptide to Curve" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -20,7 +22,7 @@ class MN_utils_curve_resample(CustomGeometryGroup):
     _name = ".MN_utils_curve_resample"
     _tree_properties = {"node_tool_idname": "geometry.mn_utils_curve_resample"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         offset = tree.inputs.float(
             "Offset", 2.3, min_value=-10_000.0, max_value=10_000.0
@@ -188,7 +190,7 @@ class AnimatePeptideToCurve(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/animate_trails.py
+++ b/molecularnodes/nodes/geometry/animate_trails.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Animate Trails' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Trails" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -158,7 +160,7 @@ class AnimateTrails(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/animate_value.py
+++ b/molecularnodes/nodes/geometry/animate_value.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Animate Value' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Value" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -105,7 +107,7 @@ class AnimateValue(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         smoother_step = tree.inputs.boolean(
             "Smoother Step",
             False,

--- a/molecularnodes/nodes/geometry/animate_wiggle.py
+++ b/molecularnodes/nodes/geometry/animate_wiggle.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Animate Wiggle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Animate Wiggle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -23,7 +25,7 @@ class MN_animate_wiggle_mask_res(CustomGeometryGroup):
     _name = ".MN_animate_wiggle_mask_res"
     _tree_properties = {"node_tool_idname": "geometry._mn_animate_wiggle_mask_res"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.integer("A", 0)
         result = tree.outputs.boolean("Result")
 
@@ -102,7 +104,7 @@ class MN_animate_wiggle_mask_length(CustomGeometryGroup):
     _name = ".MN_animate_wiggle_mask_length"
     _tree_properties = {"node_tool_idname": "geometry._mn_animate_wiggle_mask_length"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.integer("A", 0)
         result = tree.outputs.integer("Result")
 
@@ -114,7 +116,7 @@ class MN_animate_noise_repeat(CustomGeometryGroup):
     _color_tag = "TEXTURE"
     _tree_properties = {"node_tool_idname": "geometry.mn_animate_noise_repeat"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         amplitude = tree.inputs.float(
             "Amplitude", 1.0, min_value=-10_000.0, max_value=10_000.0
         )
@@ -173,7 +175,7 @@ class MN_utils_rotate_res(CustomGeometryGroup):
     _name = ".MN_utils_rotate_res"
     _tree_properties = {"node_tool_idname": "geometry._mn_utils_rotate_res"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean(
             "Selection", False, description="Selection of atoms to apply this node to"
         )
@@ -368,7 +370,7 @@ class AnimateWiggle(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/assembly_id.py
+++ b/molecularnodes/nodes/geometry/assembly_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Assembly ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Assembly ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -62,7 +64,7 @@ class AssemblyID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/assembly_instance.py
+++ b/molecularnodes/nodes/geometry/assembly_instance.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Assembly Instance' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Assembly Instance" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -127,7 +129,7 @@ class AssemblyInstance(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry that is instanced on the points"
         )

--- a/molecularnodes/nodes/geometry/atom_id.py
+++ b/molecularnodes/nodes/geometry/atom_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Atom ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Atom ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -59,7 +61,7 @@ class AtomID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/atom_name.py
+++ b/molecularnodes/nodes/geometry/atom_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Atom Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Atom Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -62,7 +64,7 @@ class AtomName(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/atomic_number.py
+++ b/molecularnodes/nodes/geometry/atomic_number.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Atomic Number' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Atomic Number" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -59,7 +61,7 @@ class AtomicNumber(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/atoms_to_ca_curves.py
+++ b/molecularnodes/nodes/geometry/atoms_to_ca_curves.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Atoms to CA Curves' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Atoms to CA Curves" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -95,7 +97,7 @@ class AtomsToCACurves(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/atoms_to_curves.py
+++ b/molecularnodes/nodes/geometry/atoms_to_curves.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Atoms to Curves' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Atoms to Curves" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -92,7 +94,7 @@ class AtomsToCurves(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/attribute_run.py
+++ b/molecularnodes/nodes/geometry/attribute_run.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Attribute Run' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Attribute Run" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class AttributeRun(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/b_factor.py
+++ b/molecularnodes/nodes/geometry/b_factor.py
@@ -1,7 +1,9 @@
-# Node-group asset 'B Factor' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "B Factor" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -59,7 +61,7 @@ class BFactor(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         b_factor = tree.outputs.float("b_factor")
 

--- a/molecularnodes/nodes/geometry/backbone_c.py
+++ b/molecularnodes/nodes/geometry/backbone_c.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone C' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone C" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     MenuSocket,
@@ -59,7 +61,7 @@ class BackboneC(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         c_ = tree.outputs.vector("C")
 

--- a/molecularnodes/nodes/geometry/backbone_ca.py
+++ b/molecularnodes/nodes/geometry/backbone_ca.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone CA' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone CA" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     MenuSocket,
@@ -59,7 +61,7 @@ class BackboneCA(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         ca = tree.outputs.vector("CA")
 

--- a/molecularnodes/nodes/geometry/backbone_n.py
+++ b/molecularnodes/nodes/geometry/backbone_n.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone N' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone N" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     MenuSocket,
@@ -59,7 +61,7 @@ class BackboneN(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         n = tree.outputs.vector("N")
 

--- a/molecularnodes/nodes/geometry/backbone_nh.py
+++ b/molecularnodes/nodes/geometry/backbone_nh.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone NH' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone NH" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class BackboneNH(AssetGeometryGroup):
     ):
         super().__init__(**{"Menu": menu})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         menu = tree.inputs.menu("Menu", expanded=True, optional_label=True)
         nh = tree.outputs.vector("NH")
 

--- a/molecularnodes/nodes/geometry/backbone_o.py
+++ b/molecularnodes/nodes/geometry/backbone_o.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone O' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone O" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     MenuSocket,
@@ -59,7 +61,7 @@ class BackboneO(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         o = tree.outputs.vector("O")
 

--- a/molecularnodes/nodes/geometry/backbone_positions.py
+++ b/molecularnodes/nodes/geometry/backbone_positions.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone Positions' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone Positions" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -81,7 +83,7 @@ class BackbonePositions(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         o = tree.outputs.vector(
             "O", description="The position of the backbone _O_ atom for the residue"

--- a/molecularnodes/nodes/geometry/backbone_vector_list.py
+++ b/molecularnodes/nodes/geometry/backbone_vector_list.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone Vector List' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone Vector List" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class BackboneVectorList(AssetGeometryGroup):
     ):
         super().__init__(**{"CA Atoms": ca_atoms, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         ca_atoms = tree.inputs.geometry("CA Atoms")
         index = tree.inputs.integer(
             "Index",

--- a/molecularnodes/nodes/geometry/backbone_vectors.py
+++ b/molecularnodes/nodes/geometry/backbone_vectors.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Backbone Vectors' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Backbone Vectors" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class BackboneVectors(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         normal = tree.outputs.vector(
             "Normal",

--- a/molecularnodes/nodes/geometry/between_float.py
+++ b/molecularnodes/nodes/geometry/between_float.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Between Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Between Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -73,7 +75,7 @@ class BetweenFloat(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Lower": lower, "Upper": upper})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.float(
             "Value",
             0.0,

--- a/molecularnodes/nodes/geometry/between_integer.py
+++ b/molecularnodes/nodes/geometry/between_integer.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Between Integer' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Between Integer" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -73,7 +75,7 @@ class BetweenInteger(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Lower": lower, "Upper": upper})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.integer(
             "Value", 0, description="The value to test if it exists within the bounds"
         )

--- a/molecularnodes/nodes/geometry/between_vector.py
+++ b/molecularnodes/nodes/geometry/between_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Between Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Between Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -73,7 +75,7 @@ class BetweenVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Lower": lower, "Upper": upper})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.vector(
             "Value", (0.0, 0.0, 0.0), description="The value to test element-wise"
         )

--- a/molecularnodes/nodes/geometry/bond_count.py
+++ b/molecularnodes/nodes/geometry/bond_count.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Bond Count' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Bond Count" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -64,7 +66,7 @@ class BondCount(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         is_bonded = tree.outputs.boolean(
             "Is Bonded", description="If the point has an edge / bond to another point"

--- a/molecularnodes/nodes/geometry/boolean_andor.py
+++ b/molecularnodes/nodes/geometry/boolean_andor.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Boolean AndOr' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Boolean AndOr" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -76,7 +78,7 @@ class BooleanAndOr(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Boolean": boolean})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/boolean_any.py
+++ b/molecularnodes/nodes/geometry/boolean_any.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Boolean Any' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Boolean Any" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -66,7 +68,7 @@ class BooleanAny(AssetGeometryGroup):
     ):
         super().__init__(**{"Boolean": boolean, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean("Boolean", False)
         group_id = tree.inputs.integer("Group ID", 0, hide_value=True)
         boolean_1 = tree.outputs.boolean("Boolean")

--- a/molecularnodes/nodes/geometry/boolean_first.py
+++ b/molecularnodes/nodes/geometry/boolean_first.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Boolean First' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Boolean First" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class BooleanFirst(AssetGeometryGroup):
     ):
         super().__init__(**{"Boolean": boolean, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean(
             "Boolean", False, description="The `Boolean` field to test", hide_value=True
         )

--- a/molecularnodes/nodes/geometry/boolean_last.py
+++ b/molecularnodes/nodes/geometry/boolean_last.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Boolean Last' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Boolean Last" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -64,7 +66,7 @@ class BooleanLast(AssetGeometryGroup):
     ):
         super().__init__(**{"Boolean": boolean})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean(
             "Boolean",
             True,

--- a/molecularnodes/nodes/geometry/boolean_run_fill.py
+++ b/molecularnodes/nodes/geometry/boolean_run_fill.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Boolean Run Fill' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Boolean Run Fill" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class BooleanRunFill(AssetGeometryGroup):
     ):
         super().__init__(**{"Boolean": boolean, "Fill Size": fill_size})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean(
             "Boolean",
             True,

--- a/molecularnodes/nodes/geometry/boolean_run_trim.py
+++ b/molecularnodes/nodes/geometry/boolean_run_trim.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Boolean Run Trim' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Boolean Run Trim" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -83,7 +85,7 @@ class BooleanRunTrim(AssetGeometryGroup):
             **{"Boolean": boolean, "Start": start, "End": end, "Size": size}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean(
             "Boolean",
             True,

--- a/molecularnodes/nodes/geometry/break_bonds.py
+++ b/molecularnodes/nodes/geometry/break_bonds.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Break Bonds' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Break Bonds" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class BreakBonds(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms, "Selection": selection, "Cutoff": cutoff})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/break_curves.py
+++ b/molecularnodes/nodes/geometry/break_curves.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Break Curves' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Break Curves" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class BreakCurves(AssetGeometryGroup):
     ):
         super().__init__(**{"Curves": curves, "Threshold": threshold})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry(
             "Curves", description="Geometry to delete elements from"
         )

--- a/molecularnodes/nodes/geometry/centre_on_selection.py
+++ b/molecularnodes/nodes/geometry/centre_on_selection.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Centre on Selection' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Centre on Selection" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -83,7 +85,7 @@ class CentreOnSelection(AssetGeometryGroup):
             **{"Atoms": atoms, "Selection": selection, "Group ID": group_id}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms",
             description="Atomic geometry that contains vertices and edges",

--- a/molecularnodes/nodes/geometry/centroid.py
+++ b/molecularnodes/nodes/geometry/centroid.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Centroid' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Centroid" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class Centroid(AssetGeometryGroup):
             **{"Position": position, "Selection": selection, "Group ID": group_id}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/chain_id.py
+++ b/molecularnodes/nodes/geometry/chain_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Chain ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Chain ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -62,7 +64,7 @@ class ChainID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/chain_parameter.py
+++ b/molecularnodes/nodes/geometry/chain_parameter.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Chain Parameter' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Chain Parameter" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -76,7 +78,7 @@ class ChainParameter(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         factor = tree.outputs.float(
             "Factor",
             description="A residues relative position along a chain. 0 being the first residue in a chain, 1 being the last",

--- a/molecularnodes/nodes/geometry/check_geometry.py
+++ b/molecularnodes/nodes/geometry/check_geometry.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Check Geometry' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Check Geometry" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class CheckGeometry(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Message": message})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         message = tree.inputs.string(
             "Message",

--- a/molecularnodes/nodes/geometry/clear_instance_transforms.py
+++ b/molecularnodes/nodes/geometry/clear_instance_transforms.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Clear Instance Transforms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Clear Instance Transforms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class ClearInstanceTransforms(AssetGeometryGroup):
             **{"Geometry": geometry, "Selection": selection, "Realize All": realize_all}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         realize_all = tree.inputs.boolean(

--- a/molecularnodes/nodes/geometry/color.py
+++ b/molecularnodes/nodes/geometry/color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -60,7 +62,7 @@ class Color(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         color = tree.outputs.color(
             "Color",

--- a/molecularnodes/nodes/geometry/color_atomic_number.py
+++ b/molecularnodes/nodes/geometry/color_atomic_number.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Atomic Number' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Atomic Number" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -69,7 +71,7 @@ class ColorAtomicNumber(AssetGeometryGroup):
     ):
         super().__init__(**{"atomic_number": atomic_number, "Color": color})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atomic_number = tree.inputs.integer(
             "atomic_number",
             6,

--- a/molecularnodes/nodes/geometry/color_attribute_map.py
+++ b/molecularnodes/nodes/geometry/color_attribute_map.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Attribute Map' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Attribute Map" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -123,7 +125,7 @@ class ColorAttributeMap(AssetGeometryGroup):
             _named_links=[("Intermediate", input_7), ("Intermediate", input_1)],
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color_space = tree.inputs.menu("Color Space", optional_label=True)
         name = tree.inputs.string(
             "Name",

--- a/molecularnodes/nodes/geometry/color_attribute_random.py
+++ b/molecularnodes/nodes/geometry/color_attribute_random.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Attribute Random' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Attribute Random" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -116,7 +118,7 @@ class ColorAttributeRandom(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "chain_id",

--- a/molecularnodes/nodes/geometry/color_backbone.py
+++ b/molecularnodes/nodes/geometry/color_backbone.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Backbone' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Backbone" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -69,7 +71,7 @@ class ColorBackbone(AssetGeometryGroup):
     ):
         super().__init__(**{"Backbone": backbone, "Side Chain": side_chain})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         backbone = tree.inputs.color("Backbone", (0.469481, 0.24, 0.6, 1.0))
         side_chain = tree.inputs.color("Side Chain", (0.525519, 0.6, 0.24, 1.0))
         color = tree.outputs.color("Color", (0.0, 0.0, 0.0, 0.0))

--- a/molecularnodes/nodes/geometry/color_common.py
+++ b/molecularnodes/nodes/geometry/color_common.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Common' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Common" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -106,7 +108,7 @@ class ColorCommon(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         hydrogen = tree.inputs.color(
             "Hydrogen",
             (1.0, 1.0, 1.0, 1.0),

--- a/molecularnodes/nodes/geometry/color_element.py
+++ b/molecularnodes/nodes/geometry/color_element.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Element' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Element" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -696,7 +698,7 @@ class ColorElement(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         with tree.inputs.panel("1-20", default_closed=True):
             h = tree.inputs.color(
                 "H", (1.0, 1.0, 1.0, 1.0), description="Set the color for the element H"

--- a/molecularnodes/nodes/geometry/color_goodsell.py
+++ b/molecularnodes/nodes/geometry/color_goodsell.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Goodsell' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Goodsell" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class ColorGoodsell(AssetGeometryGroup):
     ):
         super().__init__(**{"Color": color, "Factor": factor, "Invert": invert})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color = tree.inputs.color(
             "Color",
             (0.5, 0.5, 0.5, 1.0),

--- a/molecularnodes/nodes/geometry/color_mix_intermediate.py
+++ b/molecularnodes/nodes/geometry/color_mix_intermediate.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Mix Intermediate' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Mix Intermediate" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -102,7 +104,7 @@ class ColorMixIntermediate(AssetGeometryGroup):
             _named_links=[("Intermediate", socket_1), ("Intermediate", socket_2)],
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         factor = tree.inputs.float(
             "Factor", 0.5, min_value=0.0, max_value=1.0, subtype="FACTOR"
         )

--- a/molecularnodes/nodes/geometry/color_oklab_mix.py
+++ b/molecularnodes/nodes/geometry/color_oklab_mix.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color OKLab Mix' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color OKLab Mix" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class ColorOKLabMix(AssetGeometryGroup):
     ):
         super().__init__(**{"Factor": factor, "A": a, "B": b})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         factor = tree.inputs.float(
             "Factor", 0.5, min_value=0.0, max_value=1.0, subtype="FACTOR"
         )

--- a/molecularnodes/nodes/geometry/color_oklab_offset.py
+++ b/molecularnodes/nodes/geometry/color_oklab_offset.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Color OKLab Offset' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color OKLab Offset" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -108,7 +110,7 @@ class ColorOKLabOffset(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color = tree.inputs.color("Color", (0.07984344, 1.0, 0.2559341, 1.0))
         colorspace = tree.inputs.menu("Colorspace", expanded=True, optional_label=True)
         luminance = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/color_plddt.py
+++ b/molecularnodes/nodes/geometry/color_plddt.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color pLDDT' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color pLDDT" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -80,7 +82,7 @@ class ColorPLDDT(AssetGeometryGroup):
     ):
         super().__init__(**{"<50": _50, "<70": _70, "<90": socket_3, ">90": socket_4})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         n_50 = tree.inputs.color(
             "<50",
             (1.000169, 0.20506974, 0.05950701, 1.0),

--- a/molecularnodes/nodes/geometry/color_rainbow.py
+++ b/molecularnodes/nodes/geometry/color_rainbow.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Color Rainbow' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Rainbow" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -119,7 +121,7 @@ class ColorRainbow(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         factor = tree.inputs.menu("Factor", optional_label=True)
         color_space = tree.inputs.menu("Color Space", optional_label=True)
         offset = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/color_res_name.py
+++ b/molecularnodes/nodes/geometry/color_res_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Res Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Res Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -282,7 +284,7 @@ class ColorResName(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         with tree.inputs.panel("Peptide", default_closed=True):
             ala = tree.inputs.color(
                 "ALA",

--- a/molecularnodes/nodes/geometry/color_secondary_structure.py
+++ b/molecularnodes/nodes/geometry/color_secondary_structure.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color Secondary Structure' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color Secondary Structure" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -84,7 +86,7 @@ class ColorSecondaryStructure(AssetGeometryGroup):
             **{"Helix": helix, "Sheet": sheet, "Loop": loop, "Other": other}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         helix = tree.inputs.color(
             "Helix",
             (0.16202937, 0.6239606, 0.19461784, 1.0),

--- a/molecularnodes/nodes/geometry/color_to_lch.py
+++ b/molecularnodes/nodes/geometry/color_to_lch.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color to LCh' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color to LCh" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -67,7 +69,7 @@ class ColorToLCh(AssetGeometryGroup):
     ):
         super().__init__(**{"Color": color})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color = tree.inputs.color("Color", (0.0, 0.0, 0.0, 1.0))
         l = tree.outputs.float("L")
         c_ = tree.outputs.float("C")

--- a/molecularnodes/nodes/geometry/color_to_oklab.py
+++ b/molecularnodes/nodes/geometry/color_to_oklab.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color to OKLab' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color to OKLab" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -60,7 +62,7 @@ class ColorToOKLab(AssetGeometryGroup):
     ):
         super().__init__(**{"Color": color})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color = tree.inputs.color("Color", (0.0, 0.0, 0.0, 1.0))
         oklab = tree.outputs.vector("OKLab", subtype="XYZ")
 

--- a/molecularnodes/nodes/geometry/contains_geometry.py
+++ b/molecularnodes/nodes/geometry/contains_geometry.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Contains Geometry' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Contains Geometry" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -63,7 +65,7 @@ class ContainsGeometry(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         not_empty = tree.outputs.boolean(
             "Not Empty", description="True when the input contains some geometry"

--- a/molecularnodes/nodes/geometry/cumulative_length.py
+++ b/molecularnodes/nodes/geometry/cumulative_length.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Cumulative Length' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Cumulative Length" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -44,7 +46,7 @@ class CumulativeLength(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         length = tree.outputs.float(
             "Length",
             description="The length along the current spline added to all previous spline lengths",

--- a/molecularnodes/nodes/geometry/curve_custom_profile.py
+++ b/molecularnodes/nodes/geometry/curve_custom_profile.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Curve Custom Profile' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Custom Profile" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -167,7 +169,7 @@ class CurveCustomProfile(AssetGeometryGroup):
             ],
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         subdivisions = tree.inputs.integer("Subdivisions", 6, min_value=1)
         profile_type = tree.inputs.menu("Profile Type", optional_label=True)

--- a/molecularnodes/nodes/geometry/curve_endpoint_values.py
+++ b/molecularnodes/nodes/geometry/curve_endpoint_values.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Curve Endpoint Values' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Endpoint Values" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -107,7 +109,7 @@ class CurveEndpointValues(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         start_size = tree.inputs.integer(
             "Start Size",
             1,

--- a/molecularnodes/nodes/geometry/curve_offset_dihedral.py
+++ b/molecularnodes/nodes/geometry/curve_offset_dihedral.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Curve Offset Dihedral' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Offset Dihedral" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -88,7 +90,7 @@ class CurveOffsetDihedral(AssetGeometryGroup):
             **{"Position": position, "Normal": normal, "Index": index, "Offset": offset}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/curve_offset_dot.py
+++ b/molecularnodes/nodes/geometry/curve_offset_dot.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Curve Offset Dot' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Offset Dot" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -119,7 +121,7 @@ class CurveOffsetDot(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         normal = tree.inputs.vector("Normal", (0.0, 0.0, 0.0), default_input="NORMAL")
         offset = tree.inputs.integer("Offset", -1, min_value=-2147483647)
         with tree.inputs.panel("Threshold"):

--- a/molecularnodes/nodes/geometry/curve_rotation.py
+++ b/molecularnodes/nodes/geometry/curve_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Curve Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -63,7 +65,7 @@ class CurveRotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Normal": normal})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         normal = tree.inputs.vector(
             "Normal",
             (0.0, 0.0, 1.0),

--- a/molecularnodes/nodes/geometry/curve_transform.py
+++ b/molecularnodes/nodes/geometry/curve_transform.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Curve Transform' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Transform" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -48,7 +50,7 @@ class CurveTransform(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         transform = tree.outputs.matrix(
             "Transform",
             description="The combine 4X4 transformation matrix for the point of the curve",

--- a/molecularnodes/nodes/geometry/curve_vectors.py
+++ b/molecularnodes/nodes/geometry/curve_vectors.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Curve Vectors' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Vectors" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -52,7 +54,7 @@ class CurveVectors(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         normal = tree.outputs.vector(
             "Normal",
             description="The normal of the control point. Used for calculating the rotation for the point and when calculating `Curve to Mesh`",

--- a/molecularnodes/nodes/geometry/curve_visualize.py
+++ b/molecularnodes/nodes/geometry/curve_visualize.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Curve Visualize' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Curve Visualize" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
 import bpy
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -121,7 +123,7 @@ class CurveVisualize(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         position = tree.inputs.vector(

--- a/molecularnodes/nodes/geometry/density_style_iso_surface.py
+++ b/molecularnodes/nodes/geometry/density_style_iso_surface.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Density Style ISO Surface' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Density Style ISO Surface" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -171,7 +173,7 @@ class DensityStyleISOSurface(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         volume = tree.inputs.geometry("Volume", description="Input geometry")
         visible = tree.inputs.boolean(
             "Visible", True, description="Visibility of style"

--- a/molecularnodes/nodes/geometry/density_style_surface.py
+++ b/molecularnodes/nodes/geometry/density_style_surface.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Density Style Surface' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Density Style Surface" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -113,7 +115,7 @@ class DensityStyleSurface(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         volume = tree.inputs.geometry("Volume")
         threshold = tree.inputs.float("Threshold", 0.8)
         shade_smooth = tree.inputs.boolean(

--- a/molecularnodes/nodes/geometry/density_style_wire.py
+++ b/molecularnodes/nodes/geometry/density_style_wire.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Density Style Wire' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Density Style Wire" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -121,7 +123,7 @@ class DensityStyleWire(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         volume = tree.inputs.geometry("Volume")
         threshold = tree.inputs.float("Threshold", 0.8)
         hide_dust = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/dihedral_angle.py
+++ b/molecularnodes/nodes/geometry/dihedral_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Dihedral Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Dihedral Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -93,7 +95,7 @@ class DihedralAngle(AssetGeometryGroup):
     ):
         super().__init__(**{"A": a, "B": b, "C": c, "D": d})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.vector(
             "A",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/dihedral_chi_angle.py
+++ b/molecularnodes/nodes/geometry/dihedral_chi_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Dihedral Chi Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Dihedral Chi Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -57,7 +59,7 @@ class DihedralChiAngle(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         angle = tree.outputs.float("Angle", subtype="ANGLE")
         up = tree.outputs.vector("Up")
         axis = tree.outputs.vector("Axis")

--- a/molecularnodes/nodes/geometry/dihedral_nucleic_angle.py
+++ b/molecularnodes/nodes/geometry/dihedral_nucleic_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Dihedral Nucleic Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Dihedral Nucleic Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -56,7 +58,7 @@ class DihedralNucleicAngle(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         angle = tree.outputs.float(
             "Angle",
             description="The angle between the vectors AB and CD, when made perpendicular to BC.",

--- a/molecularnodes/nodes/geometry/dihedral_phi.py
+++ b/molecularnodes/nodes/geometry/dihedral_phi.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Dihedral Phi' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Dihedral Phi" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -79,7 +81,7 @@ class DihedralPhi(AssetGeometryGroup):
     ):
         super().__init__(**{"Menu": menu})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         menu = tree.inputs.menu("Menu", expanded=True, optional_label=True)
         phi = tree.outputs.float(
             "Phi",

--- a/molecularnodes/nodes/geometry/dihedral_psi.py
+++ b/molecularnodes/nodes/geometry/dihedral_psi.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Dihedral Psi' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Dihedral Psi" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -78,7 +80,7 @@ class DihedralPsi(AssetGeometryGroup):
     ):
         super().__init__(**{"Method": method})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         method = tree.inputs.menu("Method", expanded=True, optional_label=True)
         psi = tree.outputs.float(
             "Psi",

--- a/molecularnodes/nodes/geometry/dna_from_curve.py
+++ b/molecularnodes/nodes/geometry/dna_from_curve.py
@@ -1,9 +1,11 @@
-# Node-group asset 'DNA From Curve' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "DNA From Curve" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
 import bpy
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -33,7 +35,7 @@ from .transform_local_axis import TransformLocalAxis
 class DNASequenceToID(CustomGeometryGroup):
     _name = "DNA Sequence to ID"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         string = tree.inputs.string("String", "", optional_label=True)
         length = tree.outputs.integer("Length")
         res_id = tree.outputs.integer(
@@ -78,7 +80,7 @@ class CustomWorldObjectSpace(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         space = tree.inputs.menu("Space", optional_label=True)
         custom_0_world_1_object_2 = tree.outputs.integer(
             "Custom = 0,World = 1, Object = 2"
@@ -123,7 +125,7 @@ class CustomForce(CustomGeometryGroup):
         "description": "Create a custom force field to be used in simulations."
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         mode = tree.inputs.menu(
             "Mode",
             description="How the force field is defined.",
@@ -296,7 +298,7 @@ class CurveSegment(CustomGeometryGroup):
     _name = "Curve Segment"
     _color_tag = "INPUT"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         segment_length = tree.outputs.float(
             "Segment Length", description="Distance to previous point on curve"
         )
@@ -338,7 +340,7 @@ class StoreSegmentLength(CustomGeometryGroup):
     _name = "Store Segment Length"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry("Curves")
         name = tree.inputs.string("Name", "rest_length", optional_label=True)
         curves_1 = tree.outputs.geometry("Curves")
@@ -356,7 +358,7 @@ class StoreEdgeLength(CustomGeometryGroup):
     _name = "Store Edge Length"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry("Curves")
         name = tree.inputs.string("Name", "rest_length", optional_label=True)
         curves_1 = tree.outputs.geometry("Curves")
@@ -372,7 +374,7 @@ class StoreSegmentRotation(CustomGeometryGroup):
     _name = "Store Segment Rotation"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry("Curves")
         name = tree.inputs.string("Name", "rest_rotation", optional_label=True)
         curves_1 = tree.outputs.geometry("Curves")
@@ -396,7 +398,7 @@ class StoreBendRotation(CustomGeometryGroup):
     _name = "Store Bend Rotation"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry("Curves")
         bend_rotation_name = tree.inputs.string(
             "Bend Rotation Name", "rest_bend_rotation", optional_label=True
@@ -427,7 +429,7 @@ class SetupStructuralRestData(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 180}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         geometry_1 = tree.outputs.geometry("Geometry")
 
@@ -458,7 +460,7 @@ class Damping(CustomGeometryGroup):
     _name = "Damping"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         linear = tree.inputs.float("Linear", 2.0, min_value=0.0, structure_type="FIELD")
         angular = tree.inputs.float(
             "Angular", 2.0, min_value=0.0, structure_type="FIELD"
@@ -483,7 +485,7 @@ class RodBendTwistConstraint(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         compliance = tree.inputs.float(
             "Compliance", 0.0001, min_value=0.0, structure_type="FIELD"
         )
@@ -536,7 +538,7 @@ class RodStretchShearConstraint(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         compliance = tree.inputs.float(
             "Compliance", 0.0001, min_value=0.0, structure_type="FIELD"
         )
@@ -599,7 +601,7 @@ class SoftnessToCompliance(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         softness = tree.inputs.float(
             "Softness", 0.0, min_value=0.0, max_value=1.0, subtype="FACTOR"
         )
@@ -616,7 +618,7 @@ class SetEffector(CustomGeometryGroup):
         "default_group_node_width": 160,
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry",
             description="Geometry to add the effector to.",
@@ -673,7 +675,7 @@ class Collider(CustomGeometryGroup):
         "is_modifier": True,
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry",
             description="The collider geometry.",
@@ -796,7 +798,7 @@ class ObjectEffector(CustomGeometryGroup):
     _name = "Object Effector"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         object = tree.inputs.object("Object", optional_label=True)
         effector = tree.outputs.bundle("Effector")
 
@@ -814,7 +816,7 @@ class CollectionEffector(CustomGeometryGroup):
     _name = "Collection Effector"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         collection = tree.inputs.collection("Collection", optional_label=True)
         with tree.inputs.panel("Naming", default_closed=True):
             name_pattern = tree.inputs.string(
@@ -842,7 +844,7 @@ class PinPositions(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean(
             "Selection", True, hide_value=True, structure_type="FIELD"
         )
@@ -895,7 +897,7 @@ class PinRotation(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean("Selection", True, structure_type="FIELD")
         rotation = tree.inputs.rotation(
             "Rotation", (0.0, 0.0, 0.0), structure_type="FIELD"
@@ -932,7 +934,7 @@ class StringToList(CustomGeometryGroup):
     _name = "String to List"
     _color_tag = "CONVERTER"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         string = tree.inputs.string("String", "", optional_label=True)
         separator = tree.inputs.string("Separator", ",", optional_label=True)
         list = tree.outputs.string("List")
@@ -944,7 +946,7 @@ class SetGeometryTags(CustomGeometryGroup):
     _name = "Set Geometry Tags"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry to get the bundle of"
         )
@@ -967,7 +969,7 @@ class SetFriction(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry",
             description="Geometry to store a new attribute with the given name on",
@@ -988,7 +990,7 @@ class ThinRodMomentOfInertia(CustomGeometryGroup):
     _name = "Thin Rod Moment of Inertia"
     _color_tag = "CONVERTER"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         mass = tree.inputs.float("Mass", 0.0, hide_value=True)
         moment_of_inertia = tree.outputs.vector("Moment of Inertia")
 
@@ -1011,7 +1013,7 @@ class SetMass(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         mass = tree.inputs.float(
             "Mass", 1.0, min_value=0.0, structure_type="FIELD", subtype="MASS"
@@ -1063,7 +1065,7 @@ class SimAttributes(CustomGeometryGroup):
     _name = "Sim Attributes"
     _color_tag = "CONVERTER"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         extra = tree.inputs.string("Extra", "")
         sim_attributes = tree.outputs.string("Sim Attributes")
 
@@ -1084,7 +1086,7 @@ class ApplyGeoCacheDeformOnly(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 240}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         new_geometry = tree.inputs.geometry("New Geometry")
         cache_geometry = tree.inputs.geometry("Cache Geometry")
         sim_attributes = tree.inputs.string(
@@ -1117,7 +1119,7 @@ class SetGeoUpdaterDeformOnly(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 220}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         extra_sim_attributes = tree.inputs.string(
             "Extra Sim Attributes", "", optional_label=True
@@ -1158,7 +1160,7 @@ class IsEffectorForGeometry(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"default_group_node_width": 180}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         effector = tree.inputs.bundle("Effector")
         _effector_path = tree.inputs.string(
             "Effector Path",
@@ -1193,7 +1195,7 @@ class ForEachSimGeometry(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         closure = tree.inputs.closure("Closure")
         world_1 = tree.outputs.bundle("World")
@@ -1226,7 +1228,7 @@ class EvaluateCustomEffectors(CustomGeometryGroup):
     _name = "Evaluate Custom Effectors"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle(
             "World", structure_type="SINGLE", force_non_field=True
         )
@@ -1335,7 +1337,7 @@ class RenameSimAttributes(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         mode = tree.inputs.menu("Mode", optional_label=True)
         old = tree.inputs.string("Old", "", optional_label=True)
@@ -1365,7 +1367,7 @@ class SetPreviousWorldItems(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 180}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         cache = tree.inputs.bundle("Cache")
         world_1 = tree.outputs.bundle("World")
@@ -1402,7 +1404,7 @@ class ApplyEachGeometryCache(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         cache = tree.inputs.bundle("Cache")
         post_sim = tree.inputs.boolean("Post Sim", False)
@@ -1438,7 +1440,7 @@ class EvaluateEffectorAttributes(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 180}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         world_1 = tree.outputs.bundle("World")
 
@@ -1771,7 +1773,7 @@ class EvaluateForces(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         to_world_transform = tree.inputs.matrix("To World Transform")
         name = tree.inputs.string("Name", "external_force", optional_label=True)
@@ -1827,7 +1829,7 @@ class XPBDSolver(CustomGeometryGroup):
     _name = "XPBD Solver"
     _color_tag = "GEOMETRY"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle(
             "World", description="World state that is updated by the solver"
         )
@@ -1890,7 +1892,7 @@ class XPBDSolver(CustomGeometryGroup):
 class ForEachTypedBundle(CustomGeometryGroup):
     _name = "For Each Typed Bundle"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         type = tree.inputs.string("Type", "", optional_label=True)
         closure = tree.inputs.closure("Closure")
@@ -1919,7 +1921,7 @@ class SimplifyCachedColliderInfo(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 200}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         world_1 = tree.outputs.bundle("World")
 
@@ -1957,7 +1959,7 @@ class ClearPreviousWorldItems(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 180}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         world_1 = tree.outputs.bundle("World")
 
@@ -1989,7 +1991,7 @@ class RemoveSimAttributes(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         mode = tree.inputs.menu("Mode", optional_label=True)
         name = tree.inputs.string("Name", "", optional_label=True)
@@ -2019,7 +2021,7 @@ class CopySolverData(CustomGeometryGroup):
         "default_group_node_width": 180,
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         cache = tree.inputs.bundle("Cache")
         world_1 = tree.outputs.bundle("World")
@@ -2045,7 +2047,7 @@ class XPBDSimulation(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"default_group_node_width": 160}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.bundle("World")
         substeps = tree.inputs.integer("Substeps", 10, min_value=1)
         constraint_steps = tree.inputs.integer("Constraint Steps", 1, min_value=1)
@@ -2131,7 +2133,7 @@ class ConvertSpaceTransform(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"default_group_node_width": 180}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         from_space = tree.inputs.menu("From Space", optional_label=True)
         from_object = tree.inputs.object("From Object", optional_label=True)
         to_space = tree.inputs.menu("To Space", optional_label=True)
@@ -2177,7 +2179,7 @@ class SimulateDNAGuide(CustomGeometryGroup):
         "is_modifier": True,
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         dna_curve = tree.inputs.geometry(
             "DNA Curve",
             description="Input hair curves.",
@@ -2560,7 +2562,7 @@ class DNAFromCurve(AssetGeometryGroup):
             _named_links=[("Menu", socket_3), ("Menu", socket_5)],
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry("Curves")
         base_resolution = tree.inputs.integer(
             "Base Resolution", 0, min_value=0, max_value=4

--- a/molecularnodes/nodes/geometry/edge_group_id.py
+++ b/molecularnodes/nodes/geometry/edge_group_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Edge Group ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Edge Group ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -63,7 +65,7 @@ class EdgeGroupID(AssetGeometryGroup):
     ):
         super().__init__(**{"Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         group_id = tree.inputs.integer("Group ID", 0, hide_value=True)
         difference = tree.outputs.integer("Difference", attribute_domain="EDGE")
         is_equal = tree.outputs.boolean("Is Equal", attribute_domain="EDGE")

--- a/molecularnodes/nodes/geometry/edge_info.py
+++ b/molecularnodes/nodes/geometry/edge_info.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Edge Info' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Edge Info" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -89,7 +91,7 @@ class EdgeInfo(AssetGeometryGroup):
     ):
         super().__init__(**{"Vertex Index": vertex_index, "Edge Index": edge_index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vertex_index = tree.inputs.integer(
             "Vertex Index", 0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/edge_length.py
+++ b/molecularnodes/nodes/geometry/edge_length.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Edge Length' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Edge Length" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -43,7 +45,7 @@ class EdgeLength(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         length = tree.outputs.float("Length")
 
         edge_vertices = g.EdgeVertices()

--- a/molecularnodes/nodes/geometry/ensemble_instance.py
+++ b/molecularnodes/nodes/geometry/ensemble_instance.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Ensemble Instance' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Ensemble Instance" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -133,7 +135,7 @@ class EnsembleInstance(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         points = tree.inputs.geometry("Points")
         selection = tree.inputs.boolean(
             "Selection",

--- a/molecularnodes/nodes/geometry/entity_id.py
+++ b/molecularnodes/nodes/geometry/entity_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Entity ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Entity ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -62,7 +64,7 @@ class EntityID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/evaluate_on_atoms.py
+++ b/molecularnodes/nodes/geometry/evaluate_on_atoms.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Evaluate on Atoms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Evaluate on Atoms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -92,7 +94,7 @@ class EvaluateOnAtoms(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry to get the bundle of"
         )

--- a/molecularnodes/nodes/geometry/evaluate_on_instances.py
+++ b/molecularnodes/nodes/geometry/evaluate_on_instances.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Evaluate on Instances' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Evaluate on Instances" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class EvaluateOnInstances(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Closure": closure})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry to split into two parts"
         )

--- a/molecularnodes/nodes/geometry/evaluate_ordered_bundles.py
+++ b/molecularnodes/nodes/geometry/evaluate_ordered_bundles.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Evaluate Ordered Bundles' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Evaluate Ordered Bundles" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class EvaluateOrderedBundles(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Bundles": bundles, "Prefix": prefix})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         bundles = tree.inputs.bundle("Bundles")
         prefix = tree.inputs.string("Prefix", "MN*", optional_label=True)

--- a/molecularnodes/nodes/geometry/evaluate_per_group.py
+++ b/molecularnodes/nodes/geometry/evaluate_per_group.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Evaluate Per Group' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Evaluate Per Group" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -94,7 +96,7 @@ class EvaluatePerGroup(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry to split into two parts"
         )

--- a/molecularnodes/nodes/geometry/evluate_while_planar.py
+++ b/molecularnodes/nodes/geometry/evluate_while_planar.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Evluate While Planar' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Evluate While Planar" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class EvluateWhilePlanar(AssetGeometryGroup):
             **{"Geometry": geometry, "Selection": selection, "Closure": closure}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry", description="Geometry to transform")
         selection = tree.inputs.boolean(
             "Selection",

--- a/molecularnodes/nodes/geometry/expand_boolean.py
+++ b/molecularnodes/nodes/geometry/expand_boolean.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Expand Boolean' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Expand Boolean" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -67,7 +69,7 @@ class ExpandBoolean(AssetGeometryGroup):
     ):
         super().__init__(**{"Boolean": boolean, "Expand": expand})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean("Boolean", False, hide_value=True)
         expand = tree.inputs.integer("Expand", 0, min_value=-2147483647)
         boolean_1 = tree.outputs.boolean("Boolean")

--- a/molecularnodes/nodes/geometry/fallback_boolean.py
+++ b/molecularnodes/nodes/geometry/fallback_boolean.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Boolean' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Boolean" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class FallbackBoolean(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/fallback_color.py
+++ b/molecularnodes/nodes/geometry/fallback_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class FallbackColor(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "Color",

--- a/molecularnodes/nodes/geometry/fallback_float.py
+++ b/molecularnodes/nodes/geometry/fallback_float.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class FallbackFloat(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/fallback_geometry.py
+++ b/molecularnodes/nodes/geometry/fallback_geometry.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Geometry' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Geometry" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     GeometrySocket,
@@ -65,7 +67,7 @@ class FallbackGeometry(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         fallback = tree.inputs.geometry("Fallback")
         geometry_1 = tree.outputs.geometry("Geometry")

--- a/molecularnodes/nodes/geometry/fallback_integer.py
+++ b/molecularnodes/nodes/geometry/fallback_integer.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Integer' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Integer" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class FallbackInteger(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/fallback_matrix.py
+++ b/molecularnodes/nodes/geometry/fallback_matrix.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Matrix' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Matrix" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class FallbackMatrix(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/fallback_rotation.py
+++ b/molecularnodes/nodes/geometry/fallback_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class FallbackRotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/fallback_vector.py
+++ b/molecularnodes/nodes/geometry/fallback_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fallback Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fallback Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class FallbackVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Name": name, "Fallback": fallback})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         name = tree.inputs.string(
             "Name",
             "",

--- a/molecularnodes/nodes/geometry/field_remap.py
+++ b/molecularnodes/nodes/geometry/field_remap.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Field Remap' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Field Remap" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -91,7 +93,7 @@ class FieldRemap(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         field = tree.inputs.float(
             "Field",
             0.0,

--- a/molecularnodes/nodes/geometry/find_bonded_atom.py
+++ b/molecularnodes/nodes/geometry/find_bonded_atom.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Find Bonded Atom' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Find Bonded Atom" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -169,7 +171,7 @@ class FindBondedAtom(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         method = tree.inputs.menu("Method", optional_label=True)
         atom_name = tree.inputs.menu("Atom Name", optional_label=True)

--- a/molecularnodes/nodes/geometry/find_bonds.py
+++ b/molecularnodes/nodes/geometry/find_bonds.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Find Bonds' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Find Bonds" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -79,7 +81,7 @@ class FindBonds(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms, "Selection": selection, "Scale": scale})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/fractionate_float.py
+++ b/molecularnodes/nodes/geometry/fractionate_float.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Fractionate Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Fractionate Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class FractionateFloat(AssetGeometryGroup):
     ):
         super().__init__(**{"Menu": menu, "Value": value})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         menu = tree.inputs.menu("Menu", expanded=True, optional_label=True)
         value = tree.inputs.float("Value", 0.0, description="The value to fractionate")
         fraction = tree.outputs.float(

--- a/molecularnodes/nodes/geometry/frame_id.py
+++ b/molecularnodes/nodes/geometry/frame_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Frame ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Frame ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -62,7 +64,7 @@ class FrameID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/geoemtry_to_planar.py
+++ b/molecularnodes/nodes/geometry/geoemtry_to_planar.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Geoemtry to Planar' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Geoemtry to Planar" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class GeoemtryToPlanar(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Selection": selection})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry", description="Geometry to transform")
         selection = tree.inputs.boolean(
             "Selection",

--- a/molecularnodes/nodes/geometry/geometry_field_remap.py
+++ b/molecularnodes/nodes/geometry/geometry_field_remap.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Geometry Field Remap' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Geometry Field Remap" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -91,7 +93,7 @@ class GeometryFieldRemap(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry to get the statistics from"
         )

--- a/molecularnodes/nodes/geometry/get_geometry_atoms.py
+++ b/molecularnodes/nodes/geometry/get_geometry_atoms.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Get Geometry Atoms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Get Geometry Atoms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -67,7 +69,7 @@ class GetGeometryAtoms(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="Geometry to get the bundle of"
         )

--- a/molecularnodes/nodes/geometry/group_info.py
+++ b/molecularnodes/nodes/geometry/group_info.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Group Info' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Group Info" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class GroupInfo(AssetGeometryGroup):
     ):
         super().__init__(**{"Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         group_id = tree.inputs.integer("Group ID", 0, hide_value=True)
         size = tree.outputs.integer("Size")
         index_in_group = tree.outputs.integer("Index in Group")

--- a/molecularnodes/nodes/geometry/group_parameter.py
+++ b/molecularnodes/nodes/geometry/group_parameter.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Group Parameter' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Group Parameter" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -71,7 +73,7 @@ class GroupParameter(AssetGeometryGroup):
     ):
         super().__init__(**{"Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         group_id = tree.inputs.integer(
             "Group ID",
             0,

--- a/molecularnodes/nodes/geometry/group_pick.py
+++ b/molecularnodes/nodes/geometry/group_pick.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Group Pick' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Group Pick" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -74,7 +76,7 @@ class GroupPick(AssetGeometryGroup):
     ):
         super().__init__(**{"Pick": pick, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         pick = tree.inputs.boolean(
             "Pick",
             False,

--- a/molecularnodes/nodes/geometry/group_pick_first.py
+++ b/molecularnodes/nodes/geometry/group_pick_first.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Group Pick First' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Group Pick First" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class GroupPickFirst(AssetGeometryGroup):
     ):
         super().__init__(**{"Pick": pick, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         pick = tree.inputs.boolean(
             "Pick",
             False,

--- a/molecularnodes/nodes/geometry/group_pick_index.py
+++ b/molecularnodes/nodes/geometry/group_pick_index.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Group Pick Index' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Group Pick Index" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class GroupPickIndex(AssetGeometryGroup):
     ):
         super().__init__(**{"Relative Index": relative_index, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         relative_index = tree.inputs.integer(
             "Relative Index", 0, min_value=0, hide_value=True
         )

--- a/molecularnodes/nodes/geometry/group_pick_vector.py
+++ b/molecularnodes/nodes/geometry/group_pick_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Group Pick Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Group Pick Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -83,7 +85,7 @@ class GroupPickVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Pick": pick, "Group ID": group_id, "Position": position})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         pick = tree.inputs.boolean(
             "Pick",
             False,

--- a/molecularnodes/nodes/geometry/index_distance.py
+++ b/molecularnodes/nodes/geometry/index_distance.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Index Distance' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Index Distance" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -91,7 +93,7 @@ class IndexDistance(AssetGeometryGroup):
             **{"Index": index, "Target Index": target_index, "Position": position}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         target_index = tree.inputs.integer(
             "Target Index",

--- a/molecularnodes/nodes/geometry/index_mix_color.py
+++ b/molecularnodes/nodes/geometry/index_mix_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Index Mix Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Index Mix Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class IndexMixColor(AssetGeometryGroup):
     ):
         super().__init__(**{"Color": color, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color = tree.inputs.color(
             "Color",
             (1.0, 1.0, 1.0, 1.0),

--- a/molecularnodes/nodes/geometry/index_mix_float.py
+++ b/molecularnodes/nodes/geometry/index_mix_float.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Index Mix Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Index Mix Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class IndexMixFloat(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.float(
             "Value",
             0.0,

--- a/molecularnodes/nodes/geometry/index_mix_rotation.py
+++ b/molecularnodes/nodes/geometry/index_mix_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Index Mix Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Index Mix Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class IndexMixRotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Rotation": rotation, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         rotation = tree.inputs.rotation(
             "Rotation",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/index_mix_vector.py
+++ b/molecularnodes/nodes/geometry/index_mix_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Index Mix Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Index Mix Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class IndexMixVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.vector(
             "Value",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/integer_distance.py
+++ b/molecularnodes/nodes/geometry/integer_distance.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Integer Distance' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Integer Distance" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -76,7 +78,7 @@ class IntegerDistance(AssetGeometryGroup):
     ):
         super().__init__(**{"A": a, "B": b, "Distance": distance})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.integer("A", 0)
         b = tree.inputs.integer("B", 0)
         distance = tree.inputs.integer("Distance", 2)

--- a/molecularnodes/nodes/geometry/integer_run.py
+++ b/molecularnodes/nodes/geometry/integer_run.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Integer Run' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Integer Run" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class IntegerRun(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.integer(
             "Value",
             0,

--- a/molecularnodes/nodes/geometry/is_alpha_carbon.py
+++ b/molecularnodes/nodes/geometry/is_alpha_carbon.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Alpha Carbon' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Alpha Carbon" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -72,7 +74,7 @@ class IsAlphaCarbon(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_backbone.py
+++ b/molecularnodes/nodes/geometry/is_backbone.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Backbone' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Backbone" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -73,7 +75,7 @@ class IsBackbone(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_backbone_edge.py
+++ b/molecularnodes/nodes/geometry/is_backbone_edge.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Backbone Edge' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Backbone Edge" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -47,7 +49,7 @@ class IsBackboneEdge(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         is_backbone_edge = tree.outputs.boolean(
             "Is Backbone Edge", attribute_domain="EDGE"
         )

--- a/molecularnodes/nodes/geometry/is_boundary_edge.py
+++ b/molecularnodes/nodes/geometry/is_boundary_edge.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Boundary Edge' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Boundary Edge" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -59,7 +61,7 @@ class IsBoundaryEdge(AssetGeometryGroup):
     ):
         super().__init__(**{"Mask": mask})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         mask = tree.inputs.boolean("Mask", True, hide_value=True)
         selection = tree.outputs.boolean(
             "Selection", description="The calculated selection"

--- a/molecularnodes/nodes/geometry/is_even.py
+++ b/molecularnodes/nodes/geometry/is_even.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Even' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Even" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -62,7 +64,7 @@ class IsEven(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.integer("Value", 0, default_input="INDEX")
         even = tree.outputs.boolean("Even")
         odd = tree.outputs.boolean("Odd")

--- a/molecularnodes/nodes/geometry/is_helix.py
+++ b/molecularnodes/nodes/geometry/is_helix.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Helix' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Helix" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -70,7 +72,7 @@ class IsHelix(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_hydrogen.py
+++ b/molecularnodes/nodes/geometry/is_hydrogen.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Hydrogen' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Hydrogen" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -71,7 +73,7 @@ class IsHydrogen(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_lipid.py
+++ b/molecularnodes/nodes/geometry/is_lipid.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Lipid' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Lipid" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -70,7 +72,7 @@ class IsLipid(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_loop.py
+++ b/molecularnodes/nodes/geometry/is_loop.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Loop' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Loop" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -70,7 +72,7 @@ class IsLoop(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_nucleic.py
+++ b/molecularnodes/nodes/geometry/is_nucleic.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Nucleic' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Nucleic" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -72,7 +74,7 @@ class IsNucleic(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_peptide.py
+++ b/molecularnodes/nodes/geometry/is_peptide.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Peptide' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Peptide" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -72,7 +74,7 @@ class IsPeptide(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_sheet.py
+++ b/molecularnodes/nodes/geometry/is_sheet.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Sheet' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Sheet" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -70,7 +72,7 @@ class IsSheet(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_side_chain.py
+++ b/molecularnodes/nodes/geometry/is_side_chain.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Side Chain' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Side Chain" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -82,7 +84,7 @@ class IsSideChain(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Include CA": include_ca})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/is_solvent.py
+++ b/molecularnodes/nodes/geometry/is_solvent.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Is Solvent' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Is Solvent" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -70,7 +72,7 @@ class IsSolvent(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/lag_geometry.py
+++ b/molecularnodes/nodes/geometry/lag_geometry.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Lag Geometry' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Lag Geometry" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -96,7 +98,7 @@ class LagGeometry(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         input = tree.inputs.geometry("Input")
         selection = tree.inputs.boolean(
             "Selection",

--- a/molecularnodes/nodes/geometry/lattice_grid.py
+++ b/molecularnodes/nodes/geometry/lattice_grid.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Lattice Grid' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Lattice Grid" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -95,7 +97,7 @@ class LatticeGrid(AssetGeometryGroup):
     ):
         super().__init__(**{"A": a, "B": b, "C": c, "X": x, "Y": y, "Z": z})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.vector("A", (0.0, 0.0, 1.0), subtype="XYZ")
         b = tree.inputs.vector("B", (0.0, 0.0, 1.0), subtype="XYZ")
         c_ = tree.inputs.vector("C", (0.0, 0.0, 1.0), subtype="XYZ")

--- a/molecularnodes/nodes/geometry/lch_to_color.py
+++ b/molecularnodes/nodes/geometry/lch_to_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'LCh to Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "LCh to Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -73,7 +75,7 @@ class LChToColor(AssetGeometryGroup):
     ):
         super().__init__(**{"L": l, "C": c, "h": h})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         l = tree.inputs.float("L", 0.0)
         c_ = tree.inputs.float("C", 0.0)
         h = tree.inputs.float("h", 0.0, subtype="ANGLE")

--- a/molecularnodes/nodes/geometry/lch_to_oklab.py
+++ b/molecularnodes/nodes/geometry/lch_to_oklab.py
@@ -1,7 +1,9 @@
-# Node-group asset 'LCh to OKLab' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "LCh to OKLab" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class LChToOKLab(AssetGeometryGroup):
     ):
         super().__init__(**{"L": l, "C": c, "h": h})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         l = tree.inputs.float("L", 0.0)
         c_ = tree.inputs.float("C", 0.0)
         h = tree.inputs.float("h", 0.0, subtype="ANGLE")

--- a/molecularnodes/nodes/geometry/mass.py
+++ b/molecularnodes/nodes/geometry/mass.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Mass' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Mass" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -60,7 +62,7 @@ class Mass(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         mass = tree.outputs.float(
             "mass", description="Read the `mass` attribute from the geometry"

--- a/molecularnodes/nodes/geometry/menu_atom_name.py
+++ b/molecularnodes/nodes/geometry/menu_atom_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Menu Atom Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Menu Atom Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -139,7 +141,7 @@ class MenuAtomName(AssetGeometryGroup):
     ):
         super().__init__(**{"Atom Name": atom_name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atom_name = tree.inputs.menu("Atom Name", optional_label=True)
         atom_name_1 = tree.outputs.integer("atom_name")
         selection = tree.outputs.boolean("Selection")

--- a/molecularnodes/nodes/geometry/menu_residue_mask.py
+++ b/molecularnodes/nodes/geometry/menu_residue_mask.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Menu Residue Mask' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Menu Residue Mask" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -141,7 +143,7 @@ class MenuResidueMask(AssetGeometryGroup):
     ):
         super().__init__(**{"Atom Name": atom_name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atom_name = tree.inputs.menu("Atom Name", optional_label=True)
         is_valid = tree.outputs.boolean(
             "Is Valid",

--- a/molecularnodes/nodes/geometry/menu_residue_name.py
+++ b/molecularnodes/nodes/geometry/menu_residue_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Menu Residue Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Menu Residue Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -107,7 +109,7 @@ class MenuResidueName(AssetGeometryGroup):
     ):
         super().__init__(**{"Residue Name": residue_name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         residue_name = tree.inputs.menu("Residue Name", optional_label=True)
         res_name = tree.outputs.integer("res_name")
         selection = tree.outputs.boolean("Selection")

--- a/molecularnodes/nodes/geometry/mn_typed_bundles.py
+++ b/molecularnodes/nodes/geometry/mn_typed_bundles.py
@@ -1,7 +1,9 @@
-# Node-group asset 'MN Typed Bundles' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "MN Typed Bundles" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -84,7 +86,7 @@ class MNTypedBundles(AssetGeometryGroup):
             **{"Type": type, "Closure": closure, "step": step, "Path": path}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         type = tree.inputs.menu("Type", optional_label=True)
         closure = tree.inputs.closure("Closure")
         step = tree.inputs.integer("step", 1)

--- a/molecularnodes/nodes/geometry/n2_index_angle.py
+++ b/molecularnodes/nodes/geometry/n2_index_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset '2 Index Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "2 Index Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -89,7 +91,7 @@ class Group2IndexAngle(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/n3_index_angle.py
+++ b/molecularnodes/nodes/geometry/n3_index_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset '3 Index Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "3 Index Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class Group3IndexAngle(AssetGeometryGroup):
     ):
         super().__init__(**{"Index A": index_a, "Index B": index_b, "Index C": index_c})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index_a = tree.inputs.integer(
             "Index A",
             0,

--- a/molecularnodes/nodes/geometry/normalize_field.py
+++ b/molecularnodes/nodes/geometry/normalize_field.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Normalize Field' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Normalize Field" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -66,7 +68,7 @@ class NormalizeField(AssetGeometryGroup):
     ):
         super().__init__(**{"Field": field, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         field = tree.inputs.float("Field", 0.0)
         group_id = tree.inputs.integer(
             "Group ID",

--- a/molecularnodes/nodes/geometry/nucleic_chi.py
+++ b/molecularnodes/nodes/geometry/nucleic_chi.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Nucleic Chi' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Nucleic Chi" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -77,7 +79,7 @@ class NucleicChi(AssetGeometryGroup):
     ):
         super().__init__(**{"Position": position, "Selection": selection, "X1": x1})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position", (0.0, 0.0, 0.0), hide_value=True, default_input="POSITION"
         )

--- a/molecularnodes/nodes/geometry/nucleic_dihedral.py
+++ b/molecularnodes/nodes/geometry/nucleic_dihedral.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Nucleic Dihedral' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Nucleic Dihedral" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -121,7 +123,7 @@ class NucleicDihedral(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position", (0.0, 0.0, 0.0), hide_value=True, default_input="POSITION"
         )

--- a/molecularnodes/nodes/geometry/offset_boolean.py
+++ b/molecularnodes/nodes/geometry/offset_boolean.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Boolean' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Boolean" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -74,7 +76,7 @@ class OffsetBoolean(AssetGeometryGroup):
     ):
         super().__init__(**{"Boolean": boolean, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean(
             "Boolean",
             False,

--- a/molecularnodes/nodes/geometry/offset_color.py
+++ b/molecularnodes/nodes/geometry/offset_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -74,7 +76,7 @@ class OffsetColor(AssetGeometryGroup):
     ):
         super().__init__(**{"Color": color, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color = tree.inputs.color(
             "Color", (0.8, 0.8, 0.8, 1.0), hide_value=True, hide_in_modifier=True
         )

--- a/molecularnodes/nodes/geometry/offset_color_attribute.py
+++ b/molecularnodes/nodes/geometry/offset_color_attribute.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Color Attribute' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Color Attribute" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     ColorSocket,
@@ -68,7 +70,7 @@ class OffsetColorAttribute(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index",
             0,

--- a/molecularnodes/nodes/geometry/offset_curve.py
+++ b/molecularnodes/nodes/geometry/offset_curve.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Curve' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Curve" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class OffsetCurve(AssetGeometryGroup):
     ):
         super().__init__(**{"Curve": curve, "Points": points})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         points = tree.inputs.float(
             "Points",

--- a/molecularnodes/nodes/geometry/offset_float.py
+++ b/molecularnodes/nodes/geometry/offset_float.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -74,7 +76,7 @@ class OffsetFloat(AssetGeometryGroup):
     ):
         super().__init__(**{"Value": value, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.float(
             "Value",
             0.0,

--- a/molecularnodes/nodes/geometry/offset_index.py
+++ b/molecularnodes/nodes/geometry/offset_index.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Index' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Index" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -65,7 +67,7 @@ class OffsetIndex(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index",
             0,

--- a/molecularnodes/nodes/geometry/offset_integer.py
+++ b/molecularnodes/nodes/geometry/offset_integer.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Integer' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Integer" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -73,7 +75,7 @@ class OffsetInteger(AssetGeometryGroup):
     ):
         super().__init__(**{"Integer": integer, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         integer = tree.inputs.integer(
             "Integer",
             0,

--- a/molecularnodes/nodes/geometry/offset_matrix.py
+++ b/molecularnodes/nodes/geometry/offset_matrix.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Matrix' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Matrix" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -74,7 +76,7 @@ class OffsetMatrix(AssetGeometryGroup):
     ):
         super().__init__(**{"Matrix": matrix, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         matrix = tree.inputs.matrix(
             "Matrix",
             description="The field to evaluate at the given `Index` + `Offset` on the point domain",

--- a/molecularnodes/nodes/geometry/offset_point_along_curve.py
+++ b/molecularnodes/nodes/geometry/offset_point_along_curve.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Point Along Curve' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Point Along Curve" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -90,7 +92,7 @@ class OffsetPointAlongCurve(AssetGeometryGroup):
     ):
         super().__init__(**{"Point Index": point_index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         point_index = tree.inputs.integer(
             "Point Index",
             0,

--- a/molecularnodes/nodes/geometry/offset_rotation.py
+++ b/molecularnodes/nodes/geometry/offset_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -74,7 +76,7 @@ class OffsetRotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Rotation": rotation, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         rotation = tree.inputs.rotation(
             "Rotation",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/offset_vector.py
+++ b/molecularnodes/nodes/geometry/offset_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Offset Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Offset Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -74,7 +76,7 @@ class OffsetVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Vector": vector, "Index": index, "Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vector = tree.inputs.vector(
             "Vector",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/oklab_offset_lch.py
+++ b/molecularnodes/nodes/geometry/oklab_offset_lch.py
@@ -1,7 +1,9 @@
-# Node-group asset 'OKLab Offset LCh' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "OKLab Offset LCh" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -73,7 +75,7 @@ class OKLabOffsetLCh(AssetGeometryGroup):
     ):
         super().__init__(**{"OKLab": oklab, "L": l, "h": h})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         oklab = tree.inputs.vector(
             "OKLab", (0.64, 0.0, 0.0001), min_value=-10_000.0, max_value=10_000.0
         )

--- a/molecularnodes/nodes/geometry/oklab_to_color.py
+++ b/molecularnodes/nodes/geometry/oklab_to_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'OKLab to Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "OKLab to Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -60,7 +62,7 @@ class OKLabToColor(AssetGeometryGroup):
     ):
         super().__init__(**{"OKLab": oklab})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         oklab = tree.inputs.vector("OKLab", (0.0, 0.0, 0.0))
         color = tree.outputs.color("Color", (0.0, 0.0, 0.0, 1.0))
 

--- a/molecularnodes/nodes/geometry/oklab_to_lch.py
+++ b/molecularnodes/nodes/geometry/oklab_to_lch.py
@@ -1,7 +1,9 @@
-# Node-group asset 'OKLab to LCh' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "OKLab to LCh" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -66,7 +68,7 @@ class OKLabToLCh(AssetGeometryGroup):
     ):
         super().__init__(**{"OKLab": oklab})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         oklab = tree.inputs.vector(
             "OKLab", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0
         )

--- a/molecularnodes/nodes/geometry/oxdna_normal.py
+++ b/molecularnodes/nodes/geometry/oxdna_normal.py
@@ -1,7 +1,9 @@
-# Node-group asset 'oxDNA Normal' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "oxDNA Normal" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -58,7 +60,7 @@ class OxDNANormal(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         base_normal = tree.outputs.vector("base_normal")
 

--- a/molecularnodes/nodes/geometry/oxdna_offset.py
+++ b/molecularnodes/nodes/geometry/oxdna_offset.py
@@ -1,7 +1,9 @@
-# Node-group asset 'oxDNA Offset' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "oxDNA Offset" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -61,7 +63,7 @@ class OxDNAOffset(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/oxdna_rotation.py
+++ b/molecularnodes/nodes/geometry/oxdna_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'oxDNA Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "oxDNA Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -61,7 +63,7 @@ class OxDNARotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         rotation = tree.outputs.rotation("Rotation")
 

--- a/molecularnodes/nodes/geometry/oxdna_style_ribbon.py
+++ b/molecularnodes/nodes/geometry/oxdna_style_ribbon.py
@@ -1,8 +1,10 @@
-# Node-group asset 'oxDNA Style Ribbon' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "oxDNA Style Ribbon" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -40,7 +42,7 @@ class Utils_oxdna_base(CustomGeometryGroup):
     _name = ".utils_oxdna_base"
     _tree_properties = {"node_tool_idname": "geometry._utils_oxdna_base"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         value = tree.inputs.float("Value", 0.5, min_value=-10_000.0, max_value=10_000.0)
         value_1 = tree.inputs.float(
             "Value", 0.5, min_value=-10_000.0, max_value=10_000.0
@@ -205,7 +207,7 @@ class OxDNAStyleRibbon(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         selection = tree.inputs.boolean(
             "Selection",

--- a/molecularnodes/nodes/geometry/oxdna_vector.py
+++ b/molecularnodes/nodes/geometry/oxdna_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'oxDNA Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "oxDNA Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -58,7 +60,7 @@ class OxDNAVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         base_vector = tree.outputs.vector("base_vector")
 

--- a/molecularnodes/nodes/geometry/peptide_chi.py
+++ b/molecularnodes/nodes/geometry/peptide_chi.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Peptide Chi' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Peptide Chi" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -120,7 +122,7 @@ class PeptideChi(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position", (0.0, 0.0, 0.0), subtype="XYZ", default_input="POSITION"
         )

--- a/molecularnodes/nodes/geometry/peptide_dihedral.py
+++ b/molecularnodes/nodes/geometry/peptide_dihedral.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Peptide Dihedral' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Peptide Dihedral" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -93,7 +95,7 @@ class PeptideDihedral(AssetGeometryGroup):
             **{"Position": position, "Selection": selection, "Phi": phi, "Psi": psi}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         position = tree.inputs.vector(
             "Position", (0.0, 0.0, 0.0), hide_value=True, default_input="POSITION"
         )

--- a/molecularnodes/nodes/geometry/periodic_array.py
+++ b/molecularnodes/nodes/geometry/periodic_array.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Periodic Array' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Periodic Array" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -141,7 +143,7 @@ class PeriodicArray(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         with tree.inputs.panel("Periodic Box", default_closed=True):
             update = tree.inputs.boolean(

--- a/molecularnodes/nodes/geometry/periodic_box.py
+++ b/molecularnodes/nodes/geometry/periodic_box.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Periodic Box' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Periodic Box" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -115,7 +117,7 @@ class PeriodicBox(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         _update = tree.inputs.boolean(
             "Update",
             True,

--- a/molecularnodes/nodes/geometry/periodic_image.py
+++ b/molecularnodes/nodes/geometry/periodic_image.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Periodic Image' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Periodic Image" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -104,7 +106,7 @@ class PeriodicImage(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.vector(
             "A", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0, subtype="XYZ"
         )

--- a/molecularnodes/nodes/geometry/plexus.py
+++ b/molecularnodes/nodes/geometry/plexus.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Plexus' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Plexus" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -84,7 +86,7 @@ class Plexus(AssetGeometryGroup):
             **{"Points": points, "Sort": sort, "Distance": distance, "Radius": radius}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         points = tree.inputs.geometry("Points")
         sort = tree.inputs.boolean(
             "Sort",

--- a/molecularnodes/nodes/geometry/point_edge_angle.py
+++ b/molecularnodes/nodes/geometry/point_edge_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Point Edge Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Point Edge Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -100,7 +102,7 @@ class PointEdgeAngle(AssetGeometryGroup):
             **{"Vertex Index": vertex_index, "Edge A": edge_a, "Edge B": edge_b}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vertex_index = tree.inputs.integer(
             "Vertex Index",
             0,

--- a/molecularnodes/nodes/geometry/points_of_edge.py
+++ b/molecularnodes/nodes/geometry/points_of_edge.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Points of Edge' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Points of Edge" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -83,7 +85,7 @@ class PointsOfEdge(AssetGeometryGroup):
     ):
         super().__init__(**{"Vertex Index": vertex_index, "Edge Index": edge_index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vertex_index = tree.inputs.integer(
             "Vertex Index", 0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/primitive_arrow.py
+++ b/molecularnodes/nodes/geometry/primitive_arrow.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Primitive Arrow' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Primitive Arrow" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -99,7 +101,7 @@ class PrimitiveArrow(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vertices = tree.inputs.integer("Vertices", 6, min_value=3, max_value=16)
         height = tree.inputs.float(
             "Height", 1.0, min_value=0.0, max_value=10_000.0, subtype="DISTANCE"

--- a/molecularnodes/nodes/geometry/primitive_gimbal.py
+++ b/molecularnodes/nodes/geometry/primitive_gimbal.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Primitive Gimbal' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Primitive Gimbal" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -109,7 +111,7 @@ class PrimitiveGimbal(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         vertices = tree.inputs.integer("Vertices", 6, min_value=3, max_value=16)
         x = tree.inputs.color("X", (0.623968, 0.01033, 0.063011, 1.0))
         y = tree.inputs.color("Y", (0.076185, 0.623968, 0.084375, 1.0))

--- a/molecularnodes/nodes/geometry/random_color.py
+++ b/molecularnodes/nodes/geometry/random_color.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Random Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Random Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -116,7 +118,7 @@ class RandomColor(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         id = tree.inputs.integer("ID", 0, hide_value=True, default_input="ID_OR_INDEX")
         color_seed = tree.inputs.integer(
             "Color Seed",

--- a/molecularnodes/nodes/geometry/relative_index.py
+++ b/molecularnodes/nodes/geometry/relative_index.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Relative Index' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Relative Index" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -76,7 +78,7 @@ class RelativeIndex(AssetGeometryGroup):
     ):
         super().__init__(**{"Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         group_id = tree.inputs.integer(
             "Group ID",
             0,

--- a/molecularnodes/nodes/geometry/residue_dihedral_angle.py
+++ b/molecularnodes/nodes/geometry/residue_dihedral_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Residue Dihedral Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Residue Dihedral Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -87,7 +89,7 @@ class ResidueDihedralAngle(AssetGeometryGroup):
     ):
         super().__init__(**{"A": a, "C": c, "D": d})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.integer(
             "A", 6, description="Atom to pick from the group", min_value=2
         )

--- a/molecularnodes/nodes/geometry/residue_id.py
+++ b/molecularnodes/nodes/geometry/residue_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Residue ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Residue ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -59,7 +61,7 @@ class ResidueID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/residue_mask.py
+++ b/molecularnodes/nodes/geometry/residue_mask.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Residue Mask' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Residue Mask" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class ResidueMask(AssetGeometryGroup):
     ):
         super().__init__(**{"atom_name": atom_name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atom_name = tree.inputs.integer(
             "atom_name", 1, description="Atom to pick from the group", min_value=2
         )

--- a/molecularnodes/nodes/geometry/residue_name.py
+++ b/molecularnodes/nodes/geometry/residue_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Residue Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Residue Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -59,7 +61,7 @@ class ResidueName(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/residue_parameter.py
+++ b/molecularnodes/nodes/geometry/residue_parameter.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Residue Parameter' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Residue Parameter" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -73,7 +75,7 @@ class ResidueParameter(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         factor = tree.outputs.float(
             "Factor",
             description="An atom's relative position in a residue, with the first atom being 0 and the last atom being 1",

--- a/molecularnodes/nodes/geometry/rotation_cistem.py
+++ b/molecularnodes/nodes/geometry/rotation_cistem.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Rotation cisTEM' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Rotation cisTEM" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -48,7 +50,7 @@ class RotationCisTEM(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         rotation = tree.outputs.rotation("Rotation")
         is_valid = tree.outputs.boolean("Is Valid")
 

--- a/molecularnodes/nodes/geometry/rotation_from_zyz.py
+++ b/molecularnodes/nodes/geometry/rotation_from_zyz.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Rotation from ZYZ' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Rotation from ZYZ" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class RotationFromZYZ(AssetGeometryGroup):
     ):
         super().__init__(**{"Phi": phi, "Theta": theta, "Psi": psi})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         phi = tree.inputs.float(
             "Phi",
             0.0,

--- a/molecularnodes/nodes/geometry/rotation_relion.py
+++ b/molecularnodes/nodes/geometry/rotation_relion.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Rotation RELION' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Rotation RELION" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -48,7 +50,7 @@ class RotationRELION(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         rotation = tree.outputs.rotation("Rotation")
         is_valid = tree.outputs.boolean("Is Valid")
 

--- a/molecularnodes/nodes/geometry/sample_mix_float.py
+++ b/molecularnodes/nodes/geometry/sample_mix_float.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Mix Float' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Mix Float" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -94,7 +96,7 @@ class SampleMixFloat(AssetGeometryGroup):
             **{"A": a, "B": b, "Value": value, "Factor": factor, "Index": index}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.geometry("A", description="Geometry A to sample and mix from")
         b = tree.inputs.geometry("B", description="Geometry B to sample and mix to")
         value = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/sample_mix_vector.py
+++ b/molecularnodes/nodes/geometry/sample_mix_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Mix Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Mix Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -92,7 +94,7 @@ class SampleMixVector(AssetGeometryGroup):
             **{"A": a, "B": b, "Position": position, "Factor": factor, "Index": index}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.geometry("A", description="Geometry A to sample and mix from")
         b = tree.inputs.geometry("B", description="Geometry B to sample and mix to")
         position = tree.inputs.vector(

--- a/molecularnodes/nodes/geometry/sample_mixed_color.py
+++ b/molecularnodes/nodes/geometry/sample_mixed_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Mixed Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Mixed Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class SampleMixedColor(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Color": color, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="The geometry to sample the values from"
         )

--- a/molecularnodes/nodes/geometry/sample_mixed_rotation.py
+++ b/molecularnodes/nodes/geometry/sample_mixed_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Mixed Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Mixed Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class SampleMixedRotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Rotation": rotation, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="The geometry to sample the values from"
         )

--- a/molecularnodes/nodes/geometry/sample_mixed_vector.py
+++ b/molecularnodes/nodes/geometry/sample_mixed_vector.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Mixed Vector' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Mixed Vector" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class SampleMixedVector(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Vector": vector, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="The geometry to sample the values from"
         )

--- a/molecularnodes/nodes/geometry/sample_nearest_atoms.py
+++ b/molecularnodes/nodes/geometry/sample_nearest_atoms.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Nearest Atoms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Nearest Atoms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -82,7 +84,7 @@ class SampleNearestAtoms(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/sample_position.py
+++ b/molecularnodes/nodes/geometry/sample_position.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sample Position' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sample Position" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -78,7 +80,7 @@ class SamplePosition(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Position": position, "Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry", description="The geometry to sample the `Position` from"
         )

--- a/molecularnodes/nodes/geometry/secondary_structure.py
+++ b/molecularnodes/nodes/geometry/secondary_structure.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Secondary Structure' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Secondary Structure" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -58,7 +60,7 @@ class SecondaryStructure(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/select_atomic_number.py
+++ b/molecularnodes/nodes/geometry/select_atomic_number.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Atomic Number' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Atomic Number" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -79,7 +81,7 @@ class SelectAtomicNumber(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "atomic_number": atomic_number})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_attribute.py
+++ b/molecularnodes/nodes/geometry/select_attribute.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Attribute' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Attribute" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -78,7 +80,7 @@ class SelectAttribute(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Name": name})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_bonded.py
+++ b/molecularnodes/nodes/geometry/select_bonded.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Bonded' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Bonded" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -72,7 +74,7 @@ class SelectBonded(AssetGeometryGroup):
     ):
         super().__init__(**{"Selection": selection, "Depth": depth})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean(
             "Selection",
             False,

--- a/molecularnodes/nodes/geometry/select_cube.py
+++ b/molecularnodes/nodes/geometry/select_cube.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Select Cube' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Cube" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
 import bpy
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -81,7 +83,7 @@ class SelectCube(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Object": object})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_element.py
+++ b/molecularnodes/nodes/geometry/select_element.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Element' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Element" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -717,7 +719,7 @@ class SelectElement(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_nucleic_type.py
+++ b/molecularnodes/nodes/geometry/select_nucleic_type.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Nucleic Type' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Nucleic Type" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class SelectNucleicType(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_proximity.py
+++ b/molecularnodes/nodes/geometry/select_proximity.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Proximity' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Proximity" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -95,7 +97,7 @@ class SelectProximity(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         target_atoms = tree.inputs.geometry(
             "Target Atoms", description="The atoms to measure the distance from."
         )

--- a/molecularnodes/nodes/geometry/select_res_id.py
+++ b/molecularnodes/nodes/geometry/select_res_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Res ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Res ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -79,7 +81,7 @@ class SelectResID(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Res ID": res_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_res_id_range.py
+++ b/molecularnodes/nodes/geometry/select_res_id_range.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Res ID Range' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Res ID Range" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -86,7 +88,7 @@ class SelectResIDRange(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Min": min, "Max": max})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_res_id_string.py
+++ b/molecularnodes/nodes/geometry/select_res_id_string.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Res ID String' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Res ID String" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -60,7 +62,7 @@ class SelectResIDString(AssetGeometryGroup):
     ):
         super().__init__(**{"String": string})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         string = tree.inputs.string("String", "", optional_label=True)
         selection = tree.outputs.boolean("Selection")
 

--- a/molecularnodes/nodes/geometry/select_res_name.py
+++ b/molecularnodes/nodes/geometry/select_res_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Res Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Res Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -301,7 +303,7 @@ class SelectResName(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/select_res_whole.py
+++ b/molecularnodes/nodes/geometry/select_res_whole.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Select Res Whole' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Res Whole" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -67,7 +69,7 @@ class SelectResWhole(AssetGeometryGroup):
     ):
         super().__init__(**{"Selection": selection, "Expand": expand})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         selection = tree.inputs.boolean(
             "Selection",
             False,

--- a/molecularnodes/nodes/geometry/select_sphere.py
+++ b/molecularnodes/nodes/geometry/select_sphere.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Select Sphere' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Select Sphere" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
 import bpy
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -80,7 +82,7 @@ class SelectSphere(AssetGeometryGroup):
     ):
         super().__init__(**{"And": and_, "Or": or_, "Object": object})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         and_ = tree.inputs.boolean(
             "And",
             True,

--- a/molecularnodes/nodes/geometry/selected_instances.py
+++ b/molecularnodes/nodes/geometry/selected_instances.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Selected Instances' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Selected Instances" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class SelectedInstances(AssetGeometryGroup):
     ):
         super().__init__(**{"Instances": instances, "Selection": selection})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         instances = tree.inputs.geometry(
             "Instances",
             description="Geometry containing instances to check if they are selected or not",

--- a/molecularnodes/nodes/geometry/separate_atoms.py
+++ b/molecularnodes/nodes/geometry/separate_atoms.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Separate Atoms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Separate Atoms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -77,7 +79,7 @@ class SeparateAtoms(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms, "Selection": selection})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/separate_first_point.py
+++ b/molecularnodes/nodes/geometry/separate_first_point.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Separate First Point' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Separate First Point" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -78,7 +80,7 @@ class SeparateFirstPoint(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry, "Sort": sort, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry", hide_value=True)
         sort = tree.inputs.boolean(
             "Sort",

--- a/molecularnodes/nodes/geometry/separate_polymers.py
+++ b/molecularnodes/nodes/geometry/separate_polymers.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Separate Polymers' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Separate Polymers" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -69,7 +71,7 @@ class SeparatePolymers(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/set_chi_angle.py
+++ b/molecularnodes/nodes/geometry/set_chi_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Set Chi Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Set Chi Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -115,7 +117,7 @@ class SetChiAngle(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         x1 = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/set_color.py
+++ b/molecularnodes/nodes/geometry/set_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Set Color' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Set Color" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -75,7 +77,7 @@ class SetColor(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms, "Selection": selection, "Color": color})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/set_nucleic_dihedral.py
+++ b/molecularnodes/nodes/geometry/set_nucleic_dihedral.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Set Nucleic Dihedral' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Set Nucleic Dihedral" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -114,7 +116,7 @@ class SetNucleicDihedral(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         selection = tree.inputs.boolean(
             "Selection",

--- a/molecularnodes/nodes/geometry/set_phi_psi_angle.py
+++ b/molecularnodes/nodes/geometry/set_phi_psi_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Set Phi Psi Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Set Phi Psi Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -86,7 +88,7 @@ class SetPhiPsiAngle(AssetGeometryGroup):
             **{"Geometry": geometry, "Selection": selection, "Phi": phi, "Psi": psi}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         phi = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/set_ures_id.py
+++ b/molecularnodes/nodes/geometry/set_ures_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Set URes ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Set URes ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -59,7 +61,7 @@ class SetUResID(AssetGeometryGroup):
     ):
         super().__init__(**{"Geometry": geometry})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         geometry_1 = tree.outputs.geometry("Geometry")
 

--- a/molecularnodes/nodes/geometry/slice_edge_instances.py
+++ b/molecularnodes/nodes/geometry/slice_edge_instances.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Slice Edge Instances' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Slice Edge Instances" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -71,7 +73,7 @@ class SliceEdgeInstances(AssetGeometryGroup):
     ):
         super().__init__(**{"Instances": instances, "Selection": selection})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         instances = tree.inputs.geometry("Instances")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         instances_1 = tree.outputs.geometry("Instances")

--- a/molecularnodes/nodes/geometry/split_to_centred_instances.py
+++ b/molecularnodes/nodes/geometry/split_to_centred_instances.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Split to Centred Instances' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Split to Centred Instances" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -79,7 +81,7 @@ class SplitToCentredInstances(AssetGeometryGroup):
             **{"Geometry": geometry, "Selection": selection, "Group ID": group_id}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry(
             "Geometry",
             description="The input geometry containing points",

--- a/molecularnodes/nodes/geometry/starfile_instances.py
+++ b/molecularnodes/nodes/geometry/starfile_instances.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Starfile Instances' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Starfile Instances" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -128,7 +130,7 @@ class StarfileInstances(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         points = tree.inputs.geometry("Points")
         point_selection = tree.inputs.menu(
             "Point Selection",

--- a/molecularnodes/nodes/geometry/structure_parameter.py
+++ b/molecularnodes/nodes/geometry/structure_parameter.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Structure Parameter' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Structure Parameter" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -76,7 +78,7 @@ class StructureParameter(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atom_factor = tree.outputs.float(
             "Atom Factor",
             description="Factor of the atom within the structure, which is the relative position of the `Index` within the overall structure between 0 and 1",

--- a/molecularnodes/nodes/geometry/style_ball_and_stick.py
+++ b/molecularnodes/nodes/geometry/style_ball_and_stick.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Style Ball and Stick' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Style Ball and Stick" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -163,7 +165,7 @@ class StyleBallAndStick(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/style_cartoon.py
+++ b/molecularnodes/nodes/geometry/style_cartoon.py
@@ -1,8 +1,10 @@
-# Node-group asset 'Style Cartoon' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Style Cartoon" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -59,7 +61,7 @@ class Tmp_ss_attributes(CustomGeometryGroup):
     _color_tag = "INPUT"
     _tree_properties = {"node_tool_idname": "geometry._tmp_ss_attributes"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         tmp_ss_is_first = tree.outputs.boolean("tmp_ss_is_first")
         tmp_ss_is_last = tree.outputs.boolean("tmp_ss_is_last")
         tmp_ss_size = tree.outputs.integer("tmp_ss_size")
@@ -90,7 +92,7 @@ class SampleFromCACurve(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"node_tool_idname": "geometry._sample_from_ca_curve"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         ca_curve = tree.inputs.geometry("CA Curve")
         offset = tree.inputs.float(
             "Offset", 0.0, min_value=-10_000.0, max_value=10_000.0
@@ -139,7 +141,7 @@ class FixLoopAlignmentIntoAH(CustomGeometryGroup):
     _name = ".Fix Loop Alignment into AH"
     _tree_properties = {"node_tool_idname": "geometry._fix_loop_alignment_into_ah"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         tangent = tree.inputs.vector("Tangent", (0.0, 0.0, 0.0), hide_value=True)
         geometry = tree.outputs.geometry("Geometry")
@@ -203,7 +205,7 @@ class CAToLoops(CustomGeometryGroup):
     _name = ".CA to loops"
     _tree_properties = {"node_tool_idname": "geometry._ca_to_loops"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         subdivisions = tree.inputs.integer("Subdivisions", 12, min_value=1)
         radius = tree.inputs.float(
@@ -318,7 +320,7 @@ class CAToLoops(CustomGeometryGroup):
 class SplitCurves(CustomGeometryGroup):
     _name = "Split Curves"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry("Curves")
         selection = tree.inputs.boolean(
             "Selection", False, description="The calculated selection"
@@ -376,7 +378,7 @@ class SplitCurves(CustomGeometryGroup):
 class NodeGroup(CustomGeometryGroup):
     _name = "NodeGroup"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curves = tree.inputs.geometry(
             "Curves",
             description="Geometry to evaluate the given fields and store the resulting attributes on. All geometry types except volumes are supported",
@@ -490,7 +492,7 @@ class TweakArrowHeads(CustomGeometryGroup):
     _name = ".Tweak Arrow Heads"
     _tree_properties = {"node_tool_idname": "geometry._tweak_arrow_heads"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         rounded = tree.inputs.boolean("Rounded", False)
         input = tree.inputs.float("Input", 0.0)
@@ -542,7 +544,7 @@ class CAToSheet(CustomGeometryGroup):
     _name = ".CA to sheet"
     _tree_properties = {"node_tool_idname": "geometry._ca_to_sheet"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         profile_resolution = tree.inputs.integer(
             "Profile Resolution", 4, min_value=3, max_value=512
@@ -647,7 +649,7 @@ class BooleanShrink(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"node_tool_idname": "geometry.boolean_shrink"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         boolean = tree.inputs.boolean("Boolean", False, hide_value=True)
         shrink = tree.inputs.integer("Shrink", 0, min_value=-2147483647)
         boolean_1 = tree.outputs.boolean("Boolean")
@@ -662,7 +664,7 @@ class CAToHelix(CustomGeometryGroup):
     _name = ".CA to helix"
     _tree_properties = {"node_tool_idname": "geometry._ca_to_helix"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         curve = tree.inputs.geometry("Curve")
         boolean = tree.inputs.boolean("Boolean", False)
         thickness = tree.inputs.float(
@@ -787,7 +789,7 @@ class MN_utils_style_cartoon(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"node_tool_idname": "geometry._mn_utils_style_cartoon"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )
@@ -1190,7 +1192,7 @@ class StyleCartoon(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/style_ribbon.py
+++ b/molecularnodes/nodes/geometry/style_ribbon.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Style Ribbon' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Style Ribbon" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -42,7 +44,7 @@ class MN_utils_style_ribbon_peptide(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"node_tool_idname": "geometry._mn_utils_style_ribbon_peptide"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )
@@ -304,7 +306,7 @@ class StyleRibbon(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/style_spheres.py
+++ b/molecularnodes/nodes/geometry/style_spheres.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Style Spheres' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Style Spheres" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -130,7 +132,7 @@ class StyleSpheres(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/style_sticks.py
+++ b/molecularnodes/nodes/geometry/style_sticks.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Style Sticks' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Style Sticks" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -131,7 +133,7 @@ class StyleSticks(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/style_surface.py
+++ b/molecularnodes/nodes/geometry/style_surface.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Style Surface' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Style Surface" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -45,7 +47,7 @@ class Surface_compute_density_from_points(CustomGeometryGroup):
         "node_tool_idname": "geometry._surface_compute_density_from_points"
     }
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )
@@ -81,7 +83,7 @@ class Utils_bounding_box(CustomGeometryGroup):
     _name = ".utils_bounding_box"
     _tree_properties = {"node_tool_idname": "geometry._utils_bounding_box"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         subdivisions = tree.inputs.float(
             "Subdivisions", 16.7, min_value=-10_000.0, max_value=10_000.0
@@ -111,7 +113,7 @@ class MN_utils_style_surface_new(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"node_tool_idname": "geometry._mn_utils_style_surface_new"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )
@@ -150,7 +152,7 @@ class MN_surface_smooth_bumps(CustomGeometryGroup):
     _name = ".MN_surface_smooth_bumps"
     _tree_properties = {"node_tool_idname": "geometry._mn_surface_smooth_bumps"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         geometry_1 = tree.outputs.geometry("Geometry")
 
@@ -178,7 +180,7 @@ class MN_utils_style_surface_sdf(CustomGeometryGroup):
     _color_tag = "GEOMETRY"
     _tree_properties = {"node_tool_idname": "geometry._mn_utils_style_surface_new"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )
@@ -318,7 +320,7 @@ class MN_utils_style_surface_sdf(CustomGeometryGroup):
 class SampleColors(CustomGeometryGroup):
     _name = ".Sample Colors"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         color_source = tree.inputs.menu("Color Source", optional_label=True)
         atoms = tree.inputs.geometry("Atoms")
         step = tree.inputs.integer("step", 1)
@@ -385,7 +387,7 @@ class SampleColors(CustomGeometryGroup):
 class SurfaceToRadius(CustomGeometryGroup):
     _name = ".Surface to Radius"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         scale_radii = tree.inputs.float(
             "Scale Radii", 1.47, min_value=0.0, max_value=10.0
         )
@@ -432,7 +434,7 @@ class SurfaceToRadius(CustomGeometryGroup):
 class RelaxSurface(CustomGeometryGroup):
     _name = ".Relax Surface"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         relaxation_steps = tree.inputs.integer("Relaxation Steps", 30, min_value=0)
         step = tree.inputs.integer("step", 3)
         bundle = tree.outputs.bundle("Bundle")
@@ -467,7 +469,7 @@ class RelaxSurface(CustomGeometryGroup):
 class TriangulateMesh(CustomGeometryGroup):
     _name = ".Triangulate Mesh"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         step = tree.inputs.integer("step", 4)
         bundle = tree.outputs.bundle("Bundle")
 
@@ -654,7 +656,7 @@ class StyleSurface(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms",
             description="Atomic geometry that contains vertices and edges",

--- a/molecularnodes/nodes/geometry/sub_group_info.py
+++ b/molecularnodes/nodes/geometry/sub_group_info.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Sub Group Info' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Sub Group Info" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -92,7 +94,7 @@ class SubGroupInfo(AssetGeometryGroup):
     ):
         super().__init__(**{"Sub Group ID": sub_group_id, "Group ID": group_id})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         sub_group_id = tree.inputs.integer("Sub Group ID", 0, hide_value=True)
         group_id = tree.inputs.integer("Group ID", 0, hide_value=True)
         size = tree.outputs.integer(

--- a/molecularnodes/nodes/geometry/switch_residue_name.py
+++ b/molecularnodes/nodes/geometry/switch_residue_name.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Switch Residue Name' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Switch Residue Name" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -215,7 +217,7 @@ class SwitchResidueName(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         ala = tree.inputs.integer("ALA", 6)
         arg = tree.inputs.integer("ARG", 6)
         asn = tree.inputs.integer("ASN", 6)

--- a/molecularnodes/nodes/geometry/symmetry_id.py
+++ b/molecularnodes/nodes/geometry/symmetry_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Symmetry ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Symmetry ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     IntegerSocket,
@@ -62,7 +64,7 @@ class SymmetryID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/tem_rotation.py
+++ b/molecularnodes/nodes/geometry/tem_rotation.py
@@ -1,7 +1,9 @@
-# Node-group asset 'TEM Rotation' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "TEM Rotation" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -79,7 +81,7 @@ class TEMRotation(AssetGeometryGroup):
     ):
         super().__init__(**{"Phi": phi, "Theta": theta, "Psi": psi})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         phi = tree.inputs.string("Phi", "rlnAngleRot", optional_label=True)
         theta = tree.inputs.string("Theta", "rlnAngleTilt", optional_label=True)
         psi = tree.inputs.string("Psi", "rlnAnglePsi", optional_label=True)

--- a/molecularnodes/nodes/geometry/topology_dssp.py
+++ b/molecularnodes/nodes/geometry/topology_dssp.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Topology DSSP' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Topology DSSP" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -36,7 +38,7 @@ class RecipAngDis(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"node_tool_idname": "geometry.recip_ang_dis"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.vector(
             "A", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0
         )
@@ -53,7 +55,7 @@ class HBondEnergy(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"node_tool_idname": "geometry.hbond_energy"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         o = tree.inputs.vector("O", (0.0, 0.0, 0.0))
         c_ = tree.inputs.vector("C", (0.0, 0.0, 0.0))
         n = tree.inputs.vector("N", (0.0, 0.0, 0.0))
@@ -83,7 +85,7 @@ class CheckHBond(CustomGeometryGroup):
     _name = ".Check HBond"
     _color_tag = "CONVERTER"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         co_index = tree.inputs.integer(
             "CO Index", 0, min_value=0, default_input="INDEX"
         )
@@ -117,7 +119,7 @@ class HBondBackboneCheck(CustomGeometryGroup):
     _color_tag = "CONVERTER"
     _tree_properties = {"node_tool_idname": "geometry._hbond_backbone_check"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         with tree.inputs.panel("CO (i)"):
             co_index = tree.inputs.integer(
                 "CO Index", 0, min_value=0, default_input="INDEX"
@@ -146,7 +148,7 @@ class MN_topo_calc_helix(CustomGeometryGroup):
     _name = ".MN_topo_calc_helix"
     _tree_properties = {"node_tool_idname": "geometry._mn_topo_calc_helix"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         ca_mesh = tree.inputs.geometry("CA Mesh")
         is_helix = tree.outputs.boolean("Is Helix")
         instances = tree.outputs.geometry("Instances")
@@ -238,7 +240,7 @@ class MN_topo_calc_sheet(CustomGeometryGroup):
     _name = ".MN_topo_calc_sheet"
     _tree_properties = {"node_tool_idname": "geometry._mn_topo_calc_sheet"}
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         ca_mesh = tree.inputs.geometry("CA Mesh")
         is_sheet = tree.outputs.boolean("Is Sheet")
         instances = tree.outputs.geometry("Instances")
@@ -357,7 +359,7 @@ class TopologyDSSP(AssetGeometryGroup):
     ):
         super().__init__(**{"Atoms": atoms})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry(
             "Atoms", description="Atomic geometry that contains vertices and edges"
         )

--- a/molecularnodes/nodes/geometry/transform_accumulate.py
+++ b/molecularnodes/nodes/geometry/transform_accumulate.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transform Accumulate' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transform Accumulate" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -93,7 +95,7 @@ class TransformAccumulate(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         domain = tree.inputs.menu(
             "Domain",
             description="Domain on which to accumulate transforms",

--- a/molecularnodes/nodes/geometry/transform_accumulate_point.py
+++ b/molecularnodes/nodes/geometry/transform_accumulate_point.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transform Accumulate Point' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transform Accumulate Point" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -111,7 +113,7 @@ class TransformAccumulatePoint(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         domain = tree.inputs.menu(
             "Domain",
             description="Domain on which to accumulate the transforms",

--- a/molecularnodes/nodes/geometry/transform_local.py
+++ b/molecularnodes/nodes/geometry/transform_local.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transform Local' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transform Local" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -70,7 +72,7 @@ class TransformLocal(AssetGeometryGroup):
     ):
         super().__init__(**{"Origin": origin, "Transform": transform})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         origin = tree.inputs.vector(
             "Origin",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/transform_local_axis.py
+++ b/molecularnodes/nodes/geometry/transform_local_axis.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transform Local Axis' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transform Local Axis" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -78,7 +80,7 @@ class TransformLocalAxis(AssetGeometryGroup):
     ):
         super().__init__(**{"Origin": origin, "Axis": axis, "Angle": angle})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         origin = tree.inputs.vector(
             "Origin",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/transform_mix.py
+++ b/molecularnodes/nodes/geometry/transform_mix.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transform Mix' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transform Mix" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -116,7 +118,7 @@ class TransformMix(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.matrix("A", description="Transform A to mix from at 0.0")
         b = tree.inputs.matrix(
             "B", description="Transform B which will be mixed to at 1.0"

--- a/molecularnodes/nodes/geometry/transform_relative.py
+++ b/molecularnodes/nodes/geometry/transform_relative.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transform Relative' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transform Relative" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -74,7 +76,7 @@ class TransformRelative(AssetGeometryGroup):
     ):
         super().__init__(**{"A": a, "B": b, "C": c})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.vector(
             "A",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/unique_chain_id.py
+++ b/molecularnodes/nodes/geometry/unique_chain_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Unique Chain ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Unique Chain ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -66,7 +68,7 @@ class UniqueChainID(AssetGeometryGroup):
     ):
         super().__init__(**{"Cutoff": cutoff})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         cutoff = tree.inputs.float(
             "Cutoff",
             4.5,

--- a/molecularnodes/nodes/geometry/unique_residue_id.py
+++ b/molecularnodes/nodes/geometry/unique_residue_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Unique Residue ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Unique Residue ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -47,7 +49,7 @@ class UniqueResidueID(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         group_id = tree.outputs.integer(
             "Group ID", description="A unique Group ID for eash residue"
         )

--- a/molecularnodes/nodes/geometry/ures_id.py
+++ b/molecularnodes/nodes/geometry/ures_id.py
@@ -1,7 +1,9 @@
-# Node-group asset 'URes ID' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "URes ID" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -62,7 +64,7 @@ class UResID(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer(
             "Index", 0, min_value=0, hide_value=True, default_input="INDEX"
         )

--- a/molecularnodes/nodes/geometry/vdw_radii.py
+++ b/molecularnodes/nodes/geometry/vdw_radii.py
@@ -1,7 +1,9 @@
-# Node-group asset 'VDW Radii' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "VDW Radii" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -61,7 +63,7 @@ class VDWRadii(AssetGeometryGroup):
     ):
         super().__init__(**{"Index": index})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         index = tree.inputs.integer("Index", 0, min_value=0, default_input="INDEX")
         vdw_radii = tree.outputs.float(
             "vdw_radii", description="Read the `vdw_radii` attribute from the geometry"

--- a/molecularnodes/nodes/geometry/vector_angle.py
+++ b/molecularnodes/nodes/geometry/vector_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Vector Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Vector Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -73,7 +75,7 @@ class VectorAngle(AssetGeometryGroup):
     ):
         super().__init__(**{"A": a, "B": b})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         a = tree.inputs.vector(
             "A",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/vector_direction.py
+++ b/molecularnodes/nodes/geometry/vector_direction.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Vector Direction' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Vector Direction" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     BooleanSocket,
@@ -77,7 +79,7 @@ class VectorDirection(AssetGeometryGroup):
     ):
         super().__init__(**{"Normalize": normalize, "To": to, "From": from_})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         normalize = tree.inputs.boolean("Normalize", True)
         to = tree.inputs.vector(
             "To", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0

--- a/molecularnodes/nodes/geometry/vector_from_point.py
+++ b/molecularnodes/nodes/geometry/vector_from_point.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Vector from Point' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Vector from Point" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -80,7 +82,7 @@ class VectorFromPoint(AssetGeometryGroup):
     ):
         super().__init__(**{"Target": target, "Position": position})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         target = tree.inputs.vector(
             "Target",
             (0.0, 0.0, 0.0),

--- a/molecularnodes/nodes/geometry/velocity.py
+++ b/molecularnodes/nodes/geometry/velocity.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Velocity' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Velocity" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -42,7 +44,7 @@ class Velocity(AssetGeometryGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         velocity = tree.outputs.vector("velocity")
 
         named_attribute = g.NamedAttribute.vector("velocity")

--- a/molecularnodes/nodes/geometry/visualize_angle.py
+++ b/molecularnodes/nodes/geometry/visualize_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Visualize Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Visualize Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -125,7 +127,7 @@ class VisualizeAngle(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         points = tree.inputs.geometry("Points")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         position = tree.inputs.vector(

--- a/molecularnodes/nodes/geometry/visualize_chi_angle.py
+++ b/molecularnodes/nodes/geometry/visualize_chi_angle.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Visualize Chi Angle' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Visualize Chi Angle" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -104,7 +106,7 @@ class VisualizeChiAngle(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         geometry = tree.inputs.geometry("Geometry")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         factor = tree.inputs.float(

--- a/molecularnodes/nodes/geometry/visualize_points.py
+++ b/molecularnodes/nodes/geometry/visualize_points.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Visualize Points' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Visualize Points" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -90,7 +92,7 @@ class VisualizePoints(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         points = tree.inputs.geometry("Points")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         target = tree.inputs.vector(

--- a/molecularnodes/nodes/geometry/visualize_relative_atoms.py
+++ b/molecularnodes/nodes/geometry/visualize_relative_atoms.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Visualize Relative Atoms' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Visualize Relative Atoms" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy.builder import (
     AssetGeometryGroup,
@@ -114,7 +116,7 @@ class VisualizeRelativeAtoms(AssetGeometryGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         atoms = tree.inputs.geometry("Atoms")
         selection = tree.inputs.boolean("Selection", True, hide_value=True)
         scale = tree.inputs.float("Scale", 1.0, min_value=-10_000.0, max_value=10_000.0)

--- a/molecularnodes/nodes/geometry/world_to_angstrom.py
+++ b/molecularnodes/nodes/geometry/world_to_angstrom.py
@@ -1,7 +1,9 @@
-# Node-group asset 'World to Angstrom' (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "World to Angstrom" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
 from nodebpy.builder import (
     AssetGeometryGroup,
     FloatSocket,
@@ -59,7 +61,7 @@ class WorldToAngstrom(AssetGeometryGroup):
     ):
         super().__init__(**{"World": world})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
         world = tree.inputs.float("World", 0.5, min_value=-10_000.0, max_value=10_000.0)
         angstrom = tree.outputs.float("Angstrom")
 

--- a/molecularnodes/nodes/materials/mn_ambient_occlusion.py
+++ b/molecularnodes/nodes/materials/mn_ambient_occlusion.py
@@ -1,6 +1,8 @@
-# Material 'MN Ambient Occlusion', dumped by nodebpy.assets.dump_library.
+# Material "MN Ambient Occlusion", dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # The class is a recipe for the material's shader tree — build recreates the material and runs it into material.node_tree.
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import shader as s
 from nodebpy.builder import CustomShaderGroup
 from ..shader.color_ao import ColorAO
@@ -10,7 +12,7 @@ from ..shader.mn_color import MNColor
 class MNAmbientOcclusion(CustomShaderGroup):
     _name = "Shader Nodetree"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         _material_output = s.MaterialOutput(
             surface=s.Emission(color=ColorAO(color=MNColor().o.color)),
             is_active_output=True,

--- a/molecularnodes/nodes/materials/mn_default_old.py
+++ b/molecularnodes/nodes/materials/mn_default_old.py
@@ -1,6 +1,8 @@
-# Material 'MN Default.old', dumped by nodebpy.assets.dump_library.
+# Material "MN Default.old", dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # The class is a recipe for the material's shader tree — build recreates the material and runs it into material.node_tree.
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import shader as s
 from nodebpy.builder import CustomShaderGroup
 from ..shader.mn_color import MNColor
@@ -9,7 +11,7 @@ from ..shader.mn_color import MNColor
 class MNDefaultOld(CustomShaderGroup):
     _name = "Shader Nodetree"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         group = MNColor()
         principled_bsdf = s.PrincipledBSDF(
             base_color=group.o.color,

--- a/molecularnodes/nodes/shader/_shared/edge_detection.py
+++ b/molecularnodes/nodes/shader/_shared/edge_detection.py
@@ -1,9 +1,11 @@
-# Node group 'Edge Detection' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Edge Detection" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 import math
 from typing import TYPE_CHECKING
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import CustomShaderGroup, FloatSocket, SocketAccessor
@@ -62,7 +64,7 @@ class EdgeDetection(CustomShaderGroup):
     ):
         super().__init__(**{"Offset": offset})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         offset = tree.inputs.float("Offset", 1.0, min_value=0.0, max_value=1.0)
         co_planar_delta = tree.outputs.float("Co-Planar Delta")
         normal_delta = tree.outputs.float("Normal Delta")

--- a/molecularnodes/nodes/shader/_shared/offset_raycast.py
+++ b/molecularnodes/nodes/shader/_shared/offset_raycast.py
@@ -1,8 +1,10 @@
-# Node group 'Offset Raycast' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Offset Raycast" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import shader as s
 from nodebpy.builder import CustomShaderGroup, FloatSocket, SocketAccessor, VectorSocket
 from nodebpy.types import InputFloat
@@ -89,7 +91,7 @@ class OffsetRaycast(CustomShaderGroup):
             **{"X Offset": x_offset, "Y Offset": y_offset, "Length": length}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         x_offset = tree.inputs.float(
             "X Offset", 1.0, min_value=-10_000.0, max_value=10_000.0
         )

--- a/molecularnodes/nodes/shader/_shared/ray_origin.py
+++ b/molecularnodes/nodes/shader/_shared/ray_origin.py
@@ -1,8 +1,10 @@
-# Node group 'Ray Origin' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Ray Origin" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import shader as s
 from nodebpy.builder import CustomShaderGroup, SocketAccessor, VectorSocket
 
@@ -36,7 +38,7 @@ class RayOrigin(CustomShaderGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         vector = tree.outputs.vector("Vector")
 
         (

--- a/molecularnodes/nodes/shader/_shared/ray_tangent.py
+++ b/molecularnodes/nodes/shader/_shared/ray_tangent.py
@@ -1,8 +1,10 @@
-# Node group 'Ray Tangent' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node group "Ray Tangent" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # Shared by several assets, which import it; not an asset itself.
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import shader as s
 from nodebpy.builder import CustomShaderGroup, SocketAccessor, VectorSocket
 
@@ -40,7 +42,7 @@ class RayTangent(CustomShaderGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         tangent = tree.outputs.vector("Tangent")
         bitangent = tree.outputs.vector("Bitangent")
 

--- a/molecularnodes/nodes/shader/color_ao.py
+++ b/molecularnodes/nodes/shader/color_ao.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Color AO' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Color AO" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import (
@@ -84,7 +86,7 @@ class ColorAO(AssetShaderGroup):
             **{"Color": color, "Menu": menu, "Distance": distance, "Exponent": exponent}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         color = tree.inputs.color("Color", (0.0, 0.0, 0.0, 0.0))
         menu = tree.inputs.menu("Menu", expanded=True, optional_label=True)
         distance = tree.inputs.float("Distance", 1.0, min_value=0.0, max_value=1000.0)

--- a/molecularnodes/nodes/shader/flat.py
+++ b/molecularnodes/nodes/shader/flat.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Flat' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Flat" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import (
@@ -79,7 +81,7 @@ class Flat(AssetShaderGroup):
             **{"Outline": outline, "Threshold": threshold, "Thickness": thickness}
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         outline = tree.inputs.menu("Outline", expanded=True, optional_label=True)
         threshold = tree.inputs.float(
             "Threshold", 0.8, min_value=0.0, max_value=10_000.0

--- a/molecularnodes/nodes/shader/mn_color.py
+++ b/molecularnodes/nodes/shader/mn_color.py
@@ -1,7 +1,9 @@
-# Node-group asset 'MN Color' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "MN Color" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import (
@@ -49,7 +51,7 @@ class MNColor(AssetShaderGroup):
     def __init__(self):
         super().__init__()
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         color = tree.outputs.color("Color", (0.0, 0.0, 0.0, 0.0))
         alpha = tree.outputs.float("Alpha")
 

--- a/molecularnodes/nodes/shader/outline_mask.py
+++ b/molecularnodes/nodes/shader/outline_mask.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Outline Mask' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Outline Mask" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import (
@@ -67,7 +69,7 @@ class OutlineMask(AssetShaderGroup):
     ):
         super().__init__(**{"Threshold": threshold, "Thickness": thickness})
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         threshold = tree.inputs.float(
             "Threshold", 0.8, min_value=0.0, max_value=10_000.0
         )

--- a/molecularnodes/nodes/shader/transparent_outline.py
+++ b/molecularnodes/nodes/shader/transparent_outline.py
@@ -1,7 +1,9 @@
-# Node-group asset 'Transparent Outline' (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
+# Node-group asset "Transparent Outline" (ShaderNodeTree), dumped by nodebpy.assets.dump_library.
 # Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
 # _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
 from typing import TYPE_CHECKING, Literal
+from bpy.types import ShaderNodeTree
+from nodebpy import TreeBuilder
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import (
@@ -22,7 +24,7 @@ from .outline_mask import OutlineMask
 class MN_mask_transparent(CustomShaderGroup):
     _name = ".MN_mask_transparent"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         value = tree.inputs.float("Value", 0.0, min_value=-10_000.0, max_value=10_000.0)
         value_1 = tree.outputs.float("Value")
 
@@ -35,7 +37,7 @@ class MN_mask_transparent(CustomShaderGroup):
 class MNFresnel(CustomShaderGroup):
     _name = "MN Fresnel"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         ior = tree.inputs.float("IOR", 0.98, min_value=0.0, max_value=1000.0)
         factor = tree.inputs.float(
             "Factor",
@@ -139,7 +141,7 @@ class TransparentOutline(AssetShaderGroup):
             }
         )
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[ShaderNodeTree]) -> None:
         alpha = tree.inputs.float(
             "Alpha",
             0.95,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "imdclient>=0.2.3",
     "pandas<3.0.0",
     "griddataformats>=1.2.0",
-    "nodebpy>=520.17.0",
+    "nodebpy>=520.18.0",
 ]
 maintainers = [{ name = "Brady Johnston", email = "brady.johnston@me.com" }]
 requires-python = "~=3.13.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1454,7 +1454,7 @@ requires-dist = [
     { name = "mdanalysistests", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "mdanalysistests", marker = "extra == 'docs'", specifier = ">=2.7.0" },
     { name = "mrcfile" },
-    { name = "nodebpy", specifier = ">=520.17.0" },
+    { name = "nodebpy", specifier = ">=520.18.0" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">2.2" },
     { name = "pandas", specifier = "<3.0.0" },
     { name = "pillow", marker = "extra == 'dev'" },
@@ -1592,11 +1592,11 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "520.17.0"
+version = "520.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/e3/4eb2b059e804e3073715bc0d85db55a82922a50811f7288442e8d58ef674/nodebpy-520.17.0.tar.gz", hash = "sha256:126685d40891bace8ff7c24a4b316d1aca7fc32ccacabca3d3d163ba920c8937", size = 376524, upload-time = "2026-09-10T10:09:52.61Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/0f/5d286c485033815ee6db9b6373312a6207eaef42b1b45bf87497e8ccb0ca/nodebpy-520.18.0.tar.gz", hash = "sha256:e9cb2747da91b1669f0454a7deac3908ddfde197d1c00cca70c8e52113e9c2d1", size = 376889, upload-time = "2026-09-10T13:50:46.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/67/de323b153358e28e498c187964bd46bd388e52c4791071c7cd49aa9b3328/nodebpy-520.17.0-py3-none-any.whl", hash = "sha256:e8c83383f2c8a246f68a3b49fdf040151637e59723ca23f08423a16e87d41140", size = 419038, upload-time = "2026-09-10T10:09:50.952Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/29/eb0917af224cb994750acdf4dc170a3a21825032d2f55cef2fdedb06eb99/nodebpy-520.18.0-py3-none-any.whl", hash = "sha256:622dc990ca81794ad8e1c99e60dbddf8005fc0338e0acaf47aa3a4a20ba2c817", size = 419421, upload-time = "2026-09-10T13:50:45.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updated `nodebpy>=520.18.0`, re-dumped node API with updated types.