### PR TITLE
ENH: Add back the basic simulation nodes

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -67,6 +67,8 @@ website:
       text: Geometry
     - href: nodes/select.qmd
       text: Select
+    - href: nodes/simulation.qmd
+      text: Simulation
     - href: nodes/style.qmd
       text: Style
     - href: nodes/topology.qmd
@@ -383,15 +385,13 @@ quartodoc:
       contents:
       - name: nodes.geometry.DNAFromCurve
         children: embedded
-      - name: nodes.geometry.OxDNANormal
+      - name: nodes.geometry.OxDNARealizeVectors
         children: embedded
-      - name: nodes.geometry.OxDNAOffset
-        children: embedded
-      - name: nodes.geometry.OxDNARotation
+      - name: nodes.geometry.OxDNARecoverVectors
         children: embedded
       - name: nodes.geometry.OxDNAStyleRibbon
         children: embedded
-      - name: nodes.geometry.OxDNAVector
+      - name: nodes.geometry.OxDNAVectors
         children: embedded
     - kind: page
       path: nodes.density
@@ -540,6 +540,26 @@ quartodoc:
       - name: nodes.geometry.SeparateAtoms
         children: embedded
       - name: nodes.geometry.SeparatePolymers
+        children: embedded
+    - kind: page
+      path: nodes.simulation
+      summary:
+        name: Simulation
+        desc: Nodes for simulations inside of Geometry Nodes
+      contents:
+      - name: nodes.geometry.BuildElasticNetwork
+        children: embedded
+      - name: nodes.geometry.ForceBrownian
+        children: embedded
+      - name: nodes.geometry.ForceGravity
+        children: embedded
+      - name: nodes.geometry.ForceMeshCollide
+        children: embedded
+      - name: nodes.geometry.SimulateCurve
+        children: embedded
+      - name: nodes.geometry.SimulateElasticNetwork
+        children: embedded
+      - name: nodes.geometry.SimulateOnFaces
         children: embedded
     - kind: page
       path: nodes.style

--- a/molecularnodes/nodes/geometry/__init__.py
+++ b/molecularnodes/nodes/geometry/__init__.py
@@ -37,6 +37,7 @@ from .boolean_run_fill import BooleanRunFill
 from .boolean_run_trim import BooleanRunTrim
 from .break_bonds import BreakBonds
 from .break_curves import BreakCurves
+from .build_elastic_network import BuildElasticNetwork
 from .centre_on_selection import CentreOnSelection
 from .centroid import Centroid
 from .chain_id import ChainID
@@ -101,6 +102,9 @@ from .fallback_vector import FallbackVector
 from .field_remap import FieldRemap
 from .find_bonded_atom import FindBondedAtom
 from .find_bonds import FindBonds
+from .force_brownian import ForceBrownian
+from .force_gravity import ForceGravity
+from .force_mesh_collide import ForceMeshCollide
 from .fractionate_float import FractionateFloat
 from .frame_id import FrameID
 from .geoemtry_to_planar import GeoemtryToPlanar
@@ -215,6 +219,9 @@ from .set_color import SetColor
 from .set_nucleic_dihedral import SetNucleicDihedral
 from .set_phi_psi_angle import SetPhiPsiAngle
 from .set_ures_id import SetUResID
+from .simulate_curve import SimulateCurve
+from .simulate_elastic_network import SimulateElasticNetwork
+from .simulate_on_faces import SimulateOnFaces
 from .slice_edge_instances import SliceEdgeInstances
 from .split_to_centred_instances import SplitToCentredInstances
 from .starfile_instances import StarfileInstances
@@ -289,6 +296,7 @@ __all__ = (
     "BooleanRunTrim",
     "BreakBonds",
     "BreakCurves",
+    "BuildElasticNetwork",
     "CentreOnSelection",
     "Centroid",
     "ChainID",
@@ -353,6 +361,9 @@ __all__ = (
     "FieldRemap",
     "FindBondedAtom",
     "FindBonds",
+    "ForceBrownian",
+    "ForceGravity",
+    "ForceMeshCollide",
     "FractionateFloat",
     "FrameID",
     "GeoemtryToPlanar",
@@ -467,6 +478,9 @@ __all__ = (
     "SetNucleicDihedral",
     "SetPhiPsiAngle",
     "SetUResID",
+    "SimulateCurve",
+    "SimulateElasticNetwork",
+    "SimulateOnFaces",
     "SliceEdgeInstances",
     "SplitToCentredInstances",
     "StarfileInstances",

--- a/molecularnodes/nodes/geometry/_shared/constraint_distance.py
+++ b/molecularnodes/nodes/geometry/_shared/constraint_distance.py
@@ -1,0 +1,155 @@
+# Node group "Constraint Distance" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy.builder import (
+    CustomGeometryGroup,
+    FloatSocket,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputFloat, InputVector
+
+
+class ConstraintDistance(CustomGeometryGroup):
+    """
+    Constraint Distance
+
+    Parameters
+    ----------
+    target : InputVector
+        Target
+    self_2 : InputVector
+        Self
+    distance : InputFloat
+        Distance
+    w1 : InputFloat
+        W1
+    w2 : InputFloat
+        W2
+    alpha : InputFloat
+        alpha
+    deltat : InputFloat
+        deltaT
+
+    Inputs
+    ------
+    i.target : VectorSocket
+        Target
+    i.self_2 : VectorSocket
+        Self
+    i.distance : FloatSocket
+        Distance
+    i.w1 : FloatSocket
+        W1
+    i.w2 : FloatSocket
+        W2
+    i.alpha : FloatSocket
+        alpha
+    i.deltat : FloatSocket
+        deltaT
+
+    Outputs
+    -------
+    o.correction : VectorSocket
+        Correction
+    o.value : FloatSocket
+        Value
+    """
+
+    _name = "Constraint Distance"
+    _color_tag = "VECTOR"
+
+    class _Inputs(SocketAccessor):
+        target: VectorSocket
+        """Target"""
+        self_2: VectorSocket
+        """Self"""
+        distance: FloatSocket
+        """Distance"""
+        w1: FloatSocket
+        """W1"""
+        w2: FloatSocket
+        """W2"""
+        alpha: FloatSocket
+        deltat: FloatSocket
+        """deltaT"""
+
+    class _Outputs(SocketAccessor):
+        correction: VectorSocket
+        """Correction"""
+        value: FloatSocket
+        """Value"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        target: InputVector = None,
+        self_2: InputVector = None,
+        distance: InputFloat = 0.5,
+        w1: InputFloat = 0.5,
+        w2: InputFloat = 0.5,
+        alpha: InputFloat = 0.0,
+        deltat: InputFloat = 0.0,
+    ):
+        super().__init__(
+            **{
+                "Target": target,
+                "Self": self_2,
+                "Distance": distance,
+                "W1": w1,
+                "W2": w2,
+                "alpha": alpha,
+                "deltaT": deltat,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        target = tree.inputs.vector(
+            "Target", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0
+        )
+        self = tree.inputs.vector(
+            "Self",
+            (0.0, 0.0, 0.0),
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            default_input="POSITION",
+        )
+        distance = tree.inputs.float(
+            "Distance", 0.5, min_value=-10_000.0, max_value=10_000.0
+        )
+        w1 = tree.inputs.float("W1", 0.5, min_value=0.0, max_value=10_000.0)
+        w2 = tree.inputs.float("W2", 0.5, min_value=0.0, max_value=10_000.0)
+        alpha = tree.inputs.float("alpha", 0.0, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.0,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        correction = tree.outputs.vector("Correction")
+        value = tree.outputs.float("Value")
+
+        vector_math = target - self
+        vector_math_1 = vector_math.length()
+        (
+            vector_math.normalize()
+            * (
+                (vector_math_1 - distance)
+                * (w1 / (w1 + w2 + alpha / (deltat * deltat)))
+            )
+            >> correction
+        )
+
+        vector_math_1 >> value

--- a/molecularnodes/nodes/geometry/_shared/inverse_mass.py
+++ b/molecularnodes/nodes/geometry/_shared/inverse_mass.py
@@ -1,0 +1,65 @@
+# Node group "Inverse Mass" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    SocketAccessor,
+)
+from ..fallback_float import FallbackFloat
+
+
+class InverseMass(CustomGeometryGroup):
+    """
+    Inverse Mass
+
+    Outputs
+    -------
+    o.exists : BooleanSocket
+        Exists
+    o.w : FloatSocket
+        w
+    o.mass : FloatSocket
+        mass
+    """
+
+    _name = "Inverse Mass"
+    _color_tag = "INPUT"
+
+    class _Inputs(SocketAccessor):
+        pass
+
+    class _Outputs(SocketAccessor):
+        exists: BooleanSocket
+        """Exists"""
+        w: FloatSocket
+        mass: FloatSocket
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(self):
+        super().__init__()
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        exists = tree.outputs.boolean("Exists")
+        w = tree.outputs.float("w")
+        mass = tree.outputs.float("mass")
+
+        group = FallbackFloat(name="mass", fallback=1.0)
+        string = g.String(string="inverse_mass")
+        FallbackFloat(name=string, fallback=1.0 / group) >> w
+        named_attribute = g.NamedAttribute.float(string)
+
+        named_attribute.o.exists >> exists
+        group >> mass

--- a/molecularnodes/nodes/geometry/_shared/lerp_position.py
+++ b/molecularnodes/nodes/geometry/_shared/lerp_position.py
@@ -1,0 +1,110 @@
+# Node group "Lerp Position" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    CustomGeometryGroup,
+    FloatSocket,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputFloat, InputVector
+
+
+class LerpPosition(CustomGeometryGroup):
+    """
+    Lerp Position
+
+    Parameters
+    ----------
+    a : InputVector
+        a
+    b : InputVector
+        b
+    deltat : InputFloat
+        deltaT
+    decay : InputFloat
+        Decay
+
+    Inputs
+    ------
+    i.a : VectorSocket
+        a
+    i.b : VectorSocket
+        b
+    i.deltat : FloatSocket
+        deltaT
+    i.decay : FloatSocket
+        Decay
+
+    Outputs
+    -------
+    o.position : VectorSocket
+        Position
+    o.length : FloatSocket
+        Length
+    """
+
+    _name = "Lerp Position"
+    _color_tag = "CONVERTER"
+
+    class _Inputs(SocketAccessor):
+        a: VectorSocket
+        b: VectorSocket
+        deltat: FloatSocket
+        """deltaT"""
+        decay: FloatSocket
+        """Decay"""
+
+    class _Outputs(SocketAccessor):
+        position: VectorSocket
+        """Position"""
+        length: FloatSocket
+        """Length"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        a: InputVector = None,
+        b: InputVector = None,
+        deltat: InputFloat = 0.5,
+        decay: InputFloat = 0.5,
+    ):
+        super().__init__(**{"a": a, "b": b, "deltaT": deltat, "Decay": decay})
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        a = tree.inputs.vector(
+            "a",
+            (0.0, 0.0, 0.0),
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            default_input="POSITION",
+        )
+        b = tree.inputs.vector(
+            "b", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0
+        )
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.5,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        decay = tree.inputs.float("Decay", 0.5, min_value=-10_000.0, max_value=10_000.0)
+        position = tree.outputs.vector("Position")
+        length = tree.outputs.float("Length")
+
+        vector_math = a - b
+        b + vector_math * g.Math.exponent(deltat * (decay * -1.0)) >> position
+        vector_math.length() >> length

--- a/molecularnodes/nodes/geometry/_shared/xpbd_finalise.py
+++ b/molecularnodes/nodes/geometry/_shared/xpbd_finalise.py
@@ -1,0 +1,98 @@
+# Node group "XPBD Finalise" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    SocketAccessor,
+)
+from nodebpy.types import InputBoolean, InputFloat, InputGeometry
+
+
+class XPBDFinalise(CustomGeometryGroup):
+    """
+    XPBD Finalise
+
+    Parameters
+    ----------
+    geometry : InputGeometry
+        Geometry
+    selection : InputBoolean
+        Selection
+    deltat : InputFloat
+        deltaT
+
+    Inputs
+    ------
+    i.geometry : GeometrySocket
+        Geometry
+    i.selection : BooleanSocket
+        Selection
+    i.deltat : FloatSocket
+        deltaT
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    """
+
+    _name = "XPBD Finalise"
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+        selection: BooleanSocket
+        """Selection"""
+        deltat: FloatSocket
+        """deltaT"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        geometry: InputGeometry = None,
+        selection: InputBoolean = True,
+        deltat: InputFloat = 0.0,
+    ):
+        super().__init__(
+            **{"Geometry": geometry, "Selection": selection, "deltaT": deltat}
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        deltat = tree.inputs.float(
+            "deltaT", 0.0, structure_type="SINGLE", force_non_field=True
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        (
+            geometry
+            >> g.StoreNamedAttribute.point.vector(
+                selection=selection,
+                name="velocity",
+                value=(
+                    g.Position().o.position - g.NamedAttribute.vector("p_i").o.attribute
+                )
+                / deltat,
+            )
+            >> geometry_1
+        )

--- a/molecularnodes/nodes/geometry/_shared/xpbd_init.py
+++ b/molecularnodes/nodes/geometry/_shared/xpbd_init.py
@@ -1,0 +1,131 @@
+# Node group "XPBD Init" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputBoolean, InputFloat, InputGeometry, InputVector
+from ..velocity import Velocity
+from .inverse_mass import InverseMass
+
+
+class XPBDInit(CustomGeometryGroup):
+    """
+    XPBD Init
+
+    Parameters
+    ----------
+    geometry : InputGeometry
+        Geometry
+    selection : InputBoolean
+        Selection
+    force : InputVector
+        Force
+    drag : InputFloat
+        Drag
+    deltat : InputFloat
+        deltaT
+
+    Inputs
+    ------
+    i.geometry : GeometrySocket
+        Geometry
+    i.selection : BooleanSocket
+        Selection
+    i.force : VectorSocket
+        Force
+    i.drag : FloatSocket
+        Drag
+    i.deltat : FloatSocket
+        deltaT
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    """
+
+    _name = "XPBD Init"
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+        selection: BooleanSocket
+        """Selection"""
+        force: VectorSocket
+        """Force"""
+        drag: FloatSocket
+        """Drag"""
+        deltat: FloatSocket
+        """deltaT"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        geometry: InputGeometry = None,
+        selection: InputBoolean = True,
+        force: InputVector = None,
+        drag: InputFloat = 10.0,
+        deltat: InputFloat = 1.0,
+    ):
+        super().__init__(
+            **{
+                "Geometry": geometry,
+                "Selection": selection,
+                "Force": force,
+                "Drag": drag,
+                "deltaT": deltat,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        force = tree.inputs.vector(
+            "Force", (0.0, 0.0, -9.8), min_value=-10_000.0, max_value=10_000.0
+        )
+        drag = tree.inputs.float("Drag", 10.0, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            1.0,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        with g.Frame("Drag Force"):
+            vector_math = Velocity().o.velocity * (1.0 - drag * deltat).clamp()
+        with g.Frame("New Forces"):
+            vector_math_1 = force * deltat * InverseMass().o.w
+        (
+            geometry
+            >> g.StoreNamedAttribute.point.vector(name="p_i", value=g.Position())
+            >> g.StoreNamedAttribute.point.vector(
+                name="velocity", value=vector_math + vector_math_1
+            )
+            >> g.SetPosition(selection=selection, offset=Velocity().o.velocity * deltat)
+            >> geometry_1
+        )

--- a/molecularnodes/nodes/geometry/_shared/xpbd_solve_hook.py
+++ b/molecularnodes/nodes/geometry/_shared/xpbd_solve_hook.py
@@ -1,0 +1,124 @@
+# Node group "XPBD Solve Hook" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputBoolean, InputFloat, InputGeometry, InputVector
+from .lerp_position import LerpPosition
+
+
+class XPBDSolveHook(CustomGeometryGroup):
+    """
+    XPBD Solve Hook
+
+    Parameters
+    ----------
+    geometry : InputGeometry
+        Geometry
+    selection : InputBoolean
+        Selection
+    target : InputVector
+        Target
+    decay : InputFloat
+        Decay
+    deltat : InputFloat
+        deltaT
+
+    Inputs
+    ------
+    i.geometry : GeometrySocket
+        Geometry
+    i.selection : BooleanSocket
+        Selection
+    i.target : VectorSocket
+        Target
+    i.decay : FloatSocket
+        Decay
+    i.deltat : FloatSocket
+        deltaT
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    """
+
+    _name = "XPBD Solve Hook"
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+        selection: BooleanSocket
+        """Selection"""
+        target: VectorSocket
+        """Target"""
+        decay: FloatSocket
+        """Decay"""
+        deltat: FloatSocket
+        """deltaT"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        geometry: InputGeometry = None,
+        selection: InputBoolean = False,
+        target: InputVector = None,
+        decay: InputFloat = 0.5,
+        deltat: InputFloat = 0.5,
+    ):
+        super().__init__(
+            **{
+                "Geometry": geometry,
+                "Selection": selection,
+                "Target": target,
+                "Decay": decay,
+                "deltaT": deltat,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", False, hide_value=True)
+        target = tree.inputs.vector(
+            "Target", (0.0, 0.0, 0.0), min_value=-10_000.0, max_value=10_000.0
+        )
+        decay = tree.inputs.float("Decay", 0.5, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.5,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        group = LerpPosition(b=target, deltat=deltat, decay=decay)
+        (
+            geometry
+            >> g.SetPosition(selection=selection, position=group.o.position)
+            >> geometry_1
+        )
+        _switch = (group.o.length < 0.01).switch.vector(group.o.position, target)

--- a/molecularnodes/nodes/geometry/_shared/xpbd_solve_points.py
+++ b/molecularnodes/nodes/geometry/_shared/xpbd_solve_points.py
@@ -1,0 +1,152 @@
+# Node group "XPBD Solve Points" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# Shared by several assets, which import it; not an asset itself.
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    SocketAccessor,
+)
+from nodebpy.types import InputBoolean, InputFloat, InputGeometry
+from ..residue_id import ResidueID
+from .constraint_distance import ConstraintDistance
+from .inverse_mass import InverseMass
+
+
+class XPBDSolvePoints(CustomGeometryGroup):
+    """
+    XPBD Solve Points
+
+    Parameters
+    ----------
+    geometry : InputGeometry
+        Geometry
+    selection : InputBoolean
+        Selection
+    radius : InputFloat
+        Radius
+    alpha : InputFloat
+        alpha
+    deltat : InputFloat
+        deltaT
+
+    Inputs
+    ------
+    i.geometry : GeometrySocket
+        Geometry
+    i.selection : BooleanSocket
+        Selection
+    i.radius : FloatSocket
+        Radius
+    i.alpha : FloatSocket
+        alpha
+    i.deltat : FloatSocket
+        deltaT
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    """
+
+    _name = "XPBD Solve Points"
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+        selection: BooleanSocket
+        """Selection"""
+        radius: FloatSocket
+        """Radius"""
+        alpha: FloatSocket
+        deltat: FloatSocket
+        """deltaT"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        geometry: InputGeometry = None,
+        selection: InputBoolean = True,
+        radius: InputFloat = 0.0,
+        alpha: InputFloat = 0.0,
+        deltat: InputFloat = 0.0,
+    ):
+        super().__init__(
+            **{
+                "Geometry": geometry,
+                "Selection": selection,
+                "Radius": radius,
+                "alpha": alpha,
+                "deltaT": deltat,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        radius = tree.inputs.float("Radius", 0.0)
+        alpha = tree.inputs.float("alpha", 0.0, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.0,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        group = ResidueID()
+        group_1 = InverseMass()
+        vector_math = (
+            g.Position().o.position
+            + g.RandomValue.vector((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)).o.value * 0.001
+        )
+        capture = g.CaptureAttribute.point(geometry=geometry)
+        capture.items.vector("Vector", vector_math)
+        capture_1 = g.CaptureAttribute.point(geometry=capture.o.geometry)
+        index = capture_1.items.integer("Index", g.IndexOfNearest().o.index)
+        evaluate_at_index = group.o.res_id.point.at(index.output)
+        _compare = g.Compare.integer.not_equal(
+            abs(group.o.res_id - evaluate_at_index), 1
+        )
+        math_1 = radius.point.at(index.output) + radius
+        group_2 = ConstraintDistance(
+            target=g.Position().o.position.point.at(index.output),
+            distance=math_1,
+            w1=group_1.o.w,
+            w2=group_1.o.w.point.at(index.output),
+            alpha=alpha,
+            deltat=deltat,
+        )
+        compare_1 = g.Compare.integer.not_equal(
+            g.ShortestEdgePaths(
+                end_vertex=g.Compare.integer.equal(evaluate_at_index, g.Index())
+            ).o.next_vertex_index,
+            index.output,
+        )
+        (
+            capture_1.o.geometry
+            >> g.SetPosition(
+                selection=compare_1.o.result & (selection & (math_1 > group_2.o.value)),
+                offset=group_2.o.correction,
+            )
+            >> geometry_1
+        )

--- a/molecularnodes/nodes/geometry/build_elastic_network.py
+++ b/molecularnodes/nodes/geometry/build_elastic_network.py
@@ -1,0 +1,181 @@
+# Node-group asset "Build Elastic Network" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    BooleanSocket,
+    FloatSocket,
+    GeometrySocket,
+    MenuSocket,
+    PackageLibrary,
+    SocketAccessor,
+)
+from nodebpy.types import InputBoolean, InputFloat, InputGeometry, InputMenu
+from ._shared.sample_atomic_attributes import SampleAtomicAttributes
+from .is_alpha_carbon import IsAlphaCarbon
+from .plexus import Plexus
+
+
+class BuildElasticNetwork(AssetGeometryGroup):
+    """
+    Build Elastic Network
+
+    Parameters
+    ----------
+    atoms : InputGeometry
+        Atomic mesh which inculdes vertices and edges to generate an elastic network on
+    selection : InputBoolean
+        Atoms which aren't selected will not be included in the final output mesh
+    menu : InputMenu | Literal["Alpha Carbon", "All Atom"]
+        Output a network between just alpha carbons, or one that includes all atoms
+    alpha_carbon : InputFloat
+        Scale the distance for edge creation between just alpha carbon atoms, ignoring all other atoms.
+    all_atom : InputFloat
+        Scale the distance for edge creation, looking for all selected atoms
+
+    Inputs
+    ------
+    i.atoms : GeometrySocket
+        Atomic mesh which inculdes vertices and edges to generate an elastic network on
+    i.selection : BooleanSocket
+        Atoms which aren't selected will not be included in the final output mesh
+    i.menu : MenuSocket
+        Output a network between just alpha carbons, or one that includes all atoms
+    i.alpha_carbon : FloatSocket
+        Scale the distance for edge creation between just alpha carbon atoms, ignoring all other atoms.
+    i.all_atom : FloatSocket
+        Scale the distance for edge creation, looking for all selected atoms
+
+    Outputs
+    -------
+    o.mesh : GeometrySocket
+        The generated elastic network. Edges are formed between atoms within the cutoff distance for use as constraints in a simulation
+    """
+
+    _name = "Build Elastic Network"
+    _asset_name = "Build Elastic Network"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        atoms: GeometrySocket
+        """Atomic mesh which inculdes vertices and edges to generate an elastic network on"""
+        selection: BooleanSocket
+        """Atoms which aren't selected will not be included in the final output mesh"""
+        menu: MenuSocket
+        """Output a network between just alpha carbons, or one that includes all atoms"""
+        alpha_carbon: FloatSocket
+        """Scale the distance for edge creation between just alpha carbon atoms, ignoring all other atoms."""
+        all_atom: FloatSocket
+        """Scale the distance for edge creation, looking for all selected atoms"""
+
+    class _Outputs(SocketAccessor):
+        mesh: GeometrySocket
+        """The generated elastic network. Edges are formed between atoms within the cutoff distance for use as constraints in a simulation"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        atoms: InputGeometry = None,
+        selection: InputBoolean = True,
+        menu: InputMenu | Literal["Alpha Carbon", "All Atom"] = "Alpha Carbon",
+        alpha_carbon: InputFloat = 4.0,
+        all_atom: InputFloat = 2.0,
+    ):
+        super().__init__(
+            **{
+                "Atoms": atoms,
+                "Selection": selection,
+                "Menu": menu,
+                "Alpha Carbon": alpha_carbon,
+                "All Atom": all_atom,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        atoms = tree.inputs.geometry(
+            "Atoms",
+            description="Atomic mesh which inculdes vertices and edges to generate an elastic network on",
+        )
+        selection = tree.inputs.boolean(
+            "Selection",
+            True,
+            description="Atoms which aren't selected will not be included in the final output mesh",
+            hide_value=True,
+        )
+        menu = tree.inputs.menu(
+            "Menu",
+            description="Output a network between just alpha carbons, or one that includes all atoms",
+            optional_label=True,
+        )
+        alpha_carbon = tree.inputs.float(
+            "Alpha Carbon",
+            4.0,
+            description="Scale the distance for edge creation between just alpha carbon atoms, ignoring all other atoms.",
+            min_value=0.0,
+            max_value=10_000.0,
+        )
+        all_atom = tree.inputs.float(
+            "All Atom",
+            2.0,
+            description="Scale the distance for edge creation, looking for all selected atoms",
+            min_value=0.0,
+            max_value=10_000.0,
+        )
+        mesh = tree.outputs.geometry(
+            "Mesh",
+            description="The generated elastic network. Edges are formed between atoms within the cutoff distance for use as constraints in a simulation",
+        )
+
+        separate_geometry = g.SeparateGeometry.point(atoms, selection)
+        group = Plexus(
+            points=g.SeparateGeometry.point(
+                separate_geometry.o.selection, IsAlphaCarbon().o.selection
+            ).o.selection,
+            distance=alpha_carbon,
+            radius=0.0,
+        )
+        group_1 = Plexus(
+            points=g.SeparateGeometry.point(separate_geometry.o.selection).o.selection,
+            distance=all_atom,
+            radius=0.0,
+        )
+        merge_by_distance = g.MenuSwitch.geometry(
+            menu,
+            {
+                "Alpha Carbon": group,
+                "All Atom": g.JoinGeometry(geometry=(group, group_1)),
+            },
+        ) >> g.MergeByDistance(distance=0.0001)
+        capture = g.CaptureAttribute.point(geometry=merge_by_distance)
+        index = capture.items.integer(
+            "Index", g.SampleNearest.point(separate_geometry.o.selection)
+        )
+        (
+            SampleAtomicAttributes(
+                atoms=capture.o.geometry,
+                sample_atoms=separate_geometry.o.selection,
+                index=index.output,
+            )
+            >> g.SortElements.point(sort_weight=index.output)
+            >> mesh
+        )
+
+        menu.default_value = "Alpha Carbon"
+
+
+ASSET = BuildElasticNetwork
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}

--- a/molecularnodes/nodes/geometry/dna_from_curve.py
+++ b/molecularnodes/nodes/geometry/dna_from_curve.py
@@ -2371,7 +2371,7 @@ class SimulateDNAGuide(CustomGeometryGroup):
                 group_1 = RodBendTwistConstraint(
                     Compliance=0.0,
                     **{
-                        "Custom Bend Rotation": pin_rotations,
+                        "Custom Bend Rotation": True,
                         "Bend Rotation": g.AxisAngleToRotation(angle=angle),
                     },
                 )
@@ -2495,12 +2495,12 @@ class DNAFromCurve(AssetGeometryGroup):
         Curves
     base_resolution : InputInteger
         Base Resolution
-    socket_3 : InputMenu | Literal["Static", "Simulate"]
+    menu : InputMenu | Literal["Static", "Simulate"]
         Menu
     wind : InputFloat
         Wind
-    socket_5 : InputMenu | Literal["Instance", "Realize"]
-        Menu
+    base_instance : InputMenu | Literal["Instance", "Realize"]
+        Base Instance
 
     Inputs
     ------
@@ -2508,12 +2508,12 @@ class DNAFromCurve(AssetGeometryGroup):
         Curves
     i.base_resolution : IntegerSocket
         Base Resolution
-    i.socket_3 : MenuSocket
+    i.menu : MenuSocket
         Menu
     i.wind : FloatSocket
         Wind
-    i.socket_5 : MenuSocket
-        Menu
+    i.base_instance : MenuSocket
+        Base Instance
 
     Outputs
     -------
@@ -2531,12 +2531,12 @@ class DNAFromCurve(AssetGeometryGroup):
         """Curves"""
         base_resolution: IntegerSocket
         """Base Resolution"""
-        socket_3: MenuSocket
+        menu: MenuSocket
         """Menu"""
         wind: FloatSocket
         """Wind"""
-        socket_5: MenuSocket
-        """Menu"""
+        base_instance: MenuSocket
+        """Base Instance"""
 
     class _Outputs(SocketAccessor):
         geometry: GeometrySocket
@@ -2553,13 +2553,18 @@ class DNAFromCurve(AssetGeometryGroup):
         self,
         curves: InputGeometry = None,
         base_resolution: InputInteger = 0,
-        socket_3: InputMenu | Literal["Static", "Simulate"] = "Static",
+        menu: InputMenu | Literal["Static", "Simulate"] = "Static",
         wind: InputFloat = 1.0,
-        socket_5: InputMenu | Literal["Instance", "Realize"] = "Instance",
+        base_instance: InputMenu | Literal["Instance", "Realize"] = "Instance",
     ):
         super().__init__(
-            **{"Curves": curves, "Base Resolution": base_resolution, "Wind": wind},
-            _named_links=[("Menu", socket_3), ("Menu", socket_5)],
+            **{
+                "Curves": curves,
+                "Base Resolution": base_resolution,
+                "Menu": menu,
+                "Wind": wind,
+                "Base Instance": base_instance,
+            }
         )
 
     def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
@@ -2571,7 +2576,10 @@ class DNAFromCurve(AssetGeometryGroup):
         wind = tree.inputs.float(
             "Wind", 1.0, min_value=0.0, max_value=1.0, subtype="FACTOR"
         )
-        menu_1 = tree.inputs.menu("Menu", optional_label=True)
+        with tree.inputs.panel("Bases"):
+            base_instance = tree.inputs.menu(
+                "Base Instance", expanded=True, optional_label=True
+            )
         geometry = tree.outputs.geometry("Geometry")
 
         with g.Frame("Base instances"):
@@ -2597,18 +2605,24 @@ class DNAFromCurve(AssetGeometryGroup):
             switch = g.NamedAttribute.boolean("is_comp").o.attribute.switch.integer(
                 integer_math_1, abs(integer_math_1 - 3)
             )
-        math_1 = g.Value(math.tau).o.value / g.Value(10.5)
-        accumulate_field = g.Mix(
-            factor_float=wind, b_float=math_1 / integer_math, clamp_factor=True
-        ).o.result_float.point.trailing(g.CurveOfPoint().o.curve_index)
+        math_1 = wind * (g.Value(math.tau).o.value / g.Value(10.5) * integer_math)
+        axis_angle_to_rotation = g.AxisAngleToRotation(
+            axis=g.CurveTangent(),
+            angle=math_1.point.trailing(g.CurveOfPoint().o.curve_index),
+        )
         store_named_attribute = g.SetHandleType(
             curve=g.SetSplineType.bezier(curves)
         ) >> g.StoreNamedAttribute.point.quaternion(
-            name="rotation",
-            value=g.AxisAngleToRotation(axis=g.CurveTangent(), angle=accumulate_field),
+            name="rotation", value=axis_angle_to_rotation
         )
-        with g.Frame("Distance per unwound base"):
-            math_2 = g.Value(0.63).o.value * integer_math
+        with g.Frame("Base distances"):
+            mix = g.Mix(
+                factor_float=wind,
+                a_float=g.Value(0.63),
+                b_float=g.Value(0.34),
+                clamp_factor=True,
+            )
+            math_2 = integer_math * mix.o.result_float
         vector_math = g.VectorMath.scale(
             g.NoiseTexture(
                 w=g.SceneTime().o.seconds, scale=1.02, noise_dimensions="4D"
@@ -2616,16 +2630,9 @@ class DNAFromCurve(AssetGeometryGroup):
             4.99,
         )
         group_3 = SimulateDNAGuide(
-            **{"DNA Curve": store_named_attribute, "Pin Rotations": True},
-            Angle=g.Mix(
-                factor_float=wind, b_float=math_1 * integer_math, clamp_factor=True
-            ).o.result_float,
-            Distance=g.Mix(
-                factor_float=wind,
-                a_float=math_2,
-                b_float=g.Value(0.34),
-                clamp_factor=True,
-            ).o.result_float,
+            **{"DNA Curve": store_named_attribute},
+            Angle=math_1,
+            Distance=math_2,
             Bendiness=0.0,
             Linear=10.0,
             Angular=30.0,
@@ -2636,13 +2643,11 @@ class DNAFromCurve(AssetGeometryGroup):
         )
         with g.Frame("Handles aren't simulated, so we reset their auto positions"):
             set_handle_type = g.SetHandleType(curve=menu_switch)
+        duplicate_elements = g.DuplicateElements.spline(set_handle_type, amount=2)
         _group_4 = CurveVisualize(
             curve=g.JoinGeometry(geometry=(set_handle_type,)),
             handles=True,
             arrow_size=10.0,
-        )
-        duplicate_elements = g.DuplicateElements.spline(
-            g.SubdivideCurve(curve=set_handle_type, cuts=base_resolution), amount=2
         )
         store_named_attribute_1 = (
             duplicate_elements
@@ -2651,34 +2656,31 @@ class DNAFromCurve(AssetGeometryGroup):
             )
         )
         with g.Frame("Compute normal from rotation"):
-            axis_angle_to_rotation = g.AxisAngleToRotation(
+            axis_angle_to_rotation_1 = g.AxisAngleToRotation(
                 angle=g.NamedAttribute.boolean("is_comp").o.attribute.switch.float(
                     true=2.23
                 )
             )
             rotate_rotation = g.NamedAttribute.quaternion(
                 "rotation"
-            ).o.attribute.rotate(axis_angle_to_rotation, rotation_space="LOCAL")
+            ).o.attribute.rotate(axis_angle_to_rotation_1, rotation_space="LOCAL")
             capture = g.CaptureAttribute.point(geometry=store_named_attribute_1)
             rotation = capture.items.rotation("Rotation", rotate_rotation)
             set_curve_normal = capture.o.geometry >> g.SetCurveNormal(
                 normal=g.RotateVector(rotation=rotation.output, vector=(0.0, 1.0, 0.0)),
                 mode="Free",
             )
-        with g.Frame("Offset from guide curve using normal"):
-            capture_1 = g.CaptureAttribute.point(geometry=set_curve_normal)
-            capture_1.items.vector("Position", g.Position())
-            normal = capture_1.items.vector("Normal", g.Normal().o.normal)
-            reverse_curve = (
-                capture_1.o.geometry
-                >> g.SetPosition(offset=normal.output * AngstromToWorld(angstrom=7.5))
-                >> g.SetCurveNormal(normal=normal.output * -1.0, mode="Free")
-                >> g.ReverseCurve(
-                    selection=g.NamedAttribute.boolean("is_comp").o.attribute
-                )
-            )
-            group_5 = OffsetCurve(curve=reverse_curve)
-        capture_2 = g.CaptureAttribute.point(geometry=group_5)
+        capture_1 = g.CaptureAttribute.point(geometry=set_curve_normal)
+        capture_1.items.vector("Position", g.Position())
+        normal = capture_1.items.vector("Normal", g.Normal().o.normal)
+        reverse_curve = (
+            capture_1.o.geometry
+            >> g.SetPosition(offset=normal.output * AngstromToWorld(angstrom=7.5))
+            >> g.SetCurveNormal(normal=normal.output * -1.0, mode="Free")
+            >> g.SubdivideCurve()
+            >> g.ReverseCurve(selection=g.NamedAttribute.boolean("is_comp").o.attribute)
+        )
+        capture_2 = g.CaptureAttribute.point(geometry=OffsetCurve(curve=reverse_curve))
         normal_1 = capture_2.items.vector("Normal", g.Normal().o.normal)
         instance_on_points = capture_2.o.geometry >> g.InstanceOnPoints(
             instance=group_1,
@@ -2689,28 +2691,32 @@ class DNAFromCurve(AssetGeometryGroup):
             pick_instance=True,
         )
         with g.Frame("Rotate individual base nucleotides"):
+            group_5 = TransformLocalAxis(
+                axis=normal_1.output,
+                angle=g.Mix(
+                    factor_float=wind, a_float=math.pi / 4, clamp_factor=True
+                ).o.result_float,
+            )
             capture_3 = g.CaptureAttribute.instance(geometry=instance_on_points)
-            transform = capture_3.items.matrix(
-                "Transform", TransformLocalAxis(axis=normal_1.output, angle=1.1519172)
-            )
-            transform_point = g.Position().o.position.transform(
-                IsSideChain().o.selection.switch.matrix(true=transform.output)
-            )
+            transform = capture_3.items.matrix("Transform", group_5)
             set_position = (
                 capture_3.o.geometry
                 >> g.RealizeInstances(depth=1)
-                >> g.SetPosition(position=transform_point)
+                >> g.SetPosition(
+                    selection=IsSideChain().o.selection,
+                    position=g.Position().o.position.transform(transform.output),
+                )
             )
         (
             g.MenuSwitch.geometry(
-                menu_1, {"Instance": instance_on_points, "Realize": set_position}
+                base_instance, {"Instance": instance_on_points, "Realize": set_position}
             )
             >> g.JoinGeometry()
             >> geometry
         )
 
         menu.default_value = "Static"
-        menu_1.default_value = "Instance"
+        base_instance.default_value = "Instance"
 
 
 ASSET = DNAFromCurve

--- a/molecularnodes/nodes/geometry/force_brownian.py
+++ b/molecularnodes/nodes/geometry/force_brownian.py
@@ -1,0 +1,117 @@
+# Node-group asset "Force Brownian" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    FloatSocket,
+    PackageLibrary,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputFloat, InputVector
+
+
+class ForceBrownian(AssetGeometryGroup):
+    """
+    Force Brownian
+
+    Parameters
+    ----------
+    add : InputVector
+        Add
+    small : InputFloat
+        Small
+    large : InputFloat
+        Large
+
+    Inputs
+    ------
+    i.add : VectorSocket
+        Add
+    i.small : FloatSocket
+        Small
+    i.large : FloatSocket
+        Large
+
+    Outputs
+    -------
+    o.force : VectorSocket
+        Force
+    """
+
+    _name = "Force Brownian"
+    _asset_name = "Force Brownian"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "INPUT"
+
+    class _Inputs(SocketAccessor):
+        add: VectorSocket
+        """Add"""
+        small: FloatSocket
+        """Small"""
+        large: FloatSocket
+        """Large"""
+
+    class _Outputs(SocketAccessor):
+        force: VectorSocket
+        """Force"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        add: InputVector = None,
+        small: InputFloat = 0.1,
+        large: InputFloat = 0.0,
+    ):
+        super().__init__(**{"Add": add, "Small": small, "Large": large})
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        add = tree.inputs.vector(
+            "Add",
+            (0.0, 0.0, 0.0),
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            hide_value=True,
+        )
+        small = tree.inputs.float("Small", 0.1, min_value=0.0, max_value=10_000.0)
+        large = tree.inputs.float("Large", 0.0, min_value=0.0, max_value=10_000.0)
+        force = tree.outputs.vector("Force")
+
+        scene_time = g.SceneTime()
+        noise_texture = g.NoiseTexture(
+            w=scene_time.o.seconds,
+            scale=20.0,
+            detail=15.0,
+            roughness=1.0,
+            noise_dimensions="4D",
+        )
+        noise_texture_1 = g.NoiseTexture(
+            w=scene_time.o.seconds,
+            scale=0.1,
+            detail=15.0,
+            roughness=1.0,
+            distortion=10.0,
+            noise_dimensions="4D",
+        )
+        (
+            g.VectorMath.scale(noise_texture.o.color, small / 10.0).o.vector
+            + (add + g.VectorMath.scale(noise_texture_1.o.color, large / 50.0).o.vector)
+            >> force
+        )
+
+
+ASSET = ForceBrownian
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}

--- a/molecularnodes/nodes/geometry/force_gravity.py
+++ b/molecularnodes/nodes/geometry/force_gravity.py
@@ -1,0 +1,89 @@
+# Node-group asset "Force Gravity" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    PackageLibrary,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputVector
+
+
+class ForceGravity(AssetGeometryGroup):
+    """
+    Force Gravity
+
+    Parameters
+    ----------
+    add : InputVector
+        Add
+    gravity : InputVector
+        Gravity
+
+    Inputs
+    ------
+    i.add : VectorSocket
+        Add
+    i.gravity : VectorSocket
+        Gravity
+
+    Outputs
+    -------
+    o.force : VectorSocket
+        Force
+    """
+
+    _name = "Force Gravity"
+    _asset_name = "Force Gravity"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "INPUT"
+
+    class _Inputs(SocketAccessor):
+        add: VectorSocket
+        """Add"""
+        gravity: VectorSocket
+        """Gravity"""
+
+    class _Outputs(SocketAccessor):
+        force: VectorSocket
+        """Force"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        add: InputVector = None,
+        gravity: InputVector = None,
+    ):
+        super().__init__(**{"Add": add, "Gravity": gravity})
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        add = tree.inputs.vector(
+            "Add",
+            (0.0, 0.0, 0.0),
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            hide_value=True,
+        )
+        gravity = tree.inputs.vector(
+            "Gravity", (0.0, 0.0, -9.8), min_value=-10_000.0, max_value=10_000.0
+        )
+        force = tree.outputs.vector("Force")
+
+        add + gravity >> force
+
+
+ASSET = ForceGravity
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}

--- a/molecularnodes/nodes/geometry/force_mesh_collide.py
+++ b/molecularnodes/nodes/geometry/force_mesh_collide.py
@@ -1,0 +1,134 @@
+# Node-group asset "Force Mesh Collide" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    MenuSocket,
+    PackageLibrary,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import InputFloat, InputGeometry, InputMenu, InputVector
+
+
+class ForceMeshCollide(AssetGeometryGroup):
+    """
+    Force Mesh Collide
+
+    Parameters
+    ----------
+    add : InputVector
+        Add
+    geometry : InputGeometry
+        Geometry
+    geometry_bounds : InputMenu | Literal["Original", "Convex Hull"]
+        Geometry Bounds
+    collision_distance : InputFloat
+        Collision Distance
+
+    Inputs
+    ------
+    i.add : VectorSocket
+        Add
+    i.geometry : GeometrySocket
+        Geometry
+    i.geometry_bounds : MenuSocket
+        Geometry Bounds
+    i.collision_distance : FloatSocket
+        Collision Distance
+
+    Outputs
+    -------
+    o.force : VectorSocket
+        Force
+    """
+
+    _name = "Force Mesh Collide"
+    _asset_name = "Force Mesh Collide"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "INPUT"
+
+    class _Inputs(SocketAccessor):
+        add: VectorSocket
+        """Add"""
+        geometry: GeometrySocket
+        """Geometry"""
+        geometry_bounds: MenuSocket
+        """Geometry Bounds"""
+        collision_distance: FloatSocket
+        """Collision Distance"""
+
+    class _Outputs(SocketAccessor):
+        force: VectorSocket
+        """Force"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        add: InputVector = None,
+        geometry: InputGeometry = None,
+        geometry_bounds: InputMenu | Literal["Original", "Convex Hull"] = "Original",
+        collision_distance: InputFloat = 0.1,
+    ):
+        super().__init__(
+            **{
+                "Add": add,
+                "Geometry": geometry,
+                "Geometry Bounds": geometry_bounds,
+                "Collision Distance": collision_distance,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        add = tree.inputs.vector(
+            "Add",
+            (0.0, 0.0, 0.0),
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            hide_value=True,
+        )
+        geometry = tree.inputs.geometry("Geometry")
+        geometry_bounds = tree.inputs.menu("Geometry Bounds", optional_label=True)
+        collision_distance = tree.inputs.float(
+            "Collision Distance", 0.1, min_value=-10_000.0, max_value=10_000.0
+        )
+        force = tree.outputs.vector("Force")
+
+        menu_switch = g.MenuSwitch.geometry(
+            geometry_bounds,
+            {"Original": geometry, "Convex Hull": g.ConvexHull(geometry=geometry)},
+        )
+        geometry_proximity = g.GeometryProximity(target=menu_switch)
+        map_range = geometry_proximity.o.distance.map_range(
+            from_max=collision_distance, to_min=1.0, to_max=0.0
+        )
+        vector_math = g.Position().o.position - geometry_proximity.o.position
+        vector_math_1 = vector_math.normalize()
+        vector_math_2 = g.Raycast.vector(
+            menu_switch, (0.0, 0.0, 0.0), ray_direction=vector_math * -1.0
+        ).o.hit_normal.dot(vector_math_1)
+        (
+            add + vector_math_1 * (vector_math_2 > -0.1).switch.float(-1.0, map_range)
+            >> force
+        )
+
+        geometry_bounds.default_value = "Original"
+
+
+ASSET = ForceMeshCollide
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}

--- a/molecularnodes/nodes/geometry/simulate_curve.py
+++ b/molecularnodes/nodes/geometry/simulate_curve.py
@@ -1,0 +1,473 @@
+# Node-group asset "Simulate Curve" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    IntegerSocket,
+    PackageLibrary,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import (
+    InputBoolean,
+    InputFloat,
+    InputGeometry,
+    InputInteger,
+    InputVector,
+)
+from ._shared.constraint_distance import ConstraintDistance
+from ._shared.inverse_mass import InverseMass
+from ._shared.xpbd_finalise import XPBDFinalise
+from ._shared.xpbd_init import XPBDInit
+from ._shared.xpbd_solve_hook import XPBDSolveHook
+from .mass import Mass
+from .offset_float import OffsetFloat
+from .offset_vector import OffsetVector
+
+
+class XPBDSolveCurve(CustomGeometryGroup):
+    _name = "XPBD Solve Curve"
+    _color_tag = "GEOMETRY"
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        points = tree.inputs.integer("Points", 2, min_value=0, max_value=5)
+        straightness = tree.inputs.float(
+            "Straightness", 0.9, min_value=0.0, max_value=1.0, subtype="FACTOR"
+        )
+        length = tree.inputs.float("Length", 0.0)
+        alpha = tree.inputs.float("alpha", 0.0, min_value=0.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.0,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        group = InverseMass()
+        separate_components = g.SeparateComponents(geometry=geometry)
+        repeat_zone = g.RepeatZone(points)
+        geometry_2 = repeat_zone.items.geometry("Geometry", separate_components.o.curve)
+        integer_math = repeat_zone.iteration + 1
+        math_1 = (
+            integer_math
+            * g.Mix(
+                factor_float=straightness, a_float=0.5, b_float=1.0, clamp_factor=True
+            ).o.result_float
+        )
+        repeat_zone_1 = g.RepeatZone(2)
+        geometry_3 = repeat_zone_1.items.geometry("Geometry", geometry_2.current)
+        index_switch = g.IndexSwitch.boolean(
+            repeat_zone_1.iteration,
+            (
+                g.EndpointSelection(end_size=integer_math, start_size=0),
+                g.EndpointSelection(start_size=integer_math, end_size=0),
+            ),
+        )
+        index_switch_1 = g.IndexSwitch.integer(
+            repeat_zone_1.iteration, (integer_math, -integer_math)
+        )
+        group_1 = ConstraintDistance(
+            target=OffsetVector(offset=index_switch_1),
+            distance=(repeat_zone.iteration > 0).switch.float(integer_math, math_1)
+            * length,
+            w1=group.o.w,
+            w2=OffsetFloat(value=group.o.w, offset=index_switch_1),
+            alpha=alpha,
+            deltat=deltat,
+        )
+        set_position = g.SetPosition(
+            geometry=geometry_3.current,
+            selection=g.BooleanMath.subtract(selection, index_switch),
+            offset=group_1.o.correction,
+        )
+        set_position >> geometry_3.next
+        geometry_3.result >> geometry_2.next
+        join_geometry = g.JoinGeometry(
+            geometry=(
+                separate_components.o.mesh,
+                geometry_2.result,
+                separate_components.o.grease_pencil,
+                separate_components.o.point_cloud,
+                separate_components.o.volume,
+                separate_components.o.instances,
+            )
+        )
+
+        join_geometry >> geometry_1
+
+
+class XPBDSolvePointsForCurve(CustomGeometryGroup):
+    _name = "XPBD Solve Points for Curve"
+    _color_tag = "GEOMETRY"
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        radius = tree.inputs.float("Radius", 0.0)
+        alpha = tree.inputs.float("alpha", 0.0, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.0,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        vector_math = (
+            g.Position().o.position
+            + g.RandomValue.vector((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)).o.value * 0.001
+        )
+        capture = g.CaptureAttribute.point(geometry=geometry)
+        vector = capture.items.vector("Vector", vector_math)
+        capture_1 = g.CaptureAttribute.point(geometry=capture.o.geometry)
+        index = capture_1.items.integer(
+            "Index", g.IndexOfNearest(position=vector.output).o.index
+        )
+        math_1 = radius.point.at(index.output) + radius
+        group = ConstraintDistance(
+            target=g.Position().o.position.point.at(index.output),
+            distance=math_1,
+            w1=1.0,
+            w2=1.0,
+            alpha=alpha,
+            deltat=deltat,
+        )
+        (
+            capture_1.o.geometry
+            >> g.SetPosition(
+                selection=selection & (math_1 > group.o.value),
+                offset=group.o.correction,
+            )
+            >> geometry_1
+        )
+
+
+class SimulateCurve(AssetGeometryGroup):
+    """
+    Simulate Curve
+
+    Parameters
+    ----------
+    geometry : InputGeometry
+        Geometry containing curve to simulate
+    selection : InputBoolean
+        Which points to simulate on the curve
+    substeps : InputInteger
+        Number of substeps to simulate for each frame of the animation (higher is slower but more accurate)
+    force : InputVector
+        Additional forces to be applied to the simulation
+    drag : InputFloat
+        Drag force for how quickly velocity should dissipate in the simulation. 0 is no drag and higher values dissipate quicker.
+    point_radius : InputFloat
+        Radius for each point which is used for calculating collisions between points
+    point_alpha : InputFloat
+        Point alpha
+    curve_points : InputInteger
+        Number of points to check in each direction to maintain straightness of curve
+    curve_straightness : InputFloat
+        Curve Straightness
+    curve_segment_length : InputFloat
+        Curve Segment Length
+    curve_alpha : InputFloat
+        Curve alpha
+    hook_selection : InputBoolean
+        Hook Selection
+    hook_target : InputVector
+        Hook Target
+    hook_decay : InputFloat
+        Hook Decay
+    pin_selection : InputBoolean
+        Pin Selection
+    pin_target : InputVector
+        Pin Target
+
+    Inputs
+    ------
+    i.geometry : GeometrySocket
+        Geometry containing curve to simulate
+    i.selection : BooleanSocket
+        Which points to simulate on the curve
+    i.substeps : IntegerSocket
+        Number of substeps to simulate for each frame of the animation (higher is slower but more accurate)
+    i.force : VectorSocket
+        Additional forces to be applied to the simulation
+    i.drag : FloatSocket
+        Drag force for how quickly velocity should dissipate in the simulation. 0 is no drag and higher values dissipate quicker.
+    i.point_radius : FloatSocket
+        Radius for each point which is used for calculating collisions between points
+    i.point_alpha : FloatSocket
+        Point alpha
+    i.curve_points : IntegerSocket
+        Number of points to check in each direction to maintain straightness of curve
+    i.curve_straightness : FloatSocket
+        Curve Straightness
+    i.curve_segment_length : FloatSocket
+        Curve Segment Length
+    i.curve_alpha : FloatSocket
+        Curve alpha
+    i.hook_selection : BooleanSocket
+        Hook Selection
+    i.hook_target : VectorSocket
+        Hook Target
+    i.hook_decay : FloatSocket
+        Hook Decay
+    i.pin_selection : BooleanSocket
+        Pin Selection
+    i.pin_target : VectorSocket
+        Pin Target
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    """
+
+    _name = "Simulate Curve"
+    _asset_name = "Simulate Curve"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry containing curve to simulate"""
+        selection: BooleanSocket
+        """Which points to simulate on the curve"""
+        substeps: IntegerSocket
+        """Number of substeps to simulate for each frame of the animation (higher is slower but more accurate)"""
+        force: VectorSocket
+        """Additional forces to be applied to the simulation"""
+        drag: FloatSocket
+        """Drag force for how quickly velocity should dissipate in the simulation. 0 is no drag and higher values dissipate quicker."""
+        point_radius: FloatSocket
+        """Radius for each point which is used for calculating collisions between points"""
+        point_alpha: FloatSocket
+        """Point alpha"""
+        curve_points: IntegerSocket
+        """Number of points to check in each direction to maintain straightness of curve"""
+        curve_straightness: FloatSocket
+        """Curve Straightness"""
+        curve_segment_length: FloatSocket
+        """Curve Segment Length"""
+        curve_alpha: FloatSocket
+        """Curve alpha"""
+        hook_selection: BooleanSocket
+        """Hook Selection"""
+        hook_target: VectorSocket
+        """Hook Target"""
+        hook_decay: FloatSocket
+        """Hook Decay"""
+        pin_selection: BooleanSocket
+        """Pin Selection"""
+        pin_target: VectorSocket
+        """Pin Target"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        geometry: InputGeometry = None,
+        selection: InputBoolean = True,
+        substeps: InputInteger = 5,
+        force: InputVector = None,
+        drag: InputFloat = 1.0,
+        point_radius: InputFloat = 0.04,
+        point_alpha: InputFloat = 0.0,
+        curve_points: InputInteger = 1,
+        curve_straightness: InputFloat = 0.9,
+        curve_segment_length: InputFloat = 0.1,
+        curve_alpha: InputFloat = 0.0,
+        hook_selection: InputBoolean = False,
+        hook_target: InputVector = None,
+        hook_decay: InputFloat = 0.5,
+        pin_selection: InputBoolean = False,
+        pin_target: InputVector = None,
+    ):
+        super().__init__(
+            **{
+                "Geometry": geometry,
+                "Selection": selection,
+                "Substeps": substeps,
+                "Force": force,
+                "Drag": drag,
+                "Point Radius": point_radius,
+                "Point alpha": point_alpha,
+                "Curve Points": curve_points,
+                "Curve Straightness": curve_straightness,
+                "Curve Segment Length": curve_segment_length,
+                "Curve alpha": curve_alpha,
+                "Hook Selection": hook_selection,
+                "Hook Target": hook_target,
+                "Hook Decay": hook_decay,
+                "Pin Selection": pin_selection,
+                "Pin Target": pin_target,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry(
+            "Geometry", description="Geometry containing curve to simulate"
+        )
+        selection = tree.inputs.boolean(
+            "Selection",
+            True,
+            description="Which points to simulate on the curve",
+            hide_value=True,
+        )
+        substeps = tree.inputs.integer(
+            "Substeps",
+            5,
+            description="Number of substeps to simulate for each frame of the animation (higher is slower but more accurate)",
+            min_value=1,
+            max_value=100,
+        )
+        with tree.inputs.panel("Simulation"):
+            force = tree.inputs.vector(
+                "Force",
+                (0.0, 0.0, 0.0),
+                description="Additional forces to be applied to the simulation",
+                min_value=-10_000.0,
+                max_value=10_000.0,
+                hide_value=True,
+            )
+            drag = tree.inputs.float(
+                "Drag",
+                1.0,
+                description="Drag force for how quickly velocity should dissipate in the simulation. 0 is no drag and higher values dissipate quicker.",
+                min_value=0.0,
+                max_value=10_000.0,
+            )
+        with tree.inputs.panel("Point"):
+            point_radius = tree.inputs.float(
+                "Point Radius",
+                0.04,
+                description="Radius for each point which is used for calculating collisions between points",
+                min_value=0.0,
+            )
+            point_alpha = tree.inputs.float(
+                "Point alpha", 0.0, min_value=-10_000.0, max_value=10_000.0
+            )
+        with tree.inputs.panel("Curve"):
+            curve_points = tree.inputs.integer(
+                "Curve Points",
+                1,
+                description="Number of points to check in each direction to maintain straightness of curve",
+                min_value=0,
+                max_value=5,
+            )
+            curve_straightness = tree.inputs.float(
+                "Curve Straightness",
+                0.9,
+                min_value=0.0,
+                max_value=1.0,
+                subtype="FACTOR",
+            )
+            curve_segment_length = tree.inputs.float(
+                "Curve Segment Length", 0.1, min_value=0.0
+            )
+            curve_alpha = tree.inputs.float(
+                "Curve alpha", 0.0, min_value=0.0, max_value=10_000.0
+            )
+        with tree.inputs.panel("Hook"):
+            hook_selection = tree.inputs.boolean(
+                "Hook Selection", False, hide_value=True
+            )
+            hook_target = tree.inputs.vector(
+                "Hook Target",
+                (0.0, 0.0, 0.0),
+                min_value=-10_000.0,
+                max_value=10_000.0,
+                hide_value=True,
+            )
+            hook_decay = tree.inputs.float(
+                "Hook Decay", 0.5, min_value=-10_000.0, max_value=10_000.0
+            )
+        with tree.inputs.panel("Pin"):
+            pin_selection = tree.inputs.boolean("Pin Selection", False, hide_value=True)
+            pin_target = tree.inputs.vector(
+                "Pin Target", (0.0, 0.0, 0.0), hide_value=True, default_input="POSITION"
+            )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        boolean_math = g.BooleanMath.subtract(selection, pin_selection)
+        store_named_attribute = g.StoreNamedAttribute.point.float(
+            g.SeparateComponents(geometry=geometry).o.curve,
+            ~g.NamedAttribute.float("mass").o.exists,
+            "mass",
+            1.0,
+        )
+        simulation_zone = g.SimulationZone()
+        geometry_2 = simulation_zone.items.geometry("Geometry", store_named_attribute)
+        math_1 = simulation_zone.delta_time / substeps
+        store_named_attribute_1 = g.StoreNamedAttribute.point.float(
+            geometry_2.current, name="inverse_mass", value=1.0 / Mass()
+        )
+        repeat_zone = g.RepeatZone(substeps)
+        geometry_3 = repeat_zone.items.geometry("Geometry", store_named_attribute_1)
+        group = XPBDInit(
+            geometry=geometry_3.current,
+            selection=boolean_math,
+            force=force,
+            drag=drag,
+            deltat=math_1,
+        )
+        group_1 = XPBDSolveCurve(
+            Geometry=group,
+            Selection=boolean_math,
+            Points=curve_points,
+            Straightness=curve_straightness,
+            Length=curve_segment_length,
+            alpha=curve_alpha,
+            deltaT=math_1,
+        )
+        group_2 = XPBDSolvePointsForCurve(
+            Geometry=group_1,
+            Selection=boolean_math,
+            Radius=point_radius,
+            alpha=point_alpha,
+            deltaT=math_1,
+        )
+        set_position = XPBDSolveHook(
+            geometry=group_2,
+            selection=hook_selection,
+            target=hook_target,
+            decay=hook_decay,
+            deltat=math_1,
+        ) >> g.SetPosition(selection=pin_selection, position=pin_target)
+        (
+            XPBDFinalise(geometry=set_position, selection=boolean_math, deltat=math_1)
+            >> geometry_3.next
+        )
+        geometry_3.result >> geometry_2.next
+
+        geometry_2.result >> geometry_1
+
+
+ASSET = SimulateCurve
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}

--- a/molecularnodes/nodes/geometry/simulate_elastic_network.py
+++ b/molecularnodes/nodes/geometry/simulate_elastic_network.py
@@ -1,0 +1,373 @@
+# Node-group asset "Simulate Elastic Network" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING, Literal
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    IntegerSocket,
+    MenuSocket,
+    PackageLibrary,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import (
+    InputBoolean,
+    InputFloat,
+    InputGeometry,
+    InputInteger,
+    InputMenu,
+    InputVector,
+)
+from ._shared.constraint_distance import ConstraintDistance
+from ._shared.inverse_mass import InverseMass
+from ._shared.xpbd_finalise import XPBDFinalise
+from ._shared.xpbd_init import XPBDInit
+from ._shared.xpbd_solve_hook import XPBDSolveHook
+from ._shared.xpbd_solve_points import XPBDSolvePoints
+from .edge_info import EdgeInfo
+from .edge_length import EdgeLength
+from .mass import Mass
+
+
+class XPBDSolveEdges(CustomGeometryGroup):
+    _name = "XPBD Solve Edges"
+    _color_tag = "GEOMETRY"
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        distance = tree.inputs.float(
+            "Distance", 0.27, min_value=0.0, max_value=10_000.0
+        )
+        alpha = tree.inputs.float("alpha", 0.0, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT",
+            0.0,
+            min_value=-10_000.0,
+            max_value=10_000.0,
+            structure_type="SINGLE",
+            force_non_field=True,
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        group = InverseMass()
+        repeat_zone = g.RepeatZone(
+            g.AttributeStatistic.point.float(
+                geometry, attribute=g.EdgesOfVertex().o.total
+            ).o.max
+        )
+        geometry_2 = repeat_zone.items.geometry("Geometry", geometry)
+        correction = repeat_zone.items.vector("Correction")
+        value = repeat_zone.items.integer("Value")
+        group_1 = EdgeInfo(edge_index=repeat_zone.iteration)
+        boolean_math = selection & group_1.o.is_valid
+        group_2 = ConstraintDistance(
+            target=group_1.o.point_position,
+            distance=distance.edge.at(group_1.o.edge_index),
+            w1=group.o.w,
+            w2=group.o.w.point.at(group_1.o.edge_index),
+            alpha=alpha.edge.at(group_1.o.edge_index),
+            deltat=deltat,
+        )
+        geometry_2.current >> geometry_2.next
+        (
+            correction.current
+            + boolean_math.switch.vector((0.0, 0.0, 0.0), group_2.o.correction)
+            >> correction.next
+        )
+        g.IntegerMath(value=value.current, value_001=boolean_math) >> value.next
+        (
+            geometry_2.result
+            >> g.SetPosition(offset=correction.result / value.result)
+            >> geometry_1
+        )
+
+
+class SimulateElasticNetwork(AssetGeometryGroup):
+    """
+    Simulate Elastic Network
+
+    Parameters
+    ----------
+    mesh : InputGeometry
+        Mesh
+    selection : InputBoolean
+        Selection
+    substeps : InputInteger
+        Substeps
+    force : InputVector
+        Force
+    drag : InputFloat
+        Drag
+    edge_length_source : InputMenu | Literal["Original", "Custom"]
+        Edge Length Source
+    edge_length : InputFloat
+        Edge Length
+    edge_alpha : InputFloat
+        Edge alpha
+    particle_radius : InputFloat
+        Particle Radius
+    particle_alpha : InputFloat
+        Particle alpha
+    hook_selection : InputBoolean
+        Hook Selection
+    hook_target : InputVector
+        Hook Target
+    hook_decay : InputFloat
+        Hook Decay
+    pin_selection : InputBoolean
+        Pin Selection
+    pin_target : InputVector
+        Pin Target
+
+    Inputs
+    ------
+    i.mesh : GeometrySocket
+        Mesh
+    i.selection : BooleanSocket
+        Selection
+    i.substeps : IntegerSocket
+        Substeps
+    i.force : VectorSocket
+        Force
+    i.drag : FloatSocket
+        Drag
+    i.edge_length_source : MenuSocket
+        Edge Length Source
+    i.edge_length : FloatSocket
+        Edge Length
+    i.edge_alpha : FloatSocket
+        Edge alpha
+    i.particle_radius : FloatSocket
+        Particle Radius
+    i.particle_alpha : FloatSocket
+        Particle alpha
+    i.hook_selection : BooleanSocket
+        Hook Selection
+    i.hook_target : VectorSocket
+        Hook Target
+    i.hook_decay : FloatSocket
+        Hook Decay
+    i.pin_selection : BooleanSocket
+        Pin Selection
+    i.pin_target : VectorSocket
+        Pin Target
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    """
+
+    _name = "Simulate Elastic Network"
+    _asset_name = "Simulate Elastic Network"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        mesh: GeometrySocket
+        """Mesh"""
+        selection: BooleanSocket
+        """Selection"""
+        substeps: IntegerSocket
+        """Substeps"""
+        force: VectorSocket
+        """Force"""
+        drag: FloatSocket
+        """Drag"""
+        edge_length_source: MenuSocket
+        """Edge Length Source"""
+        edge_length: FloatSocket
+        """Edge Length"""
+        edge_alpha: FloatSocket
+        """Edge alpha"""
+        particle_radius: FloatSocket
+        """Particle Radius"""
+        particle_alpha: FloatSocket
+        """Particle alpha"""
+        hook_selection: BooleanSocket
+        """Hook Selection"""
+        hook_target: VectorSocket
+        """Hook Target"""
+        hook_decay: FloatSocket
+        """Hook Decay"""
+        pin_selection: BooleanSocket
+        """Pin Selection"""
+        pin_target: VectorSocket
+        """Pin Target"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        mesh: InputGeometry = None,
+        selection: InputBoolean = True,
+        substeps: InputInteger = 5,
+        force: InputVector = None,
+        drag: InputFloat = 0.1,
+        edge_length_source: InputMenu | Literal["Original", "Custom"] = "Original",
+        edge_length: InputFloat = 0.1,
+        edge_alpha: InputFloat = 0.0,
+        particle_radius: InputFloat = 0.005,
+        particle_alpha: InputFloat = 0.0,
+        hook_selection: InputBoolean = False,
+        hook_target: InputVector = None,
+        hook_decay: InputFloat = 2.0,
+        pin_selection: InputBoolean = False,
+        pin_target: InputVector = None,
+    ):
+        super().__init__(
+            **{
+                "Mesh": mesh,
+                "Selection": selection,
+                "Substeps": substeps,
+                "Force": force,
+                "Drag": drag,
+                "Edge Length Source": edge_length_source,
+                "Edge Length": edge_length,
+                "Edge alpha": edge_alpha,
+                "Particle Radius": particle_radius,
+                "Particle alpha": particle_alpha,
+                "Hook Selection": hook_selection,
+                "Hook Target": hook_target,
+                "Hook Decay": hook_decay,
+                "Pin Selection": pin_selection,
+                "Pin Target": pin_target,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        mesh = tree.inputs.geometry("Mesh")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        substeps = tree.inputs.integer("Substeps", 5, min_value=1, max_value=100)
+        with tree.inputs.panel("Simulation"):
+            force = tree.inputs.vector(
+                "Force",
+                (0.0, 0.0, 0.0),
+                min_value=-10_000.0,
+                max_value=10_000.0,
+                hide_value=True,
+            )
+            drag = tree.inputs.float("Drag", 0.1, min_value=0.0, max_value=10_000.0)
+            with tree.inputs.panel("Edge"):
+                edge_length_source = tree.inputs.menu(
+                    "Edge Length Source", optional_label=True
+                )
+                edge_length = tree.inputs.float(
+                    "Edge Length", 0.1, min_value=0.0, max_value=10_000.0
+                )
+                edge_alpha = tree.inputs.float("Edge alpha", 0.0, min_value=0.0)
+            with tree.inputs.panel("Particle"):
+                particle_radius = tree.inputs.float(
+                    "Particle Radius", 0.005, min_value=0.0
+                )
+                particle_alpha = tree.inputs.float("Particle alpha", 0.0, min_value=0.0)
+        with tree.inputs.panel("Hook"):
+            hook_selection = tree.inputs.boolean(
+                "Hook Selection", False, hide_value=True
+            )
+            hook_target = tree.inputs.vector(
+                "Hook Target",
+                (0.0, 0.0, 0.0),
+                min_value=-10_000.0,
+                max_value=10_000.0,
+                hide_value=True,
+            )
+            hook_decay = tree.inputs.float(
+                "Hook Decay", 2.0, min_value=0.0, max_value=10_000.0
+            )
+        with tree.inputs.panel("Pin"):
+            pin_selection = tree.inputs.boolean("Pin Selection", False, hide_value=True)
+            pin_target = tree.inputs.vector(
+                "Pin Target", (0.0, 0.0, 0.0), hide_value=True, default_input="POSITION"
+            )
+        geometry = tree.outputs.geometry("Geometry")
+
+        boolean_math = g.BooleanMath.subtract(selection, pin_selection)
+        menu_switch = g.MenuSwitch.float(
+            edge_length_source,
+            {
+                "Original": g.NamedAttribute.float("tmp_length").o.attribute,
+                "Custom": edge_length,
+            },
+        )
+        store_named_attribute = (
+            mesh
+            >> g.StoreNamedAttribute.point.float(
+                selection=~g.NamedAttribute.float("mass").o.exists,
+                name="mass",
+                value=1.0,
+            )
+            >> g.StoreNamedAttribute.edge.float(name="tmp_length", value=EdgeLength())
+        )
+        simulation_zone = g.SimulationZone()
+        geometry_1 = simulation_zone.items.geometry("Geometry", store_named_attribute)
+        math_1 = simulation_zone.delta_time / substeps
+        store_named_attribute_1 = g.StoreNamedAttribute.point.float(
+            geometry_1.current, name="inverse_mass", value=Mass().o.mass / 0.5
+        )
+        repeat_zone = g.RepeatZone(substeps)
+        geometry_2 = repeat_zone.items.geometry("Geometry", store_named_attribute_1)
+        group = XPBDInit(
+            geometry=geometry_2.current,
+            selection=boolean_math,
+            force=force,
+            drag=drag,
+            deltat=math_1,
+        )
+        group_1 = XPBDSolveEdges(
+            Geometry=group,
+            Selection=boolean_math,
+            Distance=menu_switch.o.output,
+            alpha=edge_alpha,
+            deltaT=math_1,
+        )
+        group_2 = XPBDSolvePoints(
+            geometry=group_1,
+            selection=boolean_math,
+            radius=particle_radius,
+            alpha=particle_alpha,
+            deltat=math_1,
+        )
+        set_position = XPBDSolveHook(
+            geometry=group_2,
+            selection=hook_selection,
+            target=hook_target,
+            decay=hook_decay,
+            deltat=math_1,
+        ) >> g.SetPosition(selection=pin_selection, position=pin_target)
+        (
+            XPBDFinalise(geometry=set_position, selection=boolean_math, deltat=math_1)
+            >> geometry_2.next
+        )
+        geometry_2.result >> geometry_1.next
+        (
+            geometry_1.result
+            >> g.RemoveNamedAttribute(pattern_mode="Wildcard", name="tmp_*")
+            >> geometry
+        )
+
+        edge_length_source.default_value = "Original"
+
+
+ASSET = SimulateElasticNetwork
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}

--- a/molecularnodes/nodes/geometry/simulate_on_faces.py
+++ b/molecularnodes/nodes/geometry/simulate_on_faces.py
@@ -1,0 +1,324 @@
+# Node-group asset "Simulate on Faces" (GeometryNodeTree), dumped by nodebpy.assets.dump_library.
+# Rebuild the library with nodebpy.assets.build_library (python -m nodebpy.assets build).
+# _build_group() is the source of truth: the docstring, __init__ and accessors are regenerated from it on the next dump.
+from typing import TYPE_CHECKING
+from bpy.types import GeometryNodeTree
+from nodebpy import TreeBuilder
+from nodebpy import geometry as g
+from nodebpy.builder import (
+    AssetGeometryGroup,
+    BooleanSocket,
+    CustomGeometryGroup,
+    FloatSocket,
+    GeometrySocket,
+    IntegerSocket,
+    PackageLibrary,
+    SocketAccessor,
+    VectorSocket,
+)
+from nodebpy.types import (
+    InputBoolean,
+    InputFloat,
+    InputGeometry,
+    InputInteger,
+    InputVector,
+)
+from ._shared.constraint_distance import ConstraintDistance
+from ._shared.xpbd_finalise import XPBDFinalise
+from ._shared.xpbd_init import XPBDInit
+from ._shared.xpbd_solve_hook import XPBDSolveHook
+from ._shared.xpbd_solve_points import XPBDSolvePoints
+from .mass import Mass
+
+
+class XPBDSolveOnFaces(CustomGeometryGroup):
+    _name = "XPBD Solve on Faces"
+    _color_tag = "GEOMETRY"
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        geometry = tree.inputs.geometry("Geometry")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        faces = tree.inputs.geometry("Faces")
+        alpha = tree.inputs.float("alpha", 0.0, min_value=-10_000.0, max_value=10_000.0)
+        deltat = tree.inputs.float(
+            "deltaT", 0.0, min_value=-10_000.0, max_value=10_000.0
+        )
+        geometry_1 = tree.outputs.geometry("Geometry")
+
+        geometry_proximity = g.GeometryProximity(target=faces)
+        group = ConstraintDistance(
+            target=geometry_proximity.o.position,
+            distance=0.0,
+            alpha=alpha,
+            deltat=deltat,
+        )
+        (
+            geometry
+            >> g.SetPosition(
+                selection=selection & geometry_proximity.o.is_valid,
+                offset=group.o.correction,
+            )
+            >> geometry_1
+        )
+
+
+class SimulateOnFaces(AssetGeometryGroup):
+    """
+    Simulate on Faces
+
+    Parameters
+    ----------
+    points : InputGeometry
+        Points
+    selection : InputBoolean
+        Selection
+    substeps : InputInteger
+        Substeps
+    force : InputVector
+        Force
+    drag : InputFloat
+        Drag
+    faces : InputGeometry
+        Faces
+    alpha : InputFloat
+        alpha
+    particle_radius : InputFloat
+        Particle Radius
+    particle_alpha : InputFloat
+        Particle alpha
+    hook_selection : InputBoolean
+        Hook Selection
+    hook_target : InputVector
+        Hook Target
+    hook_decay : InputFloat
+        Hook Decay
+    pin_selection : InputBoolean
+        Pin Selection
+    pin_target : InputVector
+        Pin Target
+
+    Inputs
+    ------
+    i.points : GeometrySocket
+        Points
+    i.selection : BooleanSocket
+        Selection
+    i.substeps : IntegerSocket
+        Substeps
+    i.force : VectorSocket
+        Force
+    i.drag : FloatSocket
+        Drag
+    i.faces : GeometrySocket
+        Faces
+    i.alpha : FloatSocket
+        alpha
+    i.particle_radius : FloatSocket
+        Particle Radius
+    i.particle_alpha : FloatSocket
+        Particle alpha
+    i.hook_selection : BooleanSocket
+        Hook Selection
+    i.hook_target : VectorSocket
+        Hook Target
+    i.hook_decay : FloatSocket
+        Hook Decay
+    i.pin_selection : BooleanSocket
+        Pin Selection
+    i.pin_target : VectorSocket
+        Pin Target
+
+    Outputs
+    -------
+    o.geometry : GeometrySocket
+        Geometry
+    o.normal : VectorSocket
+        Normal of the face the current point is nearest
+    """
+
+    _name = "Simulate on Faces"
+    _asset_name = "Simulate on Faces"
+    _library = PackageLibrary(__file__, "../../assets/node_data_file.blend")
+    _color_tag = "GEOMETRY"
+
+    class _Inputs(SocketAccessor):
+        points: GeometrySocket
+        """Points"""
+        selection: BooleanSocket
+        """Selection"""
+        substeps: IntegerSocket
+        """Substeps"""
+        force: VectorSocket
+        """Force"""
+        drag: FloatSocket
+        """Drag"""
+        faces: GeometrySocket
+        """Faces"""
+        alpha: FloatSocket
+        particle_radius: FloatSocket
+        """Particle Radius"""
+        particle_alpha: FloatSocket
+        """Particle alpha"""
+        hook_selection: BooleanSocket
+        """Hook Selection"""
+        hook_target: VectorSocket
+        """Hook Target"""
+        hook_decay: FloatSocket
+        """Hook Decay"""
+        pin_selection: BooleanSocket
+        """Pin Selection"""
+        pin_target: VectorSocket
+        """Pin Target"""
+
+    class _Outputs(SocketAccessor):
+        geometry: GeometrySocket
+        """Geometry"""
+        normal: VectorSocket
+        """Normal of the face the current point is nearest"""
+
+    if TYPE_CHECKING:
+
+        @property
+        def i(self) -> _Inputs: ...
+        @property
+        def o(self) -> _Outputs: ...
+
+    def __init__(
+        self,
+        points: InputGeometry = None,
+        selection: InputBoolean = True,
+        substeps: InputInteger = 5,
+        force: InputVector = None,
+        drag: InputFloat = 0.1,
+        faces: InputGeometry = None,
+        alpha: InputFloat = 0.0,
+        particle_radius: InputFloat = 0.0,
+        particle_alpha: InputFloat = 0.0,
+        hook_selection: InputBoolean = False,
+        hook_target: InputVector = None,
+        hook_decay: InputFloat = 2.0,
+        pin_selection: InputBoolean = False,
+        pin_target: InputVector = None,
+    ):
+        super().__init__(
+            **{
+                "Points": points,
+                "Selection": selection,
+                "Substeps": substeps,
+                "Force": force,
+                "Drag": drag,
+                "Faces": faces,
+                "alpha": alpha,
+                "Particle Radius": particle_radius,
+                "Particle alpha": particle_alpha,
+                "Hook Selection": hook_selection,
+                "Hook Target": hook_target,
+                "Hook Decay": hook_decay,
+                "Pin Selection": pin_selection,
+                "Pin Target": pin_target,
+            }
+        )
+
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
+        points = tree.inputs.geometry("Points")
+        selection = tree.inputs.boolean("Selection", True, hide_value=True)
+        substeps = tree.inputs.integer("Substeps", 5, min_value=1, max_value=100)
+        with tree.inputs.panel("Simulation"):
+            force = tree.inputs.vector(
+                "Force",
+                (0.0, 0.0, 0.0),
+                min_value=-10_000.0,
+                max_value=10_000.0,
+                hide_value=True,
+            )
+            drag = tree.inputs.float(
+                "Drag", 0.1, min_value=-10_000.0, max_value=10_000.0
+            )
+            with tree.inputs.panel("Faces"):
+                faces = tree.inputs.geometry("Faces")
+                alpha = tree.inputs.float(
+                    "alpha", 0.0, min_value=-10_000.0, max_value=10_000.0
+                )
+            with tree.inputs.panel("Particle"):
+                particle_radius = tree.inputs.float(
+                    "Particle Radius", 0.0, min_value=0.0
+                )
+                particle_alpha = tree.inputs.float("Particle alpha", 0.0, min_value=0.0)
+        with tree.inputs.panel("Hook"):
+            hook_selection = tree.inputs.boolean(
+                "Hook Selection", False, hide_value=True
+            )
+            hook_target = tree.inputs.vector(
+                "Hook Target",
+                (0.0, 0.0, 0.0),
+                min_value=-10_000.0,
+                max_value=10_000.0,
+                hide_value=True,
+            )
+            hook_decay = tree.inputs.float(
+                "Hook Decay", 2.0, min_value=0.0, max_value=10_000.0
+            )
+        with tree.inputs.panel("Pin"):
+            pin_selection = tree.inputs.boolean("Pin Selection", False, hide_value=True)
+            pin_target = tree.inputs.vector(
+                "Pin Target", (0.0, 0.0, 0.0), hide_value=True, default_input="POSITION"
+            )
+        geometry = tree.outputs.geometry("Geometry")
+        normal = tree.outputs.vector(
+            "Normal", description="Normal of the face the current point is nearest"
+        )
+
+        boolean_math = g.BooleanMath.subtract(selection, pin_selection)
+        store_named_attribute = g.StoreNamedAttribute.point.float(
+            points, ~g.NamedAttribute.float("mass").o.exists, "mass", 1.0
+        )
+        simulation_zone = g.SimulationZone()
+        geometry_1 = simulation_zone.items.geometry("Geometry", store_named_attribute)
+        math_1 = simulation_zone.delta_time / substeps
+        store_named_attribute_1 = g.StoreNamedAttribute.point.float(
+            geometry_1.current, name="inverse_mass", value=1.0 / Mass()
+        )
+        repeat_zone = g.RepeatZone(substeps)
+        geometry_2 = repeat_zone.items.geometry("Geometry", store_named_attribute_1)
+        group = XPBDInit(
+            geometry=geometry_2.current,
+            selection=boolean_math,
+            force=force,
+            drag=drag,
+            deltat=math_1,
+        )
+        group_1 = XPBDSolvePoints(
+            geometry=XPBDSolveOnFaces(
+                Geometry=group, Faces=faces, alpha=alpha, deltaT=math_1
+            ),
+            selection=boolean_math,
+            radius=particle_radius,
+            alpha=particle_alpha,
+            deltat=math_1,
+        )
+        set_position = XPBDSolveHook(
+            geometry=group_1,
+            selection=hook_selection,
+            target=hook_target,
+            decay=hook_decay,
+            deltat=math_1,
+        ) >> g.SetPosition(selection=pin_selection, position=pin_target)
+        (
+            XPBDFinalise(geometry=set_position, selection=boolean_math, deltat=math_1)
+            >> geometry_2.next
+        )
+        geometry_2.result >> geometry_1.next
+        capture = g.CaptureAttribute.point(geometry=geometry_1.result)
+        normal_1 = capture.items.vector(
+            "Normal", g.SampleNearestSurface.vector(faces, g.Normal().o.normal).o.value
+        )
+
+        capture.o.geometry >> geometry
+        normal_1.output >> normal
+
+
+ASSET = SimulateOnFaces
+
+ASSET_METADATA = {
+    "catalog_id": "c2c958af-5095-4fc2-884d-709bba965fc4",
+}


### PR DESCRIPTION
Re-adding the basic simulation nodes that previously shipped with MN pre v520.

They aren't updated yet to take advantage of the built-in XPBD solver as it's not quite there in terms of constraints.